### PR TITLE
Remove deprecated register cpp17

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.vscode

--- a/CPFA/build.sh
+++ b/CPFA/build.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 #if [ "$1" = "clean" ]; then
-    echo "Deleting and recreating the build directory "
-    rm -rf build
-    mkdir build
+echo "Deleting and recreating the build directory "
+rm -rf build
+mkdir build
 #fi
 
 cd build
-export PKG_CONFIG_PATH=/opt/local/argos3/2.8.12.2/gcc/5.4.0/lib/pkgconfig
+#export PKG_CONFIG_PATH=/opt/local/argos3/2.8.12.2/gcc/5.4.0/lib/pkgconfig
 echo "Configuring Makefiles with CMAKE..."
 cmake -DBUILD_EVOLVER=NO -DCMAKE_BUILD_TYPE=Release ..
 
@@ -16,4 +16,3 @@ make
 cd ..
 
 echo "Finished."
-

--- a/CPFA/source/evolver.cpp
+++ b/CPFA/source/evolver.cpp
@@ -11,7 +11,7 @@
 // For shared memory management
 #include <sys/mman.h>
 
-#include <ctime> // For clock()
+#include <ctime>  // For clock()
 #include <chrono> // For clock()
 #include <mpi.h>
 
@@ -31,12 +31,12 @@
 #include <source/CPFA/CPFA_loop_functions.h>
 
 // For timing
-#include <ctime> // For clock()
+#include <ctime>  // For clock()
 #include <chrono> // For clock()
 
 // For shared variable between child and parent process
-#include  <sys/ipc.h>
-#include  <sys/shm.h>
+#include <sys/ipc.h>
+#include <sys/shm.h>
 
 float objective(GAGenome &);
 float LaunchARGoS(GAGenome &);
@@ -44,11 +44,11 @@ float LaunchARGoS(GAGenome &);
 int mpi_tasks, mpi_rank;
 
 int elitism = 0;
-int n_trials = 20; // used by the objective function
+int n_trials = 20;            // used by the objective function
 double mutation_stdev = 1.00; // Gaussian mutation stdev - will be scaled by possible range
 string experiment_path;
 
-void CPFAInitializer(GAGenome & c);
+void CPFAInitializer(GAGenome &c);
 int GARealGaussianMutatorStdev(GAGenome &, float);
 
 std::default_random_engine generator;
@@ -62,125 +62,124 @@ int main(int argc, char **argv)
   MPI_Init(&argc, &argv);
   MPI_Comm_size(MPI_COMM_WORLD, &mpi_tasks);
   MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
-                         
-  char hostname[1024];                                                                                                       
-  hostname[1023] = '\0';                                          
+
+  char hostname[1024];
+  hostname[1023] = '\0';
   gethostname(hostname, 1023);
-  
+
   double mutation_rate = 0.01;
   double crossover_rate = 0.01;
   int population_size = 10;
   int n_generations = 10;
 
-    char c='h';
+  char c = 'h';
   // Handle command line arguments
-  while ((c = getopt (argc, argv, "t:g:p:c:m:s:h:e:x:")) != -1)
+  while ((c = getopt(argc, argv, "t:g:p:c:m:s:h:e:x:")) != -1)
     switch (c)
-      {
-      case 'x':
-	experiment_path = optarg;
+    {
+    case 'x':
+      experiment_path = optarg;
       break;
-      case 't':
-	n_trials = atoi(optarg);
-	break;
-      case 'g':
-        n_generations = atoi(optarg);
-        break;
-      case 'p':
-        population_size = atoi(optarg);
-        break;
-      case 'm':
-        mutation_rate = strtod(optarg, NULL);
-	break;
-      case 'c':
-	crossover_rate = strtod(optarg, NULL);
-	break;
-      case 's':
-        mutation_stdev = strtod(optarg, NULL);
-	break;
-      case 'e':
-        elitism = atoi(optarg);
-	break;
-      case 'h':
-	printf("Usage: %s -p {population size} -g {number of generations} -t {number of trials} -c {crossover rate} -m {mutation rate} -s {mutation standard deviation} -e {elitism 0 or 1}", argv[0]);
-	break;
-      case '?':
-        if (optopt == 'p')
-          fprintf (stderr, "Option -%c requires an argument specifying the population size.\n", optopt);
-	else if (optopt == 'g')
-	  fprintf (stderr, "Option -%c requires an argument specifying the number of generations.\n", optopt);
-	else if (optopt == 't')
-	  fprintf (stderr, "Option -%c requires an argument specifying the number of trials.\n", optopt);
-	else if (optopt == 'c')
-	  fprintf (stderr, "Option -%c requires an argument specifying the crossover rate.\n", optopt);
-	else if (optopt == 'm')
-	  fprintf (stderr, "Option -%c requires an argument specifying the mutation rate.\n", optopt);
-	else if (optopt == 's')
-	  fprintf (stderr, "Option -%c requires an argument specifying the mutation standard deviation.\n", optopt);
-        else if (isprint (optopt))
-          fprintf (stderr, "Unknown option `-%c'.\n", optopt);
-        else
-          fprintf (stderr,
-                   "Unknown option character `\\x%x'.\n",
-                   optopt);
-        return 1;
-      default:
-	printf("Usage: %s -p {population size} -g {number of generations} -t {number of trials} -c {crossover rate} -m {mutation rate} -s {mutation standard deviation}", argv[0]);
-        abort ();
-      }
+    case 't':
+      n_trials = atoi(optarg);
+      break;
+    case 'g':
+      n_generations = atoi(optarg);
+      break;
+    case 'p':
+      population_size = atoi(optarg);
+      break;
+    case 'm':
+      mutation_rate = strtod(optarg, NULL);
+      break;
+    case 'c':
+      crossover_rate = strtod(optarg, NULL);
+      break;
+    case 's':
+      mutation_stdev = strtod(optarg, NULL);
+      break;
+    case 'e':
+      elitism = atoi(optarg);
+      break;
+    case 'h':
+      printf("Usage: %s -p {population size} -g {number of generations} -t {number of trials} -c {crossover rate} -m {mutation rate} -s {mutation standard deviation} -e {elitism 0 or 1}", argv[0]);
+      break;
+    case '?':
+      if (optopt == 'p')
+        fprintf(stderr, "Option -%c requires an argument specifying the population size.\n", optopt);
+      else if (optopt == 'g')
+        fprintf(stderr, "Option -%c requires an argument specifying the number of generations.\n", optopt);
+      else if (optopt == 't')
+        fprintf(stderr, "Option -%c requires an argument specifying the number of trials.\n", optopt);
+      else if (optopt == 'c')
+        fprintf(stderr, "Option -%c requires an argument specifying the crossover rate.\n", optopt);
+      else if (optopt == 'm')
+        fprintf(stderr, "Option -%c requires an argument specifying the mutation rate.\n", optopt);
+      else if (optopt == 's')
+        fprintf(stderr, "Option -%c requires an argument specifying the mutation standard deviation.\n", optopt);
+      else if (isprint(optopt))
+        fprintf(stderr, "Unknown option `-%c'.\n", optopt);
+      else
+        fprintf(stderr,
+                "Unknown option character `\\x%x'.\n",
+                optopt);
+      return 1;
+    default:
+      printf("Usage: %s -p {population size} -g {number of generations} -t {number of trials} -c {crossover rate} -m {mutation rate} -s {mutation standard deviation}", argv[0]);
+      abort();
+    }
 
   if (experiment_path.empty())
-    {
-      printf("Usage: %s -p {population size} -g {number of generations} -t {number of trials} -c {crossover rate} -m {mutation rate} -s {mutation standard deviation} -x {argos experiment file}\n", argv[0]);
-      exit(1);
-    }
+  {
+    printf("Usage: %s -p {population size} -g {number of generations} -t {number of trials} -c {crossover rate} -m {mutation rate} -s {mutation standard deviation} -x {argos experiment file}\n", argv[0]);
+    exit(1);
+  }
 
   float max_float = std::numeric_limits<float>::max();
 
-    //printf("%s:\tworker %d ready.\n", hostname, mpi_rank);                                          
+  // printf("%s:\tworker %d ready.\n", hostname, mpi_rank);
 
   // See if we've been given a seed to use (for testing purposes).  When you
   // specify a random seed, the evolution will be exactly the same each time
   // you use that seed number
   unsigned int seed = 12345;
-  for(int i=1 ; i<argc ; i++)
-    if(strcmp(argv[i++],"seed") == 0)
+  for (int i = 1; i < argc; i++)
+    if (strcmp(argv[i++], "seed") == 0)
       seed = atoi(argv[i]);
 
   srand(seed);
   generator.seed(seed);
   // popsize / mpi_tasks must be an integer
-  population_size = mpi_tasks * int((double)population_size/(double)mpi_tasks+0.999);
-  
-  if (mpi_rank==0)
-    {
-      printf("Population size: %d\nNumber of trials: %d\nNumber of generations: %d\nCrossover rate: %f\nMutation rate: %f\nMutation stdev: %f\nAllocated MPI workers: %d\n", population_size, n_trials, n_generations, crossover_rate, mutation_rate, mutation_stdev, mpi_tasks);
-      	printf("elitism: %d\n", elitism);
-    }
+  population_size = mpi_tasks * int((double)population_size / (double)mpi_tasks + 0.999);
+
+  if (mpi_rank == 0)
+  {
+    printf("Population size: %d\nNumber of trials: %d\nNumber of generations: %d\nCrossover rate: %f\nMutation rate: %f\nMutation stdev: %f\nAllocated MPI workers: %d\n", population_size, n_trials, n_generations, crossover_rate, mutation_rate, mutation_stdev, mpi_tasks);
+    printf("elitism: %d\n", elitism);
+  }
 
   // Define the genome
   GARealAlleleSetArray allele_array;
-  
-  allele_array.add(0, 1.0); // Probability of switching to search
-  allele_array.add(0, 1.0); // Probability of returning to nest
-  allele_array.add(0, 4*M_PI); // Uninformed search variation
-  allele_array.add(0, 20); // Rate of informed search decay
-  allele_array.add(0, 20); // Rate of site fidelity
-  allele_array.add(0, 20); // Rate of laying pheremone
-  allele_array.add(0, 20); // Rate of pheremone decay
-  
-    
+
+  allele_array.add(0, 1.0);      // Probability of switching to search
+  allele_array.add(0, 1.0);      // Probability of returning to nest
+  allele_array.add(0, 4 * M_PI); // Uninformed search variation
+  allele_array.add(0, 20);       // Rate of informed search decay
+  allele_array.add(0, 20);       // Rate of site fidelity
+  allele_array.add(0, 20);       // Rate of laying pheremone
+  allele_array.add(0, 20);       // Rate of pheremone decay
+
   // Create the template genome using the phenotype map we just made.
   GARealGenome genome(allele_array, objective);
   genome.crossover(GARealUniformCrossover);
   genome.mutator(GARealGaussianMutatorStdev); // Specify our version of the Gaussuan mutator
   genome.initializer(CPFAInitializer);
- 
+
   // Now create the GA using the genome and run it.
   GASimpleGA ga(genome);
   GALinearScaling scaling;
-  ga.maximize();		// Maximize the objective
- 
+  ga.maximize(); // Maximize the objective
+
   ga.populationSize(population_size);
   ga.nGenerations(n_generations);
   ga.pMutation(mutation_rate);
@@ -190,7 +189,7 @@ int main(int argc, char **argv)
     ga.elitist(gaTrue);
   else
     ga.elitist(gaFalse);
-  if(mpi_rank == 0)
+  if (mpi_rank == 0)
     ga.scoreFilename("evolution.txt");
   else
     ga.scoreFilename("/dev/null");
@@ -198,338 +197,362 @@ int main(int argc, char **argv)
   ga.scoreFrequency(1);
   ga.flushFrequency(1);
   ga.selectScores(GAStatistics::AllScores);
-  
 
   // Pass MPI data to the GA class
   ga.mpi_rank(mpi_rank);
   ga.mpi_tasks(mpi_tasks);
-  //ga.evolve(seed); // Manual generations
+  // ga.evolve(seed); // Manual generations
 
-// initialize the ga since we are not using the evolve function
+  // initialize the ga since we are not using the evolve function
   ga.initialize(seed); // This is essential for the mpi workers to be sychronized
 
-    // Name the results file with the current time and date
- time_t t = time(0);   // get time now
-    struct tm * now = localtime( & t );
-    stringstream ss;
+  // Name the results file with the current time and date
+  time_t t = time(0); // get time now
+  struct tm *now = localtime(&t);
+  stringstream ss;
 
-    boost::filesystem::path exp_path(experiment_path);
-    
-    ss << "results/CPFA-evolution-"
-       << exp_path.stem().string() << '-'
-       <<GIT_BRANCH<<"-"<<GIT_COMMIT_HASH<<"-"
-       << (now->tm_year) << '-'
-       << (now->tm_mon + 1) << '-'
-       <<  now->tm_mday << '-'
-       <<  now->tm_hour << '-'
-       <<  now->tm_min << '-'
-       <<  now->tm_sec << ".csv";
+  boost::filesystem::path exp_path(experiment_path);
 
-    string results_file_name = ss.str();
+  ss << "results/CPFA-evolution-"
+     << exp_path.stem().string() << '-'
+     << GIT_BRANCH << "-" << GIT_COMMIT_HASH << "-"
+     << (now->tm_year) << '-'
+     << (now->tm_mon + 1) << '-'
+     << now->tm_mday << '-'
+     << now->tm_hour << '-'
+     << now->tm_min << '-'
+     << now->tm_sec << ".csv";
 
-    if (mpi_rank == 0)
-      {
+  string results_file_name = ss.str();
+
+  if (mpi_rank == 0)
+  {
     // Write output file header
     ofstream results_output_stream;
-	results_output_stream.open(results_file_name, ios::app);
-	results_output_stream << "Population size: " << population_size << "\nNumber of trials: " << n_trials << "\nNumber of generations: "<< n_generations<<"\nCrossover rate: "<< crossover_rate<<"\nMutation rate: " << mutation_rate << "\nMutation stdev: "<< mutation_stdev << "Algorithm: CPFA\n" << "Number of searchers: 6\n" << "Number of targets: 256\n" << "Target distribution: power law" << endl;
-	results_output_stream << "Generation" 
-			      << ", " << "Compute Time (s)"
-			      << ", " << "Convergence"
-			      << ", " << "Mean"
-			      << ", " << "Maximum"
-			      << ", " << "Minimum"
-			      << ", " << "Standard Deviation"
-			      << ", " << "Diversity"
-			      << ", " << "ProbabilityOfSwitchingToSearching"
-			      << ", " << "ProbabilityOfReturningToNest"
-			      << ", " << "UninformedSearchVariation"
-			      << ", " << "RateOfInformedSearchDecay"
-			      << ", " << "RateOfSiteFidelity"
-			      << ", " << "RateOfLayingPheromone"
-			      << ", " << "RateOfPheromoneDecay";
+    results_output_stream.open(results_file_name, ios::app);
+    results_output_stream << "Population size: " << population_size << "\nNumber of trials: " << n_trials << "\nNumber of generations: " << n_generations << "\nCrossover rate: " << crossover_rate << "\nMutation rate: " << mutation_rate << "\nMutation stdev: " << mutation_stdev << "Algorithm: CPFA\n"
+                          << "Number of searchers: 6\n"
+                          << "Number of targets: 256\n"
+                          << "Target distribution: power law" << endl;
+    results_output_stream << "Generation"
+                          << ", "
+                          << "Compute Time (s)"
+                          << ", "
+                          << "Convergence"
+                          << ", "
+                          << "Mean"
+                          << ", "
+                          << "Maximum"
+                          << ", "
+                          << "Minimum"
+                          << ", "
+                          << "Standard Deviation"
+                          << ", "
+                          << "Diversity"
+                          << ", "
+                          << "ProbabilityOfSwitchingToSearching"
+                          << ", "
+                          << "ProbabilityOfReturningToNest"
+                          << ", "
+                          << "UninformedSearchVariation"
+                          << ", "
+                          << "RateOfInformedSearchDecay"
+                          << ", "
+                          << "RateOfSiteFidelity"
+                          << ", "
+                          << "RateOfLayingPheromone"
+                          << ", "
+                          << "RateOfPheromoneDecay";
 
-	results_output_stream << endl;
-	results_output_stream.close();
-      }
-	while(!ga.done())
-	  {
+    results_output_stream << endl;
+    results_output_stream.close();
+  }
+  while (!ga.done())
+  {
 
-	    std::chrono::time_point<std::chrono::system_clock>generation_start, generation_end;
-	    if (mpi_rank == 0)
-	      {
-		generation_start = std::chrono::system_clock::now();
-	      }
-	    
-      // Calculate the generation
-      ga.step();
+    std::chrono::time_point<std::chrono::system_clock> generation_start, generation_end;
+    if (mpi_rank == 0)
+    {
+      generation_start = std::chrono::system_clock::now();
+    }
 
-    if(mpi_rank == 0)
-      {
-	generation_end = std::chrono::system_clock::now();
-	std::chrono::duration<double> generation_elapsed_seconds = generation_end-generation_start;
-	ofstream results_output_stream;
-	results_output_stream.open(results_file_name, ios::app);
-       results_output_stream << ga.statistics().generation() 
-			     << ", " << generation_elapsed_seconds.count()
-			     << ", " << ga.statistics().convergence()
-			     << ", " << ga.statistics().current(GAStatistics::Mean)
-			     << ", " << ga.statistics().current(GAStatistics::Maximum)
-			     << ", " << ga.statistics().current(GAStatistics::Minimum)
-			     << ", " << ga.statistics().current(GAStatistics::Deviation)
-			     << ", " << ga.statistics().current(GAStatistics::Diversity);
-       
-	  for (int i = 0; i < GENOME_SIZE; i++)
-	    results_output_stream << ", " << dynamic_cast<const GARealGenome&>(ga.population().best()).gene(i);
+    // Calculate the generation
+    ga.step();
 
-	  
-	  const GARealGenome& best_genome = dynamic_cast<const GARealGenome&>(ga.statistics().bestIndividual());
-	  results_output_stream << endl;
-	  
-	  results_output_stream << "The GA found an optimum at: ";
-	  results_output_stream << best_genome.gene(0);
-	  for (int i = 1; i < GENOME_SIZE; i++)
-	    results_output_stream << ", " << best_genome.gene(i);
-	  results_output_stream << " with score: " << best_genome.score();
-	  results_output_stream << endl;
-	  results_output_stream.close();
-      }
-	  }
-	// Display the GA's progress
-	if(mpi_rank == 0)
-	  {
-	    cout << ga.statistics() << " " << ga.parameters() << endl;
-	  }
-	
+    if (mpi_rank == 0)
+    {
+      generation_end = std::chrono::system_clock::now();
+      std::chrono::duration<double> generation_elapsed_seconds = generation_end - generation_start;
+      ofstream results_output_stream;
+      results_output_stream.open(results_file_name, ios::app);
+      results_output_stream << ga.statistics().generation()
+                            << ", " << generation_elapsed_seconds.count()
+                            << ", " << ga.statistics().convergence()
+                            << ", " << ga.statistics().current(GAStatistics::Mean)
+                            << ", " << ga.statistics().current(GAStatistics::Maximum)
+                            << ", " << ga.statistics().current(GAStatistics::Minimum)
+                            << ", " << ga.statistics().current(GAStatistics::Deviation)
+                            << ", " << ga.statistics().current(GAStatistics::Diversity);
+
+      for (int i = 0; i < GENOME_SIZE; i++)
+        results_output_stream << ", " << dynamic_cast<const GARealGenome &>(ga.population().best()).gene(i);
+
+      const GARealGenome &best_genome = dynamic_cast<const GARealGenome &>(ga.statistics().bestIndividual());
+      results_output_stream << endl;
+
+      results_output_stream << "The GA found an optimum at: ";
+      results_output_stream << best_genome.gene(0);
+      for (int i = 1; i < GENOME_SIZE; i++)
+        results_output_stream << ", " << best_genome.gene(i);
+      results_output_stream << " with score: " << best_genome.score();
+      results_output_stream << endl;
+      results_output_stream.close();
+    }
+  }
+  // Display the GA's progress
+  if (mpi_rank == 0)
+  {
+    cout << ga.statistics() << " " << ga.parameters() << endl;
+  }
+
   MPI_Finalize();
 
   program_end = std::chrono::system_clock::now();
- 
-  std::chrono::duration<double> program_elapsed_seconds = program_end-program_start;
 
-  if(mpi_rank == 0)
+  std::chrono::duration<double> program_elapsed_seconds = program_end - program_start;
+
+  if (mpi_rank == 0)
     printf("Run time was %f seconds\n", program_elapsed_seconds.count());
 
   return 0;
-  }
+}
 
-// Initializes the genome according to the Beyond Pheromones paper 
-void CPFAInitializer(GAGenome & c)
+// Initializes the genome according to the Beyond Pheromones paper
+void CPFAInitializer(GAGenome &c)
 {
   // For the exponential PDF needed to initialize some of the genes
-  
+
   std::exponential_distribution<double> exponential_distribution_10(10.0);
   std::exponential_distribution<double> exponential_distribution_5(5.0);
   std::uniform_real_distribution<double> uniform_distribution_0_1(0.0, 1.0);
-  std::uniform_real_distribution<double> uniform_distribution_0_4PI(0.0, 4.0*M_PI);
+  std::uniform_real_distribution<double> uniform_distribution_0_4PI(0.0, 4.0 * M_PI);
   std::uniform_real_distribution<double> uniform_distribution_0_20(0.0, 20.0);
 
-  GA1DArrayAlleleGenome<float> &child= DYN_CAST(GA1DArrayAlleleGenome<float> &, c);
+  GA1DArrayAlleleGenome<float> &child = DYN_CAST(GA1DArrayAlleleGenome<float> &, c);
   child.resize(GAGenome::ANY_SIZE); // let chrom resize if it can
-  
-  child.gene(0, uniform_distribution_0_1(generator)); // Probability of switching to search
-  child.gene(1, uniform_distribution_0_1(generator)); // Probability of returning to nest
-  child.gene(2, uniform_distribution_0_4PI(generator)); // Uninformed search variation
-  child.gene(3, exponential_distribution_5(generator)); // Rate of informed search decay
-  child.gene(4, uniform_distribution_0_20(generator)); // Rate of site fidelity
-  child.gene(5, uniform_distribution_0_20(generator)); // Rate of laying pheremone
+
+  child.gene(0, uniform_distribution_0_1(generator));    // Probability of switching to search
+  child.gene(1, uniform_distribution_0_1(generator));    // Probability of returning to nest
+  child.gene(2, uniform_distribution_0_4PI(generator));  // Uninformed search variation
+  child.gene(3, exponential_distribution_5(generator));  // Rate of informed search decay
+  child.gene(4, uniform_distribution_0_20(generator));   // Rate of site fidelity
+  child.gene(5, uniform_distribution_0_20(generator));   // Rate of laying pheremone
   child.gene(6, exponential_distribution_10(generator)); // Rate of pheremone decay
 }
 
 // The mutation operator based on the original from GALib but adds stdev
 // The Gaussian mutator picks a new value based on a Gaussian distribution
 // around the current value.  We respect the bounds (if any).
-int GARealGaussianMutatorStdev(GAGenome& g, float pmut)
+int GARealGaussianMutatorStdev(GAGenome &g, float pmut)
 {
-  GA1DArrayAlleleGenome<float> &child=
-    DYN_CAST(GA1DArrayAlleleGenome<float> &, g);
-  register int n, i;
-  if(pmut <= 0.0) return(0);
+  GA1DArrayAlleleGenome<float> &child =
+      DYN_CAST(GA1DArrayAlleleGenome<float> &, g);
+  int n, i;
+  if (pmut <= 0.0)
+    return (0);
 
   float nMut = pmut * (float)(child.length());
-  int length = child.length()-1;
-  if(nMut < 1.0){// we have to do a flip test on each element
+  int length = child.length() - 1;
+  if (nMut < 1.0)
+  { // we have to do a flip test on each element
     nMut = 0;
-    for(i=length; i>=0; i--){
+    for (i = length; i >= 0; i--)
+    {
       float value = child.gene(i);
-      if(GAFlipCoin(pmut)){
-	if(child.alleleset(i).type() == GAAllele::ENUMERATED ||
-	   child.alleleset(i).type() == GAAllele::DISCRETIZED)
-	  value = child.alleleset(i).allele();
-	else if(child.alleleset(i).type() == GAAllele::BOUNDED){
-	  value += GAUnitGaussian()*mutation_stdev;//*(child.alleleset(i).upper()-child.alleleset(i).lower()); // since the standard deviation varies proportionally to a constant multiplier 
-	  value = GAMax(child.alleleset(i).lower(), value);
-	  value = GAMin(child.alleleset(i).upper(), value);
-	}
-	child.gene(i, value);
-	nMut++;
+      if (GAFlipCoin(pmut))
+      {
+        if (child.alleleset(i).type() == GAAllele::ENUMERATED ||
+            child.alleleset(i).type() == GAAllele::DISCRETIZED)
+          value = child.alleleset(i).allele();
+        else if (child.alleleset(i).type() == GAAllele::BOUNDED)
+        {
+          value += GAUnitGaussian() * mutation_stdev; //*(child.alleleset(i).upper()-child.alleleset(i).lower()); // since the standard deviation varies proportionally to a constant multiplier
+          value = GAMax(child.alleleset(i).lower(), value);
+          value = GAMin(child.alleleset(i).upper(), value);
+        }
+        child.gene(i, value);
+        nMut++;
       }
     }
   }
-  else{// only mutate the ones we need to
-    for(n=0; n<nMut; n++){
-      int idx = GARandomInt(0,length);
+  else
+  { // only mutate the ones we need to
+    for (n = 0; n < nMut; n++)
+    {
+      int idx = GARandomInt(0, length);
       float value = child.gene(idx);
-      if(child.alleleset(idx).type() == GAAllele::ENUMERATED ||
-	 child.alleleset(idx).type() == GAAllele::DISCRETIZED)
-	value = child.alleleset(idx).allele();
-      else if(child.alleleset(idx).type() == GAAllele::BOUNDED){
-	value += GAUnitGaussian()*mutation_stdev*(child.alleleset(i).upper()-child.alleleset(i).lower()); // since the standard deviation varies proportionally to a constant multiplier 
-	value = GAMax(child.alleleset(idx).lower(), value);
-	value = GAMin(child.alleleset(idx).upper(), value);
+      if (child.alleleset(idx).type() == GAAllele::ENUMERATED ||
+          child.alleleset(idx).type() == GAAllele::DISCRETIZED)
+        value = child.alleleset(idx).allele();
+      else if (child.alleleset(idx).type() == GAAllele::BOUNDED)
+      {
+        value += GAUnitGaussian() * mutation_stdev * (child.alleleset(i).upper() - child.alleleset(i).lower()); // since the standard deviation varies proportionally to a constant multiplier
+        value = GAMax(child.alleleset(idx).lower(), value);
+        value = GAMin(child.alleleset(idx).upper(), value);
       }
       child.gene(idx, value);
     }
   }
-  return((int)nMut);
+  return ((int)nMut);
 }
-
 
 float objective(GAGenome &c)
 {
   float avg = 0;
-  
+
   // For timing
   std::chrono::time_point<std::chrono::system_clock> start, end;
   start = std::chrono::system_clock::now();
 
-  for (int i = 0; i < n_trials; i++) avg += LaunchARGoS(c);
-  
+  for (int i = 0; i < n_trials; i++)
+    avg += LaunchARGoS(c);
+
   avg /= n_trials;
 
-  
   end = std::chrono::system_clock::now();
-  
-  std::chrono::duration<double> elapsed_seconds = end-start;
 
-  MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);     
+  std::chrono::duration<double> elapsed_seconds = end - start;
 
-      char hostname[1024];              
-      hostname[1023] = '\0';                                          
-      gethostname(hostname, 1023);     
- 
-      /*
-      printf("Worker %d on %s evaluated genome [", mpi_rank, hostname);
-      for (int i = 0; i < GENOME_SIZE; i++)
-	printf("%f ",dynamic_cast<const GARealGenome&>(c).gene(i));
-      printf("] in %f seconds. ", elapsed_seconds.count());
-      printf("Fitness: %f.\n", avg );
-      */
+  MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
 
-      return avg;
+  char hostname[1024];
+  hostname[1023] = '\0';
+  gethostname(hostname, 1023);
+
+  /*
+  printf("Worker %d on %s evaluated genome [", mpi_rank, hostname);
+  for (int i = 0; i < GENOME_SIZE; i++)
+printf("%f ",dynamic_cast<const GARealGenome&>(c).gene(i));
+  printf("] in %f seconds. ", elapsed_seconds.count());
+  printf("Fitness: %f.\n", avg );
+  */
+
+  return avg;
 }
 
 /*
  * Launch ARGoS to evaluate a genome.
  */
-float LaunchARGoS(GAGenome& c_genome) 
+float LaunchARGoS(GAGenome &c_genome)
 {
   // Declate the fitness value and the shared memory segment id and address
   float fitness = 0;
-  int    ShmID;
-  float*   ShmPTR;
-  
+  int ShmID;
+  float *ShmPTR;
+
   // Allocate the shared memory to use between this process and the child argos process
   ShmID = shmget(IPC_PRIVATE, sizeof(float), IPC_CREAT | 0666);
-  if (ShmID < 0) {
+  if (ShmID < 0)
+  {
     printf("ERROR: Allocating shared memory segment in main.cpp:LaunchARGoS() failed.\n");
     exit(1);
   }
-  
+
   // Attach to the shared memory segment
-  ShmPTR = (float*) shmat(ShmID, NULL, 0);
-  if ((float*) ShmPTR == (float*)-1) 
-    {
-      printf("ERROR: Attaching to shared memory segment in main.cpp:LaunchARGoS() failed.\n");
-      exit(1);
-    }
+  ShmPTR = (float *)shmat(ShmID, NULL, 0);
+  if ((float *)ShmPTR == (float *)-1)
+  {
+    printf("ERROR: Attaching to shared memory segment in main.cpp:LaunchARGoS() failed.\n");
+    exit(1);
+  }
 
   *ShmPTR = 0; // Initialise
 
   pid_t pid = fork(); // Create the new process with a copy of this memory space
 
   if (pid == 0)
-    {
-      // In child process - run the argos3 simulation
+  {
+    // In child process - run the argos3 simulation
 
-      /* Convert the received genome to the actual genome type */
-      GARealGenome& cRealGenome = dynamic_cast<GARealGenome&>(c_genome);
-  
-      Real* cpfa_genome = new Real[GENOME_SIZE];
+    /* Convert the received genome to the actual genome type */
+    GARealGenome &cRealGenome = dynamic_cast<GARealGenome &>(c_genome);
 
-      // Convert to a convenient format for the argos controller
-      for (int i = 0; i < GENOME_SIZE; i++)
-	cpfa_genome[i] = cRealGenome.gene(i);
-       
-      /*      
-      printf("%s: worker %d started a genome evaluation. (%f, %f, %f, %f, %f, %f, %f)\n", hostname, mpi_rank, 
-	     cpfa_genome[0],
-	     cpfa_genome[1],
-	     cpfa_genome[2],
-	     cpfa_genome[3],
-	     cpfa_genome[4],
-	     cpfa_genome[5],
-	     cpfa_genome[6]);
-      */
+    Real *cpfa_genome = new Real[GENOME_SIZE];
 
-      /* Redirect LOG and LOGERR to dedicated files to prevent clutter on the screen */
-      std::ofstream cLOGFile("argos_logs/ARGoS_LOG_" + ToString(::getpid()), std::ios::out);
-      LOG.DisableColoredOutput();
-      LOG.GetStream().rdbuf(cLOGFile.rdbuf());
-      std::ofstream cLOGERRFile("argos_logs/ARGoS_LOGERR_" + ToString(::getpid()), std::ios::out);
-      LOGERR.DisableColoredOutput();
-      LOGERR.GetStream().rdbuf(cLOGERRFile.rdbuf());
+    // Convert to a convenient format for the argos controller
+    for (int i = 0; i < GENOME_SIZE; i++)
+      cpfa_genome[i] = cRealGenome.gene(i);
 
-      /*
-       * Initialize ARGoS
-       */
-      /* The CSimulator class of ARGoS is a singleton. Therefore, to
-       * manipulate an ARGoS experiment, it is enough to get its instance */
-      argos::CSimulator& cSimulator = argos::CSimulator::GetInstance();
+    /*
+    printf("%s: worker %d started a genome evaluation. (%f, %f, %f, %f, %f, %f, %f)\n", hostname, mpi_rank,
+     cpfa_genome[0],
+     cpfa_genome[1],
+     cpfa_genome[2],
+     cpfa_genome[3],
+     cpfa_genome[4],
+     cpfa_genome[5],
+     cpfa_genome[6]);
+    */
 
-      // Set the .argos configuration file
-      cSimulator.SetExperimentFileName(experiment_path);
-      
-      // Load it to configure ARGoS 
-      cSimulator.LoadExperiment();
+    /* Redirect LOG and LOGERR to dedicated files to prevent clutter on the screen */
+    std::ofstream cLOGFile("argos_logs/ARGoS_LOG_" + ToString(::getpid()), std::ios::out);
+    LOG.DisableColoredOutput();
+    LOG.GetStream().rdbuf(cLOGFile.rdbuf());
+    std::ofstream cLOGERRFile("argos_logs/ARGoS_LOGERR_" + ToString(::getpid()), std::ios::out);
+    LOGERR.DisableColoredOutput();
+    LOGERR.GetStream().rdbuf(cLOGERRFile.rdbuf());
 
-      // Get a reference to the loop functions
-      CPFA_loop_functions& cLoopFunctions = dynamic_cast<CPFA_loop_functions&>(cSimulator.GetLoopFunctions());
+    /*
+     * Initialize ARGoS
+     */
+    /* The CSimulator class of ARGoS is a singleton. Therefore, to
+     * manipulate an ARGoS experiment, it is enough to get its instance */
+    argos::CSimulator &cSimulator = argos::CSimulator::GetInstance();
 
-      // Configure the controller with the genome
-      cLoopFunctions.ConfigureFromGenome(cpfa_genome);
+    // Set the .argos configuration file
+    cSimulator.SetExperimentFileName(experiment_path);
 
-      // Run the experiment
-      cSimulator.Execute();
+    // Load it to configure ARGoS
+    cSimulator.LoadExperiment();
 
-      // Update performance and store in the shared memory segment
-      *ShmPTR = cLoopFunctions.Score();;
+    // Get a reference to the loop functions
+    CPFA_loop_functions &cLoopFunctions = dynamic_cast<CPFA_loop_functions &>(cSimulator.GetLoopFunctions());
 
-      // For testing
-      //float score = 0;
-      //for (int i = 0; i < GENOME_SIZE; i++) score += cpfa_genome[i];
-      //*ShmPTR = score;
+    // Configure the controller with the genome
+    cLoopFunctions.ConfigureFromGenome(cpfa_genome);
 
-      // Clean up the simulation
-      cSimulator.Destroy();
-      
-      // Clean up the temp genome copy
-	delete [] cpfa_genome;
+    // Run the experiment
+    cSimulator.Execute();
 
-	// Make this process exit
-      _Exit(0); 
-    }
-  
+    // Update performance and store in the shared memory segment
+    *ShmPTR = cLoopFunctions.Score();
+    ;
+
+    // For testing
+    // float score = 0;
+    // for (int i = 0; i < GENOME_SIZE; i++) score += cpfa_genome[i];
+    //*ShmPTR = score;
+
+    // Clean up the simulation
+    cSimulator.Destroy();
+
+    // Clean up the temp genome copy
+    delete[] cpfa_genome;
+
+    // Make this process exit
+    _Exit(0);
+  }
+
   // In parent - wait for child to finish
   int status = wait(&status);
 
   // Make a local copy of the shared fitness value
-  fitness = *ShmPTR;  
+  fitness = *ShmPTR;
 
   // Release shared memory
-  shmdt((void *) ShmPTR);
+  shmdt((void *)ShmPTR);
   shmctl(ShmID, IPC_RMID, NULL);
 
-  /* Return the result of the evaluation */  
+  /* Return the result of the evaluation */
   return fitness;
 }

--- a/CPFA/source/ga-mpi/GA1DArrayGenome.C
+++ b/CPFA/source/ga-mpi/GA1DArrayGenome.C
@@ -18,7 +18,7 @@
 #include <ga-mpi/GA1DArrayGenome.h>
 #include <ga-mpi/GAMask.h>
 
-template <class T> int 
+template <class T> int
 GA1DArrayIsHole(const GA1DArrayGenome<T>&, const GA1DArrayGenome<T>&,
 		int, int, int);
 
@@ -36,15 +36,15 @@ GA1DArrayGenome<T>::classID() const {return GAID::ArrayGenome;}
 // this point - initialization must be done explicitly by the user of the
 // genome (eg when the population is created or reset).  If we called the
 // initializer routine here then we could end up with multiple initializations
-// and/or calls to dummy initializers (for example when the genome is 
+// and/or calls to dummy initializers (for example when the genome is
 // created with a dummy initializer and the initializer is assigned later on).
 // Besides, we default to the no-initialization initializer by calling the
 // default genome constructor.
-template <class T> 
+template <class T>
 GA1DArrayGenome<T>::
 GA1DArrayGenome(unsigned int length, GAGenome::Evaluator f, void * u) :
 GAArray<T>(length),
-GAGenome(DEFAULT_1DARRAY_INITIALIZER, 
+GAGenome(DEFAULT_1DARRAY_INITIALIZER,
 	 DEFAULT_1DARRAY_MUTATOR,
 	 DEFAULT_1DARRAY_COMPARATOR) {
   evaluator(f);
@@ -56,9 +56,9 @@ GAGenome(DEFAULT_1DARRAY_INITIALIZER,
 
 // This is the copy initializer.  We set everything to the default values, then
 // copy the original.  The Array creator takes care of zeroing the data.
-template <class T> 
+template <class T>
 GA1DArrayGenome<T>::
-GA1DArrayGenome(const GA1DArrayGenome<T> & orig) : 
+GA1DArrayGenome(const GA1DArrayGenome<T> & orig) :
 GAArray<T>(orig.sz), GAGenome() {
   GA1DArrayGenome<T>::copy(orig);
 }
@@ -74,7 +74,7 @@ GA1DArrayGenome<T>::~GA1DArrayGenome() { }
 // what we define here - a virtual function).  We should check to be sure that
 // both genomes are the same class and same dimension.  This function tries
 // to be smart about they way it copies.  If we already have data, then we do
-// a memcpy of the one we're supposed to copy.  If we don't or we're not the 
+// a memcpy of the one we're supposed to copy.  If we don't or we're not the
 // same size as the one we're supposed to copy, then we adjust ourselves.
 //   The Array takes care of the resize in its copy method.
 template <class T> void
@@ -92,7 +92,7 @@ GA1DArrayGenome<T>::copy(const GAGenome & orig){
 template <class T> GAGenome *
 GA1DArrayGenome<T>::clone(GAGenome::CloneMethod flag) const {
   GA1DArrayGenome<T> *cpy = new GA1DArrayGenome<T>(nx);
-  if(flag == CONTENTS){ 
+  if(flag == CONTENTS){
     cpy->copy(*this);
   }
   else{
@@ -110,10 +110,10 @@ GA1DArrayGenome<T>::clone(GAGenome::CloneMethod flag) const {
 // length, then we don't do anything.
 //   We pay attention to the values of minX and maxX - they determine what kind
 // of resizing we are allowed to do.  If a resize is requested with a length
-// less than the min length specified by the behaviour, we set the minimum 
+// less than the min length specified by the behaviour, we set the minimum
 // to the length.  If the length is longer than the max length specified by
 // the behaviour, we set the max value to the length.
-//   We return the total size (in bits) of the genome after resize. 
+//   We return the total size (in bits) of the genome after resize.
 //   We don't do anything to the new contents!
 template <class T> int
 GA1DArrayGenome<T>::resize(int len)
@@ -160,7 +160,7 @@ GA1DArrayGenome<T>::write(STD_OSTREAM & os) const {
 //   Set the resize behaviour of the genome.  A genome can be fixed
 // length, resizeable with a max and min limit, or resizeable with no limits
 // (other than an implicit one that we use internally).
-//   A value of 0 means no resize, a value less than zero mean unlimited 
+//   A value of 0 means no resize, a value less than zero mean unlimited
 // resize, and a positive value means resize with that value as the limit.
 template <class T> int
 GA1DArrayGenome<T>::
@@ -183,7 +183,7 @@ GA1DArrayGenome<T>::resizeBehaviour() const {
   return val;
 }
 
-template <class T> int 
+template <class T> int
 GA1DArrayGenome<T>::equal(const GAGenome & c) const {
   const GA1DArrayGenome<T> & b = DYN_CAST(const GA1DArrayGenome<T> &, c);
   return((this == &c) ? 1 : ((nx != b.nx) ? 0 : GAArray<T>::equal(b,0,0,nx)));
@@ -205,7 +205,7 @@ its own, independent allele set.  If we clone a new genome, the new one gets a
 link to our allele set (so we don't end up with zillions of allele sets).  Same
 is true for the copy constructor.
   The array may have a single allele set or an array of allele sets, depending
-on which creator was called.  Either way, the allele set cannot be changed 
+on which creator was called.  Either way, the allele set cannot be changed
 once the array is created.
 ---------------------------------------------------------------------------- */
 template <class T> const char *
@@ -213,7 +213,7 @@ GA1DArrayAlleleGenome<T>::className() const {return "GA1DArrayAlleleGenome";}
 template <class T> int
 GA1DArrayAlleleGenome<T>::classID() const {return GAID::ArrayAlleleGenome;}
 
-template <class T> 
+template <class T>
 GA1DArrayAlleleGenome<T>::
 GA1DArrayAlleleGenome(unsigned int length, const GAAlleleSet<T> & s,
 		      GAGenome::Evaluator f, void * u) :
@@ -228,7 +228,7 @@ GA1DArrayGenome<T>(length, f, u){
   this->crossover(GA1DArrayAlleleGenome<T>::DEFAULT_1DARRAY_ALLELE_CROSSOVER);
 }
 
-template <class T> 
+template <class T>
 GA1DArrayAlleleGenome<T>::
 GA1DArrayAlleleGenome(const GAAlleleSetArray<T> & sa,
 		      GAGenome::Evaluator f, void * u) :
@@ -247,9 +247,9 @@ GA1DArrayGenome<T>(sa.size(), f, u) {
 
 // The copy constructor creates a new genome whose allele set refers to the
 // original's allele set.
-template <class T> 
+template <class T>
 GA1DArrayAlleleGenome<T>::
-GA1DArrayAlleleGenome(const GA1DArrayAlleleGenome<T>& orig) : 
+GA1DArrayAlleleGenome(const GA1DArrayAlleleGenome<T>& orig) :
 GA1DArrayGenome<T>(orig.sz) {
   naset = 0;
   aset = (GAAlleleSet<T>*)0;
@@ -265,7 +265,7 @@ GA1DArrayAlleleGenome<T>::~GA1DArrayAlleleGenome(){
 
 
 // This implementation of clone does not make use of the contents/attributes
-// capability because this whole interface isn't quite right yet...  Just 
+// capability because this whole interface isn't quite right yet...  Just
 // clone the entire thing, contents and all.
 template <class T> GAGenome *
 GA1DArrayAlleleGenome<T>::clone(GAGenome::CloneMethod) const {
@@ -273,10 +273,10 @@ GA1DArrayAlleleGenome<T>::clone(GAGenome::CloneMethod) const {
 }
 
 
-template <class T> void 
+template <class T> void
 GA1DArrayAlleleGenome<T>::copy(const GAGenome& orig){
   if(&orig == this) return;
-  const GA1DArrayAlleleGenome<T> * c = 
+  const GA1DArrayAlleleGenome<T> * c =
     DYN_CAST(const GA1DArrayAlleleGenome<T>*, &orig);
   if(c) {
     GA1DArrayGenome<T>::copy(*c);
@@ -339,7 +339,7 @@ GA1DArrayAlleleGenome<T>::equal(const GAGenome & c) const {
 ---------------------------------------------------------------------------- */
 // The random initializer sets the elements of the array based on the alleles
 // set.  We choose randomly the allele for each element.
-template <class ARRAY_TYPE> void 
+template <class ARRAY_TYPE> void
 GA1DArrayAlleleGenome<ARRAY_TYPE>::UniformInitializer(GAGenome & c)
 {
   GA1DArrayAlleleGenome<ARRAY_TYPE> &child=
@@ -354,7 +354,7 @@ GA1DArrayAlleleGenome<ARRAY_TYPE>::UniformInitializer(GAGenome & c)
 // and assign each element the next allele in the allele set.  Once each
 // element has been initialized, scramble the contents by swapping elements.
 // This assumes that there is only one allele set for the array.
-template <class ARRAY_TYPE> void 
+template <class ARRAY_TYPE> void
 GA1DArrayAlleleGenome<ARRAY_TYPE>::OrderedInitializer(GAGenome & c)
 {
   GA1DArrayAlleleGenome<ARRAY_TYPE> &child=
@@ -372,15 +372,15 @@ GA1DArrayAlleleGenome<ARRAY_TYPE>::OrderedInitializer(GAGenome & c)
 }
 
 
-// Randomly pick elements in the array then set the element to any of the 
+// Randomly pick elements in the array then set the element to any of the
 // alleles in the allele set for this genome.  This will work for any number
 // of allele sets for a given array.
-template <class ARRAY_TYPE> int 
+template <class ARRAY_TYPE> int
 GA1DArrayAlleleGenome<ARRAY_TYPE>::FlipMutator(GAGenome & c, float pmut)
 {
   GA1DArrayAlleleGenome<ARRAY_TYPE> &child=
     DYN_CAST(GA1DArrayAlleleGenome<ARRAY_TYPE> &, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.length());
@@ -404,11 +404,11 @@ GA1DArrayAlleleGenome<ARRAY_TYPE>::FlipMutator(GAGenome & c, float pmut)
 
 
 // Randomly swap elements in the array.
-template <class ARRAY_TYPE> int 
+template <class ARRAY_TYPE> int
 GA1DArrayGenome<ARRAY_TYPE>::SwapMutator(GAGenome & c, float pmut)
 {
   GA1DArrayGenome<ARRAY_TYPE> &child=DYN_CAST(GA1DArrayGenome<ARRAY_TYPE>&, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.length());
@@ -469,7 +469,7 @@ ElementComparator(const GAGenome& a, const GAGenome& b)
 #define SWAP(a,b) {unsigned int tmp=a; a=b; b=tmp;}
 
 // Randomly take bits from each parent.  For each bit we flip a coin to see if
-// that bit should come from the mother or the father.  If strings are 
+// that bit should come from the mother or the father.  If strings are
 // different lengths then we need to use the mask to get things right.
 template <class T> int
 GA1DArrayGenome<T>::
@@ -517,8 +517,8 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
     n = 2;
   }
   else if(c1 || c2){
-    GA1DArrayGenome<T> &sis = (c1 ? 
-			       DYN_CAST(GA1DArrayGenome<T> &, *c1) : 
+    GA1DArrayGenome<T> &sis = (c1 ?
+			       DYN_CAST(GA1DArrayGenome<T> &, *c1) :
 			       DYN_CAST(GA1DArrayGenome<T> &, *c2));
 
     if(mom.length() == dad.length() && sis.length() == mom.length()){
@@ -550,7 +550,7 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
 // we cannot handle that and post an error message.
 template <class T> int
 GA1DArrayGenome<T>::
-OnePointCrossover(const GAGenome& p1, const GAGenome& p2, 
+OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 		  GAGenome* c1, GAGenome* c2){
   const GA1DArrayGenome<T> &mom=DYN_CAST(const GA1DArrayGenome<T> &, p1);
   const GA1DArrayGenome<T> &dad=DYN_CAST(const GA1DArrayGenome<T> &, p2);
@@ -565,7 +565,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour() == GAGenome::FIXED_SIZE){
-      if(mom.length() != dad.length() || 
+      if(mom.length() != dad.length() ||
 	 sis.length() != bro.length() ||
 	 sis.length() != mom.length()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -587,17 +587,17 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sis.resize(momsite+dadlen);
       bro.resize(dadsite+momlen);
     }
-    
+
     sis.copy(mom, 0, 0, momsite);
     sis.copy(dad, momsite, dadsite, dadlen);
     bro.copy(dad, 0, 0, dadsite);
     bro.copy(mom, dadsite, momsite, momlen);
-  
+
     nc = 2;
   }
   else if(c1 || c2){
-    GA1DArrayGenome<T> &sis = (c1 ? 
-			       DYN_CAST(GA1DArrayGenome<T> &, *c1) : 
+    GA1DArrayGenome<T> &sis = (c1 ?
+			       DYN_CAST(GA1DArrayGenome<T> &, *c1) :
 			       DYN_CAST(GA1DArrayGenome<T> &, *c2));
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE){
@@ -615,7 +615,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       dadlen = dad.length() - dadsite;
       sis.resize(momsite+dadlen);
     }
-    
+
     if(GARandomBit()){
       sis.copy(mom, 0, 0, momsite);
       sis.copy(dad, momsite, dadsite, dadlen);
@@ -642,14 +642,14 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
 
 // Two point crossover for the 1D array genome.  Similar to the single point
-// crossover, but here we pick two points then grab the sections based upon 
+// crossover, but here we pick two points then grab the sections based upon
 // those two points.
 //   When we pick the points, it doesn't matter where they fall (one is not
 // dependent upon the other).  Make sure we get the lesser one into the first
 // position of our site array.
 template <class T> int
 GA1DArrayGenome<T>::
-TwoPointCrossover(const GAGenome& p1, const GAGenome& p2, 
+TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
 		  GAGenome* c1, GAGenome* c2){
   const GA1DArrayGenome<T> &mom=DYN_CAST(const GA1DArrayGenome<T> &, p1);
   const GA1DArrayGenome<T> &dad=DYN_CAST(const GA1DArrayGenome<T> &, p2);
@@ -664,7 +664,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour() == GAGenome::FIXED_SIZE){
-      if(mom.length() != dad.length() || 
+      if(mom.length() != dad.length() ||
 	 sis.length() != bro.length() ||
 	 sis.length() != mom.length()){
 	GAErr(GA_LOC, mom.className(), "two-point cross", gaErrSameLengthReqd);
@@ -675,7 +675,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
       if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
-      
+
       dadsite[0] = momsite[0];
       dadsite[1] = momsite[1];
       dadlen[0] = momlen[0];
@@ -691,13 +691,13 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
       if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
-      
+
       dadsite[0] = GARandomInt(0, dad.length());
       dadsite[1] = GARandomInt(0, dad.length());
       if(dadsite[0] > dadsite[1]) SWAP(dadsite[0], dadsite[1]);
       dadlen[0] = dadsite[1] - dadsite[0];
       dadlen[1] = dad.length() - dadsite[1];
-      
+
       sis.resize(momsite[0]+dadlen[0]+momlen[1]);
       bro.resize(dadsite[0]+momlen[0]+dadlen[1]);
     }
@@ -726,7 +726,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
       if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
-      
+
       dadsite[0] = momsite[0];
       dadsite[1] = momsite[1];
       dadlen[0] = momlen[0];
@@ -738,7 +738,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
       if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
-      
+
       dadsite[0] = GARandomInt(0, dad.length());
       dadsite[1] = GARandomInt(0, dad.length());
       if(dadsite[0] > dadsite[1]) SWAP(dadsite[0], dadsite[1]);
@@ -771,13 +771,13 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
 
 
 
-// Even and odd crossover for the array works just like it does for the 
+// Even and odd crossover for the array works just like it does for the
 // binary strings.  For even crossover we take the 0th element and every other
 // one after that from the mother.  The 1st and every other come from the
 // father.  For odd crossover, we do just the opposite.
 template <class T> int
 GA1DArrayGenome<T>::
-EvenOddCrossover(const GAGenome& p1, const GAGenome& p2, 
+EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
 		 GAGenome* c1, GAGenome* c2){
   const GA1DArrayGenome<T> &mom=DYN_CAST(const GA1DArrayGenome<T> &, p1);
   const GA1DArrayGenome<T> &dad=DYN_CAST(const GA1DArrayGenome<T> &, p2);
@@ -816,10 +816,10 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
     nc = 2;
   }
   else if(c1 || c2){
-    GA1DArrayGenome<T> &sis = (c1 ? 
-			       DYN_CAST(GA1DArrayGenome<T> &, *c1) : 
+    GA1DArrayGenome<T> &sis = (c1 ?
+			       DYN_CAST(GA1DArrayGenome<T> &, *c1) :
 			       DYN_CAST(GA1DArrayGenome<T> &, *c2));
-    
+
     if(mom.length() == dad.length() && sis.length() == mom.length()){
       for(i=sis.length()-1; i>=1; i-=2){
 	sis.gene(i, mom.gene(i));
@@ -853,7 +853,7 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
 //   We make sure that b will be greater than a.
 template <class T> int
 GA1DArrayGenome<T>::
-PartialMatchCrossover(const GAGenome& p1, const GAGenome& p2, 
+PartialMatchCrossover(const GAGenome& p1, const GAGenome& p2,
 		      GAGenome* c1, GAGenome* c2){
   const GA1DArrayGenome<T> &mom=DYN_CAST(const GA1DArrayGenome<T> &, p1);
   const GA1DArrayGenome<T> &dad=DYN_CAST(const GA1DArrayGenome<T> &, p2);
@@ -868,7 +868,7 @@ PartialMatchCrossover(const GAGenome& p1, const GAGenome& p2,
     GAErr(GA_LOC, mom.className(), "parial match cross", gaErrBadParentLength);
     return nc;
   }
-  
+
   if(c1 && c2){
     GA1DArrayGenome<T> &sis=DYN_CAST(GA1DArrayGenome<T> &, *c1);
     GA1DArrayGenome<T> &bro=DYN_CAST(GA1DArrayGenome<T> &, *c2);
@@ -887,8 +887,8 @@ PartialMatchCrossover(const GAGenome& p1, const GAGenome& p2,
     nc = 2;
   }
   else if(c1 || c2){
-    GA1DArrayGenome<T> &sis = (c1 ? 
-			       DYN_CAST(GA1DArrayGenome<T> &, *c1) : 
+    GA1DArrayGenome<T> &sis = (c1 ?
+			       DYN_CAST(GA1DArrayGenome<T> &, *c1) :
 			       DYN_CAST(GA1DArrayGenome<T> &, *c2));
 
     const GA1DArrayGenome<T> *parent1, *parent2;
@@ -929,7 +929,7 @@ GA1DArrayIsHole(const GA1DArrayGenome<T> &c, const GA1DArrayGenome<T> &dad,
 //   This implementation isn't terribly smart.  For example, I do a linear
 // search rather than caching and doing binary search or smarter hash tables.
 //   First we copy the mother into the sister.  Then move the 'holes' into the
-// crossover section and maintain the ordering of the non-hole elements.  
+// crossover section and maintain the ordering of the non-hole elements.
 // Finally, put the 'holes' in the proper order within the crossover section.
 // After we have done the sister, we do the brother.
 template <class T> int
@@ -949,7 +949,7 @@ OrderCrossover(const GAGenome& p1, const GAGenome& p2,
     GAErr(GA_LOC, mom.className(), "order cross", gaErrBadParentLength);
     return nc;
   }
-  
+
   if(c1 && c2){
     GA1DArrayGenome<T> &sis=DYN_CAST(GA1DArrayGenome<T> &, *c1);
     GA1DArrayGenome<T> &bro=DYN_CAST(GA1DArrayGenome<T> &, *c2);
@@ -962,7 +962,7 @@ OrderCrossover(const GAGenome& p1, const GAGenome& p2,
       if(index >= sis.size()) index=0;
       if(GA1DArrayIsHole(sis,dad,index,a,b)) break;
     }
-    
+
     for(; i<sis.size()-b+a; i++, index++){
       if(index >= sis.size()) index=0;
       j=index;
@@ -999,7 +999,7 @@ OrderCrossover(const GAGenome& p1, const GAGenome& p2,
       } while(GA1DArrayIsHole(bro,mom,j,a,b));
       bro.swap(index,j);
     }
-    
+
 // Now put the 'holes' in the proper order within the crossover section.
     for(i=a; i<b; i++){
       if(bro.gene(i) != mom.gene(i)){
@@ -1011,8 +1011,8 @@ OrderCrossover(const GAGenome& p1, const GAGenome& p2,
     nc = 2;
   }
   else if(c1 || c2){
-    GA1DArrayGenome<T> &sis = (c1 ? 
-			       DYN_CAST(GA1DArrayGenome<T> &, *c1) : 
+    GA1DArrayGenome<T> &sis = (c1 ?
+			       DYN_CAST(GA1DArrayGenome<T> &, *c1) :
 			       DYN_CAST(GA1DArrayGenome<T> &, *c2));
 
     const GA1DArrayGenome<T> *parent1, *parent2;
@@ -1053,7 +1053,7 @@ OrderCrossover(const GAGenome& p1, const GAGenome& p2,
 
 
 
-// Cycle crossover for the 1D array genome.  This is implemented as described 
+// Cycle crossover for the 1D array genome.  This is implemented as described
 // in goldberg's book.  The first is picked from mom, then cycle using dad.
 // Finally, fill in the gaps with the elements from dad.
 //   We allocate space for a temporary array in this routine.  It never frees
@@ -1063,8 +1063,8 @@ OrderCrossover(const GAGenome& p1, const GAGenome& p2,
 //  Allocate space for an array of flags.  We use this to keep track of whether
 // the child's contents came from the mother or the father.  We don't free the
 // space here, but it is not a memory leak.
-//   The first step is to cycle through mom & dad to get the cyclic part of 
-// the crossover.  Then fill in the rest of the sis with dad's contents that 
+//   The first step is to cycle through mom & dad to get the cyclic part of
+// the crossover.  Then fill in the rest of the sis with dad's contents that
 // we didn't use in the cycle.  Finally, do the same thing for the other child.
 //   Notice that this implementation makes serious use of the operator= for the
 // objects in the array.  It also requires the operator != and == comparators.
@@ -1139,7 +1139,7 @@ CycleCrossover(const GAGenome& p1, const GAGenome& p2,
     GAMask mask;
     mask.size(sis.length());
     mask.clear();
-    
+
     sis.gene(0, parent1->gene(0));
     mask[0] = 1;
     while(parent2->gene(current) != parent1->gene(0)){

--- a/CPFA/source/ga-mpi/GA1DBinStrGenome.C
+++ b/CPFA/source/ga-mpi/GA1DBinStrGenome.C
@@ -27,13 +27,13 @@
 // this point - initialization must be done explicitly by the user of the
 // genome (eg when the population is created or reset).  If we called the
 // initializer routine here then we could end up with multiple initializations
-// and/or calls to dummy initializers (for example when the genome is 
+// and/or calls to dummy initializers (for example when the genome is
 // created with a dummy initializer and the initializer is assigned later on).
 GA1DBinaryStringGenome::
-GA1DBinaryStringGenome(unsigned int len, 
+GA1DBinaryStringGenome(unsigned int len,
 		       GAGenome::Evaluator f, void * u) :
 GABinaryString(len),
-GAGenome(DEFAULT_1DBINSTR_INITIALIZER, 
+GAGenome(DEFAULT_1DBINSTR_INITIALIZER,
 	 DEFAULT_1DBINSTR_MUTATOR,
 	 DEFAULT_1DBINSTR_COMPARATOR) {
   evaluator(f);
@@ -60,7 +60,7 @@ GA1DBinaryStringGenome::~GA1DBinaryStringGenome() {
 
 
 // The clone member creates a duplicate (exact or just attributes, depending
-// on the flag).  The caller is responsible for freeing the memory that is 
+// on the flag).  The caller is responsible for freeing the memory that is
 // allocated by this method.
 GAGenome*
 GA1DBinaryStringGenome::clone(GAGenome::CloneMethod flag) const {
@@ -81,7 +81,7 @@ GA1DBinaryStringGenome::clone(GAGenome::CloneMethod flag) const {
 // what we define here - a virtual function).  We should check to be sure that
 // both genomes are the same class and same dimension.  This function tries
 // to be smart about they way it copies.  If we already have data, then we do
-// a memcpy of the one we're supposed to copy.  If we don't or we're not the 
+// a memcpy of the one we're supposed to copy.  If we don't or we're not the
 // same size as the one we're supposed to copy, then we adjust ourselves.
 //   The BinaryStringGenome takes care of the resize in its copy method.
 // It also copies the bitstring for us.
@@ -89,7 +89,7 @@ void
 GA1DBinaryStringGenome::copy(const GAGenome & orig)
 {
   if(&orig == this) return;
-  const GA1DBinaryStringGenome* c = 
+  const GA1DBinaryStringGenome* c =
     DYN_CAST(const GA1DBinaryStringGenome*, &orig);
   if(c) {
     GAGenome::copy(*c);
@@ -173,7 +173,7 @@ GA1DBinaryStringGenome::write(STD_OSTREAM & os) const
 //   Set the resize behaviour of the genome.  A genome can be fixed
 // length, resizeable with a max and min limit, or resizeable with no limits
 // (other than an implicit one that we use internally).
-//   A value of 0 means no resize, a value less than zero mean unlimited 
+//   A value of 0 means no resize, a value less than zero mean unlimited
 // resize, and a positive value means resize with that value as the limit.
 //   We return the upper limit of the genome's size.
 int
@@ -190,21 +190,21 @@ resizeBehaviour(unsigned int lower, unsigned int upper)
   return resizeBehaviour();
 }
 
-int 
+int
 GA1DBinaryStringGenome::resizeBehaviour() const {
   int val = maxX;
   if(maxX == minX) val = FIXED_SIZE;
   return val;
 }
 
-int 
+int
 GA1DBinaryStringGenome::
 equal(const GA1DBinaryStringGenome& c,
       unsigned int dest, unsigned int src, unsigned int len) const {
   return GABinaryString::equal(c,dest,src,len);
 }
 
-int 
+int
 GA1DBinaryStringGenome::equal(const GAGenome & c) const {
   if(this == &c) return 1;
   const GA1DBinaryStringGenome* b = DYN_CAST(const GA1DBinaryStringGenome*,&c);
@@ -231,7 +231,7 @@ GA1DBinaryStringGenome::equal(const GAGenome & c) const {
 // random bit function so we don't have to worry about machine-specific stuff.
 //   We also do a resize so the genome can resize itself (randomly) if it
 // is a resizeable genome.
-void 
+void
 GA1DBinaryStringGenome::UniformInitializer(GAGenome & c)
 {
   GA1DBinaryStringGenome &child=DYN_CAST(GA1DBinaryStringGenome &, c);
@@ -242,7 +242,7 @@ GA1DBinaryStringGenome::UniformInitializer(GAGenome & c)
 
 
 //   Unset all of the bits in the genome.
-void 
+void
 GA1DBinaryStringGenome::UnsetInitializer(GAGenome & c)
 {
   GA1DBinaryStringGenome &child=DYN_CAST(GA1DBinaryStringGenome &, c);
@@ -252,7 +252,7 @@ GA1DBinaryStringGenome::UnsetInitializer(GAGenome & c)
 
 
 //   Set all of the bits in the genome.
-void 
+void
 GA1DBinaryStringGenome::SetInitializer(GAGenome & c)
 {
   GA1DBinaryStringGenome &child=DYN_CAST(GA1DBinaryStringGenome &, c);
@@ -271,11 +271,11 @@ GA1DBinaryStringGenome::SetInitializer(GAGenome & c)
 // better the chance that it will match the desired mutation rate.
 //   If nMut is greater than 1, then we round up, so a mutation of 2.2 would
 // be 3 mutations, and 2.9 would be 3 as well.  nMut of 3 would be 3 mutations.
-int 
+int
 GA1DBinaryStringGenome::FlipMutator(GAGenome & c, float pmut)
 {
   GA1DBinaryStringGenome &child=DYN_CAST(GA1DBinaryStringGenome &, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float, child.length());
@@ -298,10 +298,10 @@ GA1DBinaryStringGenome::FlipMutator(GAGenome & c, float pmut)
 }
 
 
-// Return a number from 0 to 1 to indicate how similar two genomes are.  For 
+// Return a number from 0 to 1 to indicate how similar two genomes are.  For
 // the binary strings we compare bits.  We count the number of bits that are
 // the same then divide by the number of bits.  If the genomes are different
-// length then we return a -1 to indicate that we cannot calculate the 
+// length then we return a -1 to indicate that we cannot calculate the
 // similarity.
 //   Normal hamming distance makes use of population information - this is not
 // a hamming measure!  This is a similarity measure of two individuals, not
@@ -334,7 +334,7 @@ GA1DBinaryStringGenome::BitComparator(const GAGenome& a, const GAGenome& b){
 
 
 // Randomly take bits from each parent.  For each bit we flip a coin to see if
-// that bit should come from the mother or the father.  This operator can be 
+// that bit should come from the mother or the father.  This operator can be
 // used on genomes of different lengths, but the crossover is truncated to the
 // shorter of the parents and child.
 int
@@ -385,8 +385,8 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
     n = 2;
   }
   else if(c1 || c2){
-    GA1DBinaryStringGenome &sis = (c1 ? 
-				   DYN_CAST(GA1DBinaryStringGenome&, *c1) : 
+    GA1DBinaryStringGenome &sis = (c1 ?
+				   DYN_CAST(GA1DBinaryStringGenome&, *c1) :
 				   DYN_CAST(GA1DBinaryStringGenome&, *c2));
 
     if(mom.length() == dad.length() && sis.length() == mom.length()){
@@ -434,7 +434,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour() == GAGenome::FIXED_SIZE){
-      if(mom.length() != dad.length() || 
+      if(mom.length() != dad.length() ||
 	 sis.length() != bro.length() ||
 	 sis.length() != mom.length()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -461,12 +461,12 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
     sis.copy(dad, momsite, dadsite, dadlen);
     bro.copy(dad, 0, 0, dadsite);
     bro.copy(mom, dadsite, momsite, momlen);
-  
+
     n = 2;
   }
   else if(c1 || c2){
-    GA1DBinaryStringGenome &sis = (c1 ? 
-				   DYN_CAST(GA1DBinaryStringGenome&, *c1) : 
+    GA1DBinaryStringGenome &sis = (c1 ?
+				   DYN_CAST(GA1DBinaryStringGenome&, *c1) :
 				   DYN_CAST(GA1DBinaryStringGenome&, *c2));
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE){
@@ -530,7 +530,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour() == GAGenome::FIXED_SIZE){
-      if(mom.length() != dad.length() || 
+      if(mom.length() != dad.length() ||
 	 sis.length() != bro.length() ||
 	 sis.length() != mom.length()){
 	GAErr(GA_LOC, mom.className(), "two-point cross", gaErrSameLengthReqd);
@@ -558,7 +558,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
       if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
-      
+
       dadsite[0] = GARandomInt(0, dad.length());
       dadsite[1] = GARandomInt(0, dad.length());
       if(dadsite[0] > dadsite[1]) SWAP(dadsite[0], dadsite[1]);
@@ -579,8 +579,8 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
     n = 2;
   }
   else if(c1 || c2){
-    GA1DBinaryStringGenome &sis = (c1 ? 
-				   DYN_CAST(GA1DBinaryStringGenome&, *c1) : 
+    GA1DBinaryStringGenome &sis = (c1 ?
+				   DYN_CAST(GA1DBinaryStringGenome&, *c1) :
 				   DYN_CAST(GA1DBinaryStringGenome&, *c2));
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE){
@@ -605,7 +605,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
       if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
-      
+
       dadsite[0] = GARandomInt(0, dad.length());
       dadsite[1] = GARandomInt(0, dad.length());
       if(dadsite[0] > dadsite[1]) SWAP(dadsite[0], dadsite[1]);
@@ -639,10 +639,10 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
 //   Even and odd crossovers take alternating bits from the mother and father.
 // For even crossover, we take every even bit from the mother and every odd bit
 // from the father (the first bit is the 0th bit, so it is even).  Odd
-// crossover is just the opposite.  
+// crossover is just the opposite.
 int
 GA1DBinaryStringGenome::
-EvenOddCrossover(const GAGenome& p1, const GAGenome& p2, 
+EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
 		 GAGenome* c1, GAGenome* c2){
   const GA1DBinaryStringGenome &mom=
     DYN_CAST(const GA1DBinaryStringGenome &, p1);
@@ -685,7 +685,7 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
   }
   else if(c1 || c2){
     GA1DBinaryStringGenome &sis = (c1 ?
-				   DYN_CAST(GA1DBinaryStringGenome&, *c1) : 
+				   DYN_CAST(GA1DBinaryStringGenome&, *c1) :
 				   DYN_CAST(GA1DBinaryStringGenome&, *c2));
 
     if(mom.length() == dad.length() && sis.length() == mom.length()){

--- a/CPFA/source/ga-mpi/GA2DArrayGenome.C
+++ b/CPFA/source/ga-mpi/GA2DArrayGenome.C
@@ -27,13 +27,13 @@ GA2DArrayGenome<T>::className() const {return "GA2DArrayGenome";}
 template <class T> int
 GA2DArrayGenome<T>::classID() const {return GAID::ArrayGenome2D;}
 
-template <class T> 
+template <class T>
 GA2DArrayGenome<T>::
-GA2DArrayGenome(unsigned int width, unsigned int height, 
+GA2DArrayGenome(unsigned int width, unsigned int height,
 		GAGenome::Evaluator f,
 		void * u) :
 GAArray<T>(width*height),
-GAGenome(DEFAULT_2DARRAY_INITIALIZER, 
+GAGenome(DEFAULT_2DARRAY_INITIALIZER,
 	 DEFAULT_2DARRAY_MUTATOR,
 	 DEFAULT_2DARRAY_COMPARATOR)
 {
@@ -44,7 +44,7 @@ GAGenome(DEFAULT_2DARRAY_INITIALIZER,
 }
 
 
-template <class T> 
+template <class T>
 GA2DArrayGenome<T>::
 GA2DArrayGenome(const GA2DArrayGenome<T> & orig) : GAArray<T>(orig.sz){
   GA2DArrayGenome<T>::copy(orig);
@@ -62,10 +62,10 @@ GA2DArrayGenome<T>::copy(const GAGenome & orig){
   if(c) {
     GAGenome::copy(*c);
     GAArray<T>::copy(*c);
-    nx = c->nx; ny = c->ny; 
-    minX = c->minX; minY = c->minY; 
+    nx = c->nx; ny = c->ny;
+    minX = c->minX; minY = c->minY;
     maxX = c->maxX; maxY = c->maxY;
-  } 
+  }
 }
 
 
@@ -77,8 +77,8 @@ GA2DArrayGenome<T>::clone(GAGenome::CloneMethod flag) const {
   }
   else{
     cpy->GAGenome::copy(*this);
-    cpy->minX = minX; cpy->minY = minY; 
-    cpy->maxX = maxX; cpy->maxY = maxY; 
+    cpy->minX = minX; cpy->minY = minY;
+    cpy->maxX = maxX; cpy->maxY = maxY;
   }
   return cpy;
 }
@@ -137,7 +137,7 @@ GA2DArrayGenome<T>::read(STD_ISTREAM &) {
 
 
 template <class T> int
-GA2DArrayGenome<T>::write(STD_OSTREAM & os) const 
+GA2DArrayGenome<T>::write(STD_OSTREAM & os) const
 {
   for(unsigned int j=0; j<ny; j++){
     for(unsigned int i=0; i<nx; i++){
@@ -167,7 +167,7 @@ GA2DArrayGenome<T>::resizeBehaviour(GAGenome::Dimension which) const {
 
 template <class T> int
 GA2DArrayGenome<T>::
-resizeBehaviour(GAGenome::Dimension which, 
+resizeBehaviour(GAGenome::Dimension which,
 		unsigned int lower, unsigned int upper)
 {
   if(upper < lower){
@@ -212,12 +212,12 @@ GA2DArrayGenome<T>::copy(const GA2DArrayGenome<T> & orig,
   for(unsigned int j=0; j<h; j++)
     GAArray<T>::copy(orig, (s+j)*nx+r, (y+j)*orig.nx+x, w);
 
-  _evaluated = gaFalse; 
+  _evaluated = gaFalse;
 }
 
 
 
-template <class T> int 
+template <class T> int
 GA2DArrayGenome<T>::equal(const GAGenome & c) const
 {
   if(this == &c) return 1;
@@ -259,9 +259,9 @@ GA2DArrayAlleleGenome<T>::className() const {return "GA2DArrayAlleleGenome";}
 template <class T> int
 GA2DArrayAlleleGenome<T>::classID() const {return GAID::ArrayAlleleGenome2D;}
 
-template <class T> 
+template <class T>
 GA2DArrayAlleleGenome<T>::
-GA2DArrayAlleleGenome(unsigned int width, unsigned int height, 
+GA2DArrayAlleleGenome(unsigned int width, unsigned int height,
 		      const GAAlleleSet<T> & s,
 		      GAGenome::Evaluator f, void * u) :
 GA2DArrayGenome<T>(width,height,f,u){
@@ -275,9 +275,9 @@ GA2DArrayGenome<T>(width,height,f,u){
   this->crossover(GA2DArrayAlleleGenome<T>::DEFAULT_2DARRAY_ALLELE_CROSSOVER);
 }
 
-template <class T> 
+template <class T>
 GA2DArrayAlleleGenome<T>::
-GA2DArrayAlleleGenome(unsigned int width, unsigned int height, 
+GA2DArrayAlleleGenome(unsigned int width, unsigned int height,
 		      const GAAlleleSetArray<T> & sa,
 		      GAGenome::Evaluator f, void * u) :
 GA2DArrayGenome<T>(width,height, f, u) {
@@ -293,9 +293,9 @@ GA2DArrayGenome<T>(width,height, f, u) {
 }
 
 
-template <class T> 
+template <class T>
 GA2DArrayAlleleGenome<T>::
-GA2DArrayAlleleGenome(const GA2DArrayAlleleGenome<T> & orig) : 
+GA2DArrayAlleleGenome(const GA2DArrayAlleleGenome<T> & orig) :
 GA2DArrayGenome<T>(orig.nx, orig.ny) {
   naset = 0;
   aset = (GAAlleleSet<T>*)0;
@@ -315,10 +315,10 @@ GA2DArrayAlleleGenome<T>::clone(GAGenome::CloneMethod) const {
 }
 
 
-template <class T> void 
+template <class T> void
 GA2DArrayAlleleGenome<T>::copy(const GAGenome& orig){
   if(&orig == this) return;
-  const GA2DArrayAlleleGenome<T>* c = 
+  const GA2DArrayAlleleGenome<T>* c =
     DYN_CAST(const GA2DArrayAlleleGenome<T>*, &orig);
   if(c) {
     GA2DArrayGenome<T>::copy(*c);
@@ -386,24 +386,24 @@ GA2DArrayAlleleGenome<T>::equal(const GAGenome & c) const {
    Operator definitions
 ---------------------------------------------------------------------------- */
 // this does not handle genomes with multiple allele sets!
-template <class ARRAY_TYPE> void 
+template <class ARRAY_TYPE> void
 GA2DArrayAlleleGenome<ARRAY_TYPE>::UniformInitializer(GAGenome & c)
 {
   GA2DArrayAlleleGenome<ARRAY_TYPE> &child=
     DYN_CAST(GA2DArrayAlleleGenome<ARRAY_TYPE> &, c);
-  child.resize(GAGenome::ANY_SIZE,GAGenome::ANY_SIZE); 
+  child.resize(GAGenome::ANY_SIZE,GAGenome::ANY_SIZE);
   for(int i=child.width()-1; i>=0; i--)
     for(int j=child.height()-1; j>=0; j--)
       child.gene(i, j, child.alleleset().allele());
 }
 
 
-template <class ARRAY_TYPE> int 
+template <class ARRAY_TYPE> int
 GA2DArrayAlleleGenome<ARRAY_TYPE>::FlipMutator(GAGenome & c, float pmut)
 {
   GA2DArrayAlleleGenome<ARRAY_TYPE> &child=
     DYN_CAST(GA2DArrayAlleleGenome<ARRAY_TYPE> &, c);
-  register int n, m, i, j;
+  int n, m, i, j;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.size());
@@ -430,11 +430,11 @@ GA2DArrayAlleleGenome<ARRAY_TYPE>::FlipMutator(GAGenome & c, float pmut)
 }
 
 
-template <class ARRAY_TYPE> int 
+template <class ARRAY_TYPE> int
 GA2DArrayGenome<ARRAY_TYPE>::SwapMutator(GAGenome & c, float pmut)
 {
   GA2DArrayGenome<ARRAY_TYPE> &child=DYN_CAST(GA2DArrayGenome<ARRAY_TYPE>&, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.size());
@@ -496,7 +496,7 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
   if(c1 && c2){
     GA2DArrayGenome<T> &sis=DYN_CAST(GA2DArrayGenome<T> &, *c1);
     GA2DArrayGenome<T> &bro=DYN_CAST(GA2DArrayGenome<T> &, *c2);
-    
+
     if(sis.width() == bro.width() && sis.height() == bro.height() &&
        mom.width() == dad.width() && mom.height() == dad.height() &&
        sis.width() == mom.width() && sis.height() == mom.height()){
@@ -567,7 +567,7 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
 
 
 // This crossover does clipping (no padding) for resizables.  Notice that this
-// means that any resizable children of two parents will have identical 
+// means that any resizable children of two parents will have identical
 // dimensions no matter what.
 template <class T> int
 GA2DArrayGenome<T>::
@@ -587,8 +587,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE){
-      if(mom.width() != dad.width() || 
-	 sis.width() != bro.width() || 
+      if(mom.width() != dad.width() ||
+	 sis.width() != bro.width() ||
 	 sis.width() != mom.width()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -612,8 +612,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
-      if(mom.height() != dad.height() || 
-	 sis.height() != bro.height() || 
+      if(mom.height() != dad.height() ||
+	 sis.height() != bro.height() ||
 	 sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -637,12 +637,12 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     sis.resize(sitex+lenx, sitey+leny);
     bro.resize(sitex+lenx, sitey+leny);
-    
+
     sis.copy(mom, 0, 0, momsitex-sitex, momsitey-sitey, sitex, sitey);
     sis.copy(dad, sitex, 0, dadsitex, dadsitey-sitey, lenx, sitey);
     sis.copy(dad, 0, sitey, dadsitex-sitex, dadsitey, sitex, leny);
     sis.copy(mom, sitex, sitey, momsitex, momsitey, lenx, leny);
-    
+
     bro.copy(dad, 0, 0, dadsitex-sitex, dadsitey-sitey, sitex, sitey);
     bro.copy(mom, sitex, 0, momsitex, momsitey-sitey, lenx, sitey);
     bro.copy(mom, 0, sitey, momsitex-sitex, momsitey, sitex, leny);
@@ -652,7 +652,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
   }
   else if(c1){
     GA2DArrayGenome<T> &sis=DYN_CAST(GA2DArrayGenome<T> &, *c1);
-    
+
     if(sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE){
       if(mom.width() != dad.width() || sis.width() != mom.width()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -669,7 +669,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitex = GAMin(momsitex, dadsitex);
       lenx = GAMin(momlenx, dadlenx);
     }
-    
+
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
       if(mom.height() != dad.height() || sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -686,9 +686,9 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitey = GAMin(momsitey, dadsitey);
       leny = GAMin(momleny, dadleny);
     }
-    
+
     sis.resize(sitex+lenx, sitey+leny);
-    
+
     if(GARandomBit()){
       sis.copy(mom, 0, 0, momsitex-sitex, momsitey-sitey, sitex, sitey);
       sis.copy(dad, sitex, 0, dadsitex, dadsitey-sitey, lenx, sitey);
@@ -759,7 +759,7 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
   }
   else if(c1){
     GA2DArrayGenome<T> &sis=DYN_CAST(GA2DArrayGenome<T> &, *c1);
-    
+
     if(mom.width() == dad.width() && mom.height() == dad.height() &&
        sis.width() == mom.width() && sis.height() == mom.height()){
       int count=0;

--- a/CPFA/source/ga-mpi/GA2DBinStrGenome.C
+++ b/CPFA/source/ga-mpi/GA2DBinStrGenome.C
@@ -21,141 +21,164 @@
    Genome class definition
 ---------------------------------------------------------------------------- */
 GA2DBinaryStringGenome::
-GA2DBinaryStringGenome(unsigned int width, unsigned int height, 
-		       GAGenome::Evaluator f, void * u) :
-GABinaryString(width*height),
-GAGenome(DEFAULT_2DBINSTR_INITIALIZER,
-	 DEFAULT_2DBINSTR_MUTATOR,
-	 DEFAULT_2DBINSTR_COMPARATOR) {
+    GA2DBinaryStringGenome(unsigned int width, unsigned int height,
+                           GAGenome::Evaluator f, void *u) : GABinaryString(width * height),
+                                                             GAGenome(DEFAULT_2DBINSTR_INITIALIZER,
+                                                                      DEFAULT_2DBINSTR_MUTATOR,
+                                                                      DEFAULT_2DBINSTR_COMPARATOR)
+{
   evaluator(f);
   userData(u);
   crossover(DEFAULT_2DBINSTR_CROSSOVER);
-  nx=minX=maxX=0; ny=minY=maxY=0;
+  nx = minX = maxX = 0;
+  ny = minY = maxY = 0;
   resize(width, height);
 }
 
-
 GA2DBinaryStringGenome::
-GA2DBinaryStringGenome(const GA2DBinaryStringGenome & orig) :
-GABinaryString(orig.GABinaryString::size()),
-GAGenome() {
-  nx=minX=maxX=0; ny=minY=maxY=0;
+    GA2DBinaryStringGenome(const GA2DBinaryStringGenome &orig) : GABinaryString(orig.GABinaryString::size()),
+                                                                 GAGenome()
+{
+  nx = minX = maxX = 0;
+  ny = minY = maxY = 0;
   GA2DBinaryStringGenome::copy(orig);
 }
 
-GA2DBinaryStringGenome::~GA2DBinaryStringGenome() {
+GA2DBinaryStringGenome::~GA2DBinaryStringGenome()
+{
 }
 
 GAGenome *
-GA2DBinaryStringGenome::clone(GAGenome::CloneMethod flag) const {
-  GA2DBinaryStringGenome *cpy = new GA2DBinaryStringGenome(nx,ny);
-  if(flag == CONTENTS){
+GA2DBinaryStringGenome::clone(GAGenome::CloneMethod flag) const
+{
+  GA2DBinaryStringGenome *cpy = new GA2DBinaryStringGenome(nx, ny);
+  if (flag == CONTENTS)
+  {
     cpy->copy(*this);
   }
-  else{
+  else
+  {
     cpy->GAGenome::copy(*this);
-    cpy->minX = minX; cpy->minY = minY; 
-    cpy->maxX = maxX; cpy->maxY = maxY; 
+    cpy->minX = minX;
+    cpy->minY = minY;
+    cpy->maxX = maxX;
+    cpy->maxY = maxY;
   }
   return cpy;
 }
 
-void
-GA2DBinaryStringGenome::copy(const GAGenome & orig)
+void GA2DBinaryStringGenome::copy(const GAGenome &orig)
 {
-  if(&orig == this) return;
-  const GA2DBinaryStringGenome* c =
-    DYN_CAST(const GA2DBinaryStringGenome*, &orig);
-  if(c) {
+  if (&orig == this)
+    return;
+  const GA2DBinaryStringGenome *c =
+      DYN_CAST(const GA2DBinaryStringGenome *, &orig);
+  if (c)
+  {
     GAGenome::copy(*c);
     GABinaryString::copy(*c);
-    nx = c->nx; ny = c->ny; 
-    minX = c->minX; minY = c->minY; 
-    maxX = c->maxX; maxY = c->maxY;
-  } 
+    nx = c->nx;
+    ny = c->ny;
+    minX = c->minX;
+    minY = c->minY;
+    maxX = c->maxX;
+    maxY = c->maxY;
+  }
 }
 
-
-int
-GA2DBinaryStringGenome::resize(int w, int h)
+int GA2DBinaryStringGenome::resize(int w, int h)
 {
-  if((unsigned int)w == nx && (unsigned int)h == ny) return sz;
+  if ((unsigned int)w == nx && (unsigned int)h == ny)
+    return sz;
 
-  if(w == GAGenome::ANY_SIZE)
+  if (w == GAGenome::ANY_SIZE)
     w = GARandomInt(minX, maxX);
-  else if(w < 0)
-    w = nx;		// do nothing
-  else if(minX == maxX)
-    minX=maxX = w;
-  else{
-    if(w < STA_CAST(int, minX)) w=minX;
-    if(w > STA_CAST(int, maxX)) w=maxX;
+  else if (w < 0)
+    w = nx; // do nothing
+  else if (minX == maxX)
+    minX = maxX = w;
+  else
+  {
+    if (w < STA_CAST(int, minX))
+      w = minX;
+    if (w > STA_CAST(int, maxX))
+      w = maxX;
   }
 
-  if(h == GAGenome::ANY_SIZE)
+  if (h == GAGenome::ANY_SIZE)
     h = GARandomInt(minY, maxY);
-  else if(h < 0)
-    h = ny;		// do nothing
-  else if(minY == maxY)
-    minY=maxY = h;
-  else{
-    if(h < STA_CAST(int, minY)) h=minY;
-    if(h > STA_CAST(int, maxY)) h=maxY;
+  else if (h < 0)
+    h = ny; // do nothing
+  else if (minY == maxY)
+    minY = maxY = h;
+  else
+  {
+    if (h < STA_CAST(int, minY))
+      h = minY;
+    if (h > STA_CAST(int, maxY))
+      h = maxY;
   }
 
-// Move the bits into the right position.  If we're smaller, then shift to
-// the smaller size before we do the resize (the resize method maintains bit
-// integrety).  If we're larger, do the move after the resize.  If we're the 
-// same size the we don't do anything.  When we're adding more bits, the new
-// bits get set randomly to 0 or 1.
+  // Move the bits into the right position.  If we're smaller, then shift to
+  // the smaller size before we do the resize (the resize method maintains bit
+  // integrety).  If we're larger, do the move after the resize.  If we're the
+  // same size the we don't do anything.  When we're adding more bits, the new
+  // bits get set randomly to 0 or 1.
 
-  if(w < STA_CAST(int,nx)){
-    int y=GAMin(STA_CAST(int,ny),h);
-    for(int j=0; j<y; j++)
-      GABinaryString::move(j*w,j*nx,w);
+  if (w < STA_CAST(int, nx))
+  {
+    int y = GAMin(STA_CAST(int, ny), h);
+    for (int j = 0; j < y; j++)
+      GABinaryString::move(j * w, j * nx, w);
   }
-  GABinaryString::resize(w*h);
-  if(w > STA_CAST(int,nx)){		// adjust the existing chunks of bits
-    int y=GAMin(STA_CAST(int,ny),h);
-    for(int j=y-1; j>=0; j--){
-      GABinaryString::move(j*w,j*nx,nx);
-      for(int i=nx; i<w; i++)
-	bit(j*w+i, GARandomBit());
+  GABinaryString::resize(w * h);
+  if (w > STA_CAST(int, nx))
+  { // adjust the existing chunks of bits
+    int y = GAMin(STA_CAST(int, ny), h);
+    for (int j = y - 1; j >= 0; j--)
+    {
+      GABinaryString::move(j * w, j * nx, nx);
+      for (int i = nx; i < w; i++)
+        bit(j * w + i, GARandomBit());
     }
   }
-  if(h > STA_CAST(int,ny)){		// change in height is always new bits
-    for(int i=w*ny; i<w*h; i++)
+  if (h > STA_CAST(int, ny))
+  { // change in height is always new bits
+    for (int i = w * ny; i < w * h; i++)
       bit(i, GARandomBit());
   }
 
-  nx = w; ny = h;
+  nx = w;
+  ny = h;
   _evaluated = gaFalse;
   return sz;
 }
 
-
 #ifdef GALIB_USE_STREAMS
-int
-GA2DBinaryStringGenome::read(STD_ISTREAM & is)
+int GA2DBinaryStringGenome::read(STD_ISTREAM &is)
 {
   static char c;
-  unsigned int i=0, j=0;
-  while(!is.fail() && !is.eof() && j < ny) {
+  unsigned int i = 0, j = 0;
+  while (!is.fail() && !is.eof() && j < ny)
+  {
     is >> c;
-    if(isdigit(c)){
+    if (isdigit(c))
+    {
       gene(i, j, ((c == '0') ? 0 : 1));
-      if(++i >= nx){		// ready for next row
-	i=0;
-	j++;
+      if (++i >= nx)
+      { // ready for next row
+        i = 0;
+        j++;
       }
     }
   }
 
   _evaluated = gaFalse;
 
-  if(is.eof() && 
-     ((j < ny) ||	     // didn't get some lines
-      (i < nx && i != 0))){   // stopped early on a row
+  if (is.eof() &&
+      ((j < ny) || // didn't get some lines
+       (i < nx && i != 0)))
+  { // stopped early on a row
     GAErr(GA_LOC, className(), "read", gaErrUnexpectedEOF);
     is.clear(STD_IOS_BADBIT | is.rdstate());
     return 1;
@@ -164,57 +187,67 @@ GA2DBinaryStringGenome::read(STD_ISTREAM & is)
   return 0;
 }
 
-
 // Dump the digits to the stream with a newline between each row.  No newline
 // at the end of the whole thing.
-int
-GA2DBinaryStringGenome::write(STD_OSTREAM & os) const 
+int GA2DBinaryStringGenome::write(STD_OSTREAM &os) const
 {
-  for(unsigned int j=0; j<ny; j++){
-    for(unsigned int i=0; i<nx; i++)
-      os << gene(i,j);
+  for (unsigned int j = 0; j < ny; j++)
+  {
+    for (unsigned int i = 0; i < nx; i++)
+      os << gene(i, j);
     os << "\n";
   }
   return 0;
 }
 #endif
 
-
-int 
-GA2DBinaryStringGenome::resizeBehaviour(GAGenome::Dimension which) const {
+int GA2DBinaryStringGenome::resizeBehaviour(GAGenome::Dimension which) const
+{
   int val = 0;
-  if(which == WIDTH) {
-    if(maxX == minX) val = FIXED_SIZE;
-    else val = maxX;
+  if (which == WIDTH)
+  {
+    if (maxX == minX)
+      val = FIXED_SIZE;
+    else
+      val = maxX;
   }
-  else if(which == HEIGHT) {
-    if(maxY == minY) val = FIXED_SIZE;
-    else val = maxY;
+  else if (which == HEIGHT)
+  {
+    if (maxY == minY)
+      val = FIXED_SIZE;
+    else
+      val = maxY;
   }
   return val;
 }
 
-
-int
-GA2DBinaryStringGenome::
-resizeBehaviour(Dimension which, unsigned int lower, unsigned int upper)
+int GA2DBinaryStringGenome::
+    resizeBehaviour(Dimension which, unsigned int lower, unsigned int upper)
 {
-  if(upper < lower){
+  if (upper < lower)
+  {
     GAErr(GA_LOC, className(), "resizeBehaviour", gaErrBadResizeBehaviour);
     return resizeBehaviour(which);
   }
 
-  switch(which){
+  switch (which)
+  {
   case WIDTH:
-    minX = lower; maxX = upper;
-    if(nx > upper) resize(upper,ny);
-    if(nx < lower) resize(lower,ny);
+    minX = lower;
+    maxX = upper;
+    if (nx > upper)
+      resize(upper, ny);
+    if (nx < lower)
+      resize(lower, ny);
     break;
 
   case HEIGHT:
-    minY = lower; maxY = upper;
-    if(ny > upper) resize(nx,upper);
-    if(ny < lower) resize(nx,lower);
+    minY = lower;
+    maxY = upper;
+    if (ny > upper)
+      resize(nx, upper);
+    if (ny < lower)
+      resize(nx, lower);
     break;
 
   default:
@@ -224,117 +257,116 @@ resizeBehaviour(Dimension which, unsigned int lower, unsigned int upper)
   return resizeBehaviour(which);
 }
 
-
-void
-GA2DBinaryStringGenome::copy(const GA2DBinaryStringGenome & orig,
-			     unsigned int r, unsigned int s,
-			     unsigned int x, unsigned int y,
-			     unsigned int w, unsigned int h)
+void GA2DBinaryStringGenome::copy(const GA2DBinaryStringGenome &orig,
+                                  unsigned int r, unsigned int s,
+                                  unsigned int x, unsigned int y,
+                                  unsigned int w, unsigned int h)
 {
-  if(w == 0 || x >= orig.nx || r >= nx ||
-     h == 0 || y >= orig.ny || s >= ny) return;
-  if(x + w > orig.nx) w = orig.nx - x;
-  if(y + h > orig.ny) h = orig.ny - y;
-  if(r + w > nx) w = nx - r;
-  if(s + h > ny) h = ny - s;
+  if (w == 0 || x >= orig.nx || r >= nx ||
+      h == 0 || y >= orig.ny || s >= ny)
+    return;
+  if (x + w > orig.nx)
+    w = orig.nx - x;
+  if (y + h > orig.ny)
+    h = orig.ny - y;
+  if (r + w > nx)
+    w = nx - r;
+  if (s + h > ny)
+    h = ny - s;
 
-  for(unsigned int j=0; j<h; j++)
-    GABinaryString::copy(orig, (s+j)*nx+r, (y+j)*orig.nx+x, w);
+  for (unsigned int j = 0; j < h; j++)
+    GABinaryString::copy(orig, (s + j) * nx + r, (y + j) * orig.nx + x, w);
   _evaluated = gaFalse;
 }
 
-
-void
-GA2DBinaryStringGenome::set(unsigned int x, unsigned int y,
-			    unsigned int w, unsigned int h)
+void GA2DBinaryStringGenome::set(unsigned int x, unsigned int y,
+                                 unsigned int w, unsigned int h)
 {
-  if(x + w > nx) w = nx - x;
-  if(y + h > ny) h = ny - y;
+  if (x + w > nx)
+    w = nx - x;
+  if (y + h > ny)
+    h = ny - y;
 
-  for(unsigned int j=0; j<h; j++)
-    GABinaryString::set((y+j)*nx+x, w);
+  for (unsigned int j = 0; j < h; j++)
+    GABinaryString::set((y + j) * nx + x, w);
   _evaluated = gaFalse;
 }
 
-
-void
-GA2DBinaryStringGenome::unset(unsigned int x, unsigned int y,
-			      unsigned int w, unsigned int h)
+void GA2DBinaryStringGenome::unset(unsigned int x, unsigned int y,
+                                   unsigned int w, unsigned int h)
 {
-  if(x + w > nx) w = nx - x;
-  if(y + h > ny) h = ny - y;
+  if (x + w > nx)
+    w = nx - x;
+  if (y + h > ny)
+    h = ny - y;
 
-  for(unsigned int j=0; j<h; j++)
-    GABinaryString::unset((y+j)*nx+x, w);
+  for (unsigned int j = 0; j < h; j++)
+    GABinaryString::unset((y + j) * nx + x, w);
   _evaluated = gaFalse;
 }
 
-
-void
-GA2DBinaryStringGenome::randomize(unsigned int x, unsigned int y,
-				  unsigned int w, unsigned int h)
+void GA2DBinaryStringGenome::randomize(unsigned int x, unsigned int y,
+                                       unsigned int w, unsigned int h)
 {
-  if(x + w > nx) w = nx - x;
-  if(y + h > ny) h = ny - y;
+  if (x + w > nx)
+    w = nx - x;
+  if (y + h > ny)
+    h = ny - y;
 
-  for(unsigned int j=0; j<h; j++)
-    GABinaryString::randomize((y+j)*nx+x, w);
+  for (unsigned int j = 0; j < h; j++)
+    GABinaryString::randomize((y + j) * nx + x, w);
   _evaluated = gaFalse;
 }
 
-
-void
-GA2DBinaryStringGenome::move(unsigned int x, unsigned int y,
-			     unsigned int srcx, unsigned int srcy,
-			     unsigned int w, unsigned int h)
+void GA2DBinaryStringGenome::move(unsigned int x, unsigned int y,
+                                  unsigned int srcx, unsigned int srcy,
+                                  unsigned int w, unsigned int h)
 {
-  if(srcx + w > nx) w = nx - srcx;
-  if(x + w > nx) w = nx - x;
-  if(srcy + h > ny) h = ny - srcy;
-  if(y + h > ny) h = ny - y;
+  if (srcx + w > nx)
+    w = nx - srcx;
+  if (x + w > nx)
+    w = nx - x;
+  if (srcy + h > ny)
+    h = ny - srcy;
+  if (y + h > ny)
+    h = ny - y;
 
-  if(srcy<y){
-    for(int j=h-1; j>=0; j--)
-      GABinaryString::move((y+j)*nx+x, (srcy+j)*nx+srcx, w);
+  if (srcy < y)
+  {
+    for (int j = h - 1; j >= 0; j--)
+      GABinaryString::move((y + j) * nx + x, (srcy + j) * nx + srcx, w);
   }
-  else{
-    for(unsigned int j=0; j<h; j++)
-      GABinaryString::move((y+j)*nx+x, (srcy+j)*nx+srcx, w);
+  else
+  {
+    for (unsigned int j = 0; j < h; j++)
+      GABinaryString::move((y + j) * nx + x, (srcy + j) * nx + srcx, w);
   }
   _evaluated = gaFalse;
 }
 
-
-int
-GA2DBinaryStringGenome::equal(const GA2DBinaryStringGenome& orig,
-			      unsigned int x, unsigned int y,
-			      unsigned int srcx, unsigned int srcy,
-			      unsigned int w, unsigned int h) const
+int GA2DBinaryStringGenome::equal(const GA2DBinaryStringGenome &orig,
+                                  unsigned int x, unsigned int y,
+                                  unsigned int srcx, unsigned int srcy,
+                                  unsigned int w, unsigned int h) const
 {
   unsigned int eq = 0;
-  for(unsigned int j=0; j<h; j++)
-    eq += GABinaryString::equal(orig, (y+j)*nx+x, (srcy+j)*nx+srcx, w);
-  return eq==h ? 1 : 0;
+  for (unsigned int j = 0; j < h; j++)
+    eq += GABinaryString::equal(orig, (y + j) * nx + x, (srcy + j) * nx + srcx, w);
+  return eq == h ? 1 : 0;
 }
 
-
-int 
-GA2DBinaryStringGenome::equal(const GAGenome & c) const
+int GA2DBinaryStringGenome::equal(const GAGenome &c) const
 {
-  if(this == &c) return 1;
-  GA2DBinaryStringGenome & b = (GA2DBinaryStringGenome &)c;
-  if(nx != b.nx || ny != b.ny) return 0;
-  int val=0;
-  for(unsigned int j=0; j<ny && val==0; j++)
-    val = GABinaryString::equal(b,j*nx,j*nx,nx) ? 0 : 1;
-  return(val ? 0 : 1);
+  if (this == &c)
+    return 1;
+  GA2DBinaryStringGenome &b = (GA2DBinaryStringGenome &)c;
+  if (nx != b.nx || ny != b.ny)
+    return 0;
+  int val = 0;
+  for (unsigned int j = 0; j < ny && val == 0; j++)
+    val = GABinaryString::equal(b, j * nx, j * nx, nx) ? 0 : 1;
+  return (val ? 0 : 1);
 }
-
-
-
-
-
-
 
 /* ----------------------------------------------------------------------------
    Operators
@@ -344,166 +376,165 @@ GA2DBinaryStringGenome::equal(const GAGenome & c) const
   The order for looping through indices is height-then-width (ie height loops
 before a single width increment)
 ---------------------------------------------------------------------------- */
-void 
-GA2DBinaryStringGenome::UniformInitializer(GAGenome & c)
+void GA2DBinaryStringGenome::UniformInitializer(GAGenome &c)
 {
-  GA2DBinaryStringGenome &child=DYN_CAST(GA2DBinaryStringGenome &, c);
+  GA2DBinaryStringGenome &child = DYN_CAST(GA2DBinaryStringGenome &, c);
   child.resize(GAGenome::ANY_SIZE, GAGenome::ANY_SIZE);
-  for(int i=child.width()-1; i>=0; i--)
-    for(int j=child.height()-1; j>=0; j--)
+  for (int i = child.width() - 1; i >= 0; i--)
+    for (int j = child.height() - 1; j >= 0; j--)
       child.gene(i, j, GARandomBit());
 }
 
-
-void 
-GA2DBinaryStringGenome::UnsetInitializer(GAGenome & c)
+void GA2DBinaryStringGenome::UnsetInitializer(GAGenome &c)
 {
-  GA2DBinaryStringGenome &child=DYN_CAST(GA2DBinaryStringGenome &, c);
+  GA2DBinaryStringGenome &child = DYN_CAST(GA2DBinaryStringGenome &, c);
   child.resize(GAGenome::ANY_SIZE, GAGenome::ANY_SIZE);
   child.unset(0, 0, child.width(), child.height());
 }
 
-
-void 
-GA2DBinaryStringGenome::SetInitializer(GAGenome & c)
+void GA2DBinaryStringGenome::SetInitializer(GAGenome &c)
 {
-  GA2DBinaryStringGenome &child=DYN_CAST(GA2DBinaryStringGenome &, c);
-  child.resize(GAGenome::ANY_SIZE, GAGenome::ANY_SIZE);	
+  GA2DBinaryStringGenome &child = DYN_CAST(GA2DBinaryStringGenome &, c);
+  child.resize(GAGenome::ANY_SIZE, GAGenome::ANY_SIZE);
   child.set(0, 0, child.width(), child.height());
 }
 
-
-int 
-GA2DBinaryStringGenome::FlipMutator(GAGenome & c, float pmut)
+int GA2DBinaryStringGenome::FlipMutator(GAGenome &c, float pmut)
 {
-  GA2DBinaryStringGenome &child=DYN_CAST(GA2DBinaryStringGenome &, c);
-  register int n, m, i, j;
-  if(pmut <= 0.0) return(0);
+  GA2DBinaryStringGenome &child = DYN_CAST(GA2DBinaryStringGenome &, c);
+  int n, m, i, j;
+  if (pmut <= 0.0)
+    return (0);
 
   float nMut = pmut * STA_CAST(float, child.size());
-  if(nMut < 1.0){		// we have to do a flip test on each bit
+  if (nMut < 1.0)
+  { // we have to do a flip test on each bit
     nMut = 0;
-    for(i=child.width()-1; i>=0; i--){
-      for(j=child.height()-1; j>=0; j--){
-	if(GAFlipCoin(pmut)){
-	  child.gene(i, j, ((child.gene(i,j) == 0) ? 1 : 0));
-	  nMut++;
-	}
+    for (i = child.width() - 1; i >= 0; i--)
+    {
+      for (j = child.height() - 1; j >= 0; j--)
+      {
+        if (GAFlipCoin(pmut))
+        {
+          child.gene(i, j, ((child.gene(i, j) == 0) ? 1 : 0));
+          nMut++;
+        }
       }
     }
   }
-  else{				// only flip the number of bits we need to flip
-    for(n=0; n<nMut; n++){
-      m = GARandomInt(0, child.size()-1);
+  else
+  { // only flip the number of bits we need to flip
+    for (n = 0; n < nMut; n++)
+    {
+      m = GARandomInt(0, child.size() - 1);
       i = m % child.width();
       j = m / child.width();
-      child.gene(i, j, ((child.gene(i,j) == 0) ? 1 : 0));
+      child.gene(i, j, ((child.gene(i, j) == 0) ? 1 : 0));
     }
   }
-  return(STA_CAST(int,nMut));
+  return (STA_CAST(int, nMut));
 }
 
-
-float
-GA2DBinaryStringGenome::BitComparator(const GAGenome& a, const GAGenome& b){
-  const GA2DBinaryStringGenome &sis=
-    DYN_CAST(const GA2DBinaryStringGenome &, a);
-  const GA2DBinaryStringGenome &bro=
-    DYN_CAST(const GA2DBinaryStringGenome &, b);
-  if(sis.size() != bro.size()) return -1;
-  if(sis.size() == 0) return 0;
+float GA2DBinaryStringGenome::BitComparator(const GAGenome &a, const GAGenome &b)
+{
+  const GA2DBinaryStringGenome &sis =
+      DYN_CAST(const GA2DBinaryStringGenome &, a);
+  const GA2DBinaryStringGenome &bro =
+      DYN_CAST(const GA2DBinaryStringGenome &, b);
+  if (sis.size() != bro.size())
+    return -1;
+  if (sis.size() == 0)
+    return 0;
   float count = 0.0;
-  for(int i=sis.width()-1; i>=0; i--)
-    for(int j=sis.height()-1; j>=0; j--)
-      count += ((sis.gene(i,j) == bro.gene(i,j)) ? 0 : 1);
-  return count/sis.size();
+  for (int i = sis.width() - 1; i >= 0; i--)
+    for (int j = sis.height() - 1; j >= 0; j--)
+      count += ((sis.gene(i, j) == bro.gene(i, j)) ? 0 : 1);
+  return count / sis.size();
 }
 
+int GA2DBinaryStringGenome::
+    UniformCrossover(const GAGenome &p1, const GAGenome &p2,
+                     GAGenome *c1, GAGenome *c2)
+{
+  const GA2DBinaryStringGenome &mom =
+      DYN_CAST(const GA2DBinaryStringGenome &, p1);
+  const GA2DBinaryStringGenome &dad =
+      DYN_CAST(const GA2DBinaryStringGenome &, p2);
 
+  int nc = 0;
+  int i, j;
 
+  if (c1 && c2)
+  {
+    GA2DBinaryStringGenome &sis = DYN_CAST(GA2DBinaryStringGenome &, *c1);
+    GA2DBinaryStringGenome &bro = DYN_CAST(GA2DBinaryStringGenome &, *c2);
 
-
-
-
-
-
-
-
-int
-GA2DBinaryStringGenome::
-UniformCrossover(const GAGenome& p1, const GAGenome& p2, 
-		 GAGenome* c1, GAGenome* c2){
-  const GA2DBinaryStringGenome &mom=
-    DYN_CAST(const GA2DBinaryStringGenome &, p1);
-  const GA2DBinaryStringGenome &dad=
-    DYN_CAST(const GA2DBinaryStringGenome &, p2);
-
-  int nc=0;
-  int i,j;
-
-  if(c1 && c2){
-    GA2DBinaryStringGenome &sis=DYN_CAST(GA2DBinaryStringGenome &, *c1);
-    GA2DBinaryStringGenome &bro=DYN_CAST(GA2DBinaryStringGenome &, *c2);
-
-    if(sis.width() == bro.width() && sis.height() == bro.height() &&
-       mom.width() == dad.width() && mom.height() == dad.height() &&
-       sis.width() == mom.width() && sis.height() == mom.height()){
-      for(i=sis.width()-1; i>=0; i--){
-	for(j=sis.height()-1; j>=0; j--){
-	  if(GARandomBit()){
-	    sis.gene(i,j, mom.gene(i,j));
-	    bro.gene(i,j, dad.gene(i,j));
-	  }
-	  else{
-	    sis.gene(i,j, dad.gene(i,j));
-	    bro.gene(i,j, mom.gene(i,j));
-	  }
-	}
+    if (sis.width() == bro.width() && sis.height() == bro.height() &&
+        mom.width() == dad.width() && mom.height() == dad.height() &&
+        sis.width() == mom.width() && sis.height() == mom.height())
+    {
+      for (i = sis.width() - 1; i >= 0; i--)
+      {
+        for (j = sis.height() - 1; j >= 0; j--)
+        {
+          if (GARandomBit())
+          {
+            sis.gene(i, j, mom.gene(i, j));
+            bro.gene(i, j, dad.gene(i, j));
+          }
+          else
+          {
+            sis.gene(i, j, dad.gene(i, j));
+            bro.gene(i, j, mom.gene(i, j));
+          }
+        }
       }
     }
-    else{
+    else
+    {
       GAMask mask;
       int maxx = GAMax(sis.width(), bro.width());
       int minx = GAMin(mom.width(), dad.width());
       int maxy = GAMax(sis.height(), bro.height());
       int miny = GAMin(mom.height(), dad.height());
-      mask.size(maxx*maxy);
-      for(i=0; i<maxx; i++)
-	for(j=0; j<maxy; j++)
-	  mask[i*maxy+j] = GARandomBit();
+      mask.size(maxx * maxy);
+      for (i = 0; i < maxx; i++)
+        for (j = 0; j < maxy; j++)
+          mask[i * maxy + j] = GARandomBit();
       minx = GAMin(sis.width(), minx);
       miny = GAMin(sis.height(), miny);
-      for(i=0; i<minx; i++)
-	for(j=0; j<miny; j++)
-	  sis.gene(i,j, (mask[i*miny+j] ? mom.gene(i,j) : dad.gene(i,j)));
+      for (i = 0; i < minx; i++)
+        for (j = 0; j < miny; j++)
+          sis.gene(i, j, (mask[i * miny + j] ? mom.gene(i, j) : dad.gene(i, j)));
       minx = GAMin(bro.width(), minx);
       miny = GAMin(bro.height(), miny);
-      for(i=0; i<minx; i++)
-	for(j=0; j<miny; j++)
-	  bro.gene(i,j, (mask[i*miny+j] ? dad.gene(i,j) : mom.gene(i,j)));
+      for (i = 0; i < minx; i++)
+        for (j = 0; j < miny; j++)
+          bro.gene(i, j, (mask[i * miny + j] ? dad.gene(i, j) : mom.gene(i, j)));
     }
 
     nc = 2;
   }
-  else if(c1 || c2){
-    GA2DBinaryStringGenome &sis = (c1 ? 
-				   DYN_CAST(GA2DBinaryStringGenome&, *c1) : 
-				   DYN_CAST(GA2DBinaryStringGenome&, *c2));
+  else if (c1 || c2)
+  {
+    GA2DBinaryStringGenome &sis = (c1 ? DYN_CAST(GA2DBinaryStringGenome &, *c1) : DYN_CAST(GA2DBinaryStringGenome &, *c2));
 
-    if(mom.width() == dad.width() && mom.height() == dad.height() &&
-       sis.width() == mom.width() && sis.height() == mom.height()){
-      for(i=sis.width()-1; i>=0; i--)
-	for(j=sis.height()-1; j>=0; j--)
-	  sis.gene(i,j, (GARandomBit() ? mom.gene(i,j) : dad.gene(i,j)));
+    if (mom.width() == dad.width() && mom.height() == dad.height() &&
+        sis.width() == mom.width() && sis.height() == mom.height())
+    {
+      for (i = sis.width() - 1; i >= 0; i--)
+        for (j = sis.height() - 1; j >= 0; j--)
+          sis.gene(i, j, (GARandomBit() ? mom.gene(i, j) : dad.gene(i, j)));
     }
-    else{
+    else
+    {
       int minx = GAMin(mom.width(), dad.width());
       int miny = GAMin(mom.height(), dad.height());
       minx = GAMin(sis.width(), minx);
       miny = GAMin(sis.height(), miny);
-      for(i=0; i<minx; i++)
-	for(j=0; j<miny; j++)
-	  sis.gene(i,j, (GARandomBit() ? mom.gene(i,j) : dad.gene(i,j)));
+      for (i = 0; i < minx; i++)
+        for (j = 0; j < miny; j++)
+          sis.gene(i, j, (GARandomBit() ? mom.gene(i, j) : dad.gene(i, j)));
     }
 
     nc = 1;
@@ -512,48 +543,52 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
   return nc;
 }
 
-
 //   When we do single point crossover on resizable 2D genomes we can either
 // clip or pad to make the mismatching geometries work out.  Either way, both
-// children end up with the same dimensions (the children have the same 
+// children end up with the same dimensions (the children have the same
 // dimensions as each other, not the same as if they were clipped/padded).
 //   When we pad, the extra space is filled with random bits.  This
 // implementation does only clipping, no padding!
-int
-GA2DBinaryStringGenome::
-OnePointCrossover(const GAGenome& p1, const GAGenome& p2, 
-		  GAGenome* c1, GAGenome* c2){
-  const GA2DBinaryStringGenome &mom=
-    DYN_CAST(const GA2DBinaryStringGenome &, p1);
-  const GA2DBinaryStringGenome &dad=
-    DYN_CAST(const GA2DBinaryStringGenome &, p2);
+int GA2DBinaryStringGenome::
+    OnePointCrossover(const GAGenome &p1, const GAGenome &p2,
+                      GAGenome *c1, GAGenome *c2)
+{
+  const GA2DBinaryStringGenome &mom =
+      DYN_CAST(const GA2DBinaryStringGenome &, p1);
+  const GA2DBinaryStringGenome &dad =
+      DYN_CAST(const GA2DBinaryStringGenome &, p2);
 
-  int nc=0;
+  int nc = 0;
   unsigned int momsitex, momlenx, momsitey, momleny;
   unsigned int dadsitex, dadlenx, dadsitey, dadleny;
   unsigned int sitex, lenx, sitey, leny;
 
-  if(c1 && c2){
-    GA2DBinaryStringGenome &sis=DYN_CAST(GA2DBinaryStringGenome &, *c1);
-    GA2DBinaryStringGenome &bro=DYN_CAST(GA2DBinaryStringGenome &, *c2);
+  if (c1 && c2)
+  {
+    GA2DBinaryStringGenome &sis = DYN_CAST(GA2DBinaryStringGenome &, *c1);
+    GA2DBinaryStringGenome &bro = DYN_CAST(GA2DBinaryStringGenome &, *c2);
 
-    if(sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE &&
-       bro.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE){
-      if(mom.width() != dad.width() || 
-	 sis.width() != bro.width() || 
-	 sis.width() != mom.width()){
-	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
-	return nc;
+    if (sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE &&
+        bro.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE)
+    {
+      if (mom.width() != dad.width() ||
+          sis.width() != bro.width() ||
+          sis.width() != mom.width())
+      {
+        GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
+        return nc;
       }
       sitex = momsitex = dadsitex = GARandomInt(0, mom.width());
       lenx = momlenx = dadlenx = mom.width() - momsitex;
     }
-    else if(sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE ||
-	    bro.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE){
+    else if (sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE ||
+             bro.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE)
+    {
       GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameBehavReqd);
       return nc;
     }
-    else{
+    else
+    {
       momsitex = GARandomInt(0, mom.width());
       dadsitex = GARandomInt(0, dad.width());
       momlenx = mom.width() - momsitex;
@@ -562,23 +597,27 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       lenx = GAMin(momlenx, dadlenx);
     }
 
-    if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE &&
-       bro.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
-      if(mom.height() != dad.height() || 
-	 sis.height() != bro.height() || 
-	 sis.height() != mom.height()){
-	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
-	return nc;
+    if (sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE &&
+        bro.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE)
+    {
+      if (mom.height() != dad.height() ||
+          sis.height() != bro.height() ||
+          sis.height() != mom.height())
+      {
+        GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
+        return nc;
       }
       sitey = momsitey = dadsitey = GARandomInt(0, mom.height());
       leny = momleny = dadleny = mom.height() - momsitey;
     }
-    else if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE ||
-	    bro.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
+    else if (sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE ||
+             bro.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE)
+    {
       GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameBehavReqd);
       return nc;
     }
-    else{
+    else
+    {
       momsitey = GARandomInt(0, mom.height());
       dadsitey = GARandomInt(0, dad.height());
       momleny = mom.height() - momsitey;
@@ -587,35 +626,37 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       leny = GAMin(momleny, dadleny);
     }
 
-    sis.resize(sitex+lenx, sitey+leny);
-    bro.resize(sitex+lenx, sitey+leny);
+    sis.resize(sitex + lenx, sitey + leny);
+    bro.resize(sitex + lenx, sitey + leny);
 
-    sis.copy(mom, 0, 0, momsitex-sitex, momsitey-sitey, sitex, sitey);
-    sis.copy(dad, sitex, 0, dadsitex, dadsitey-sitey, lenx, sitey);
-    sis.copy(dad, 0, sitey, dadsitex-sitex, dadsitey, sitex, leny);
+    sis.copy(mom, 0, 0, momsitex - sitex, momsitey - sitey, sitex, sitey);
+    sis.copy(dad, sitex, 0, dadsitex, dadsitey - sitey, lenx, sitey);
+    sis.copy(dad, 0, sitey, dadsitex - sitex, dadsitey, sitex, leny);
     sis.copy(mom, sitex, sitey, momsitex, momsitey, lenx, leny);
 
-    bro.copy(dad, 0, 0, dadsitex-sitex, dadsitey-sitey, sitex, sitey);
-    bro.copy(mom, sitex, 0, momsitex, momsitey-sitey, lenx, sitey);
-    bro.copy(mom, 0, sitey, momsitex-sitex, momsitey, sitex, leny);
+    bro.copy(dad, 0, 0, dadsitex - sitex, dadsitey - sitey, sitex, sitey);
+    bro.copy(mom, sitex, 0, momsitex, momsitey - sitey, lenx, sitey);
+    bro.copy(mom, 0, sitey, momsitex - sitex, momsitey, sitex, leny);
     bro.copy(dad, sitex, sitey, dadsitex, dadsitey, lenx, leny);
 
     nc = 2;
   }
-  else if(c1 || c2){
-    GA2DBinaryStringGenome &sis = (c1 ?
-				   DYN_CAST(GA2DBinaryStringGenome&, *c1) :
-				   DYN_CAST(GA2DBinaryStringGenome&, *c2));
+  else if (c1 || c2)
+  {
+    GA2DBinaryStringGenome &sis = (c1 ? DYN_CAST(GA2DBinaryStringGenome &, *c1) : DYN_CAST(GA2DBinaryStringGenome &, *c2));
 
-    if(sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE){
-      if(mom.width() != dad.width() || sis.width() != mom.width()){
-	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
-	return nc;
+    if (sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE)
+    {
+      if (mom.width() != dad.width() || sis.width() != mom.width())
+      {
+        GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
+        return nc;
       }
       sitex = momsitex = dadsitex = GARandomInt(0, mom.width());
       lenx = momlenx = dadlenx = mom.width() - momsitex;
     }
-    else{
+    else
+    {
       momsitex = GARandomInt(0, mom.width());
       dadsitex = GARandomInt(0, dad.width());
       momlenx = mom.width() - momsitex;
@@ -624,15 +665,18 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       lenx = GAMin(momlenx, dadlenx);
     }
 
-    if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
-      if(mom.height() != dad.height() || sis.height() != mom.height()){
-	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
-	return nc;
+    if (sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE)
+    {
+      if (mom.height() != dad.height() || sis.height() != mom.height())
+      {
+        GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
+        return nc;
       }
       sitey = momsitey = dadsitey = GARandomInt(0, mom.height());
       leny = momleny = dadleny = mom.height() - momsitey;
     }
-    else{
+    else
+    {
       momsitey = GARandomInt(0, mom.height());
       dadsitey = GARandomInt(0, dad.height());
       momleny = mom.height() - momsitey;
@@ -640,19 +684,21 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitey = GAMin(momsitey, dadsitey);
       leny = GAMin(momleny, dadleny);
     }
-    
-    sis.resize(sitex+lenx, sitey+leny);
-    
-    if(GARandomBit()){
-      sis.copy(mom, 0, 0, momsitex-sitex, momsitey-sitey, sitex, sitey);
-      sis.copy(dad, sitex, 0, dadsitex, dadsitey-sitey, lenx, sitey);
-      sis.copy(dad, 0, sitey, dadsitex-sitex, dadsitey, sitex, leny);
+
+    sis.resize(sitex + lenx, sitey + leny);
+
+    if (GARandomBit())
+    {
+      sis.copy(mom, 0, 0, momsitex - sitex, momsitey - sitey, sitex, sitey);
+      sis.copy(dad, sitex, 0, dadsitex, dadsitey - sitey, lenx, sitey);
+      sis.copy(dad, 0, sitey, dadsitex - sitex, dadsitey, sitex, leny);
       sis.copy(mom, sitex, sitey, momsitex, momsitey, lenx, leny);
     }
-    else{
-      sis.copy(dad, 0, 0, dadsitex-sitex, dadsitey-sitey, sitex, sitey);
-      sis.copy(mom, sitex, 0, momsitex, momsitey-sitey, lenx, sitey);
-      sis.copy(mom, 0, sitey, momsitex-sitex, momsitey, sitex, leny);
+    else
+    {
+      sis.copy(dad, 0, 0, dadsitex - sitex, dadsitey - sitey, sitex, sitey);
+      sis.copy(mom, sitex, 0, momsitex, momsitey - sitey, lenx, sitey);
+      sis.copy(mom, 0, sitey, momsitex - sitex, momsitey, sitex, leny);
       sis.copy(dad, sitex, sitey, dadsitex, dadsitey, lenx, leny);
     }
 
@@ -662,85 +708,93 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
   return nc;
 }
 
+int GA2DBinaryStringGenome::
+    EvenOddCrossover(const GAGenome &p1, const GAGenome &p2,
+                     GAGenome *c1, GAGenome *c2)
+{
+  const GA2DBinaryStringGenome &mom =
+      DYN_CAST(const GA2DBinaryStringGenome &, p1);
+  const GA2DBinaryStringGenome &dad =
+      DYN_CAST(const GA2DBinaryStringGenome &, p2);
 
+  int nc = 0;
+  int i, j;
 
-int
-GA2DBinaryStringGenome::
-EvenOddCrossover(const GAGenome& p1, const GAGenome& p2, 
-		 GAGenome* c1, GAGenome* c2){
-  const GA2DBinaryStringGenome &mom=
-    DYN_CAST(const GA2DBinaryStringGenome &, p1);
-  const GA2DBinaryStringGenome &dad=
-    DYN_CAST(const GA2DBinaryStringGenome &, p2);
+  if (c1 && c2)
+  {
+    GA2DBinaryStringGenome &sis = DYN_CAST(GA2DBinaryStringGenome &, *c1);
+    GA2DBinaryStringGenome &bro = DYN_CAST(GA2DBinaryStringGenome &, *c2);
 
-  int nc=0;
-  int i,j;
-
-  if(c1 && c2){
-    GA2DBinaryStringGenome &sis=DYN_CAST(GA2DBinaryStringGenome &, *c1);
-    GA2DBinaryStringGenome &bro=DYN_CAST(GA2DBinaryStringGenome &, *c2);
-    
-    if(sis.width() == bro.width() && sis.height() == bro.height() &&
-       mom.width() == dad.width() && mom.height() == dad.height() &&
-       sis.width() == mom.width() && sis.height() == mom.height()){
-      int count=0;
-      for(i=sis.width()-1; i>=0; i--){
-	for(j=sis.height()-1; j>=0; j--){
-	  if(count%2 == 0){
-	    sis.gene(i,j, mom.gene(i,j));
-	    bro.gene(i,j, dad.gene(i,j));
-	  }
-	  else{
-	    sis.gene(i,j, dad.gene(i,j));
-	    bro.gene(i,j, mom.gene(i,j));
-	  }
-	  count++;
-	}
+    if (sis.width() == bro.width() && sis.height() == bro.height() &&
+        mom.width() == dad.width() && mom.height() == dad.height() &&
+        sis.width() == mom.width() && sis.height() == mom.height())
+    {
+      int count = 0;
+      for (i = sis.width() - 1; i >= 0; i--)
+      {
+        for (j = sis.height() - 1; j >= 0; j--)
+        {
+          if (count % 2 == 0)
+          {
+            sis.gene(i, j, mom.gene(i, j));
+            bro.gene(i, j, dad.gene(i, j));
+          }
+          else
+          {
+            sis.gene(i, j, dad.gene(i, j));
+            bro.gene(i, j, mom.gene(i, j));
+          }
+          count++;
+        }
       }
     }
-    else{
+    else
+    {
       int count;
       int minx = GAMin(mom.width(), dad.width());
       int miny = GAMin(mom.height(), dad.height());
       count = 0;
       minx = GAMin(sis.width(), minx);
       miny = GAMin(sis.height(), miny);
-      for(i=0; i<minx; i++)
-	for(j=0; j<miny; j++)
-	  sis.gene(i,j, (((count++)%2 == 0) ? mom.gene(i,j):dad.gene(i,j)));
+      for (i = 0; i < minx; i++)
+        for (j = 0; j < miny; j++)
+          sis.gene(i, j, (((count++) % 2 == 0) ? mom.gene(i, j) : dad.gene(i, j)));
       count = 0;
       minx = GAMin(bro.width(), minx);
       miny = GAMin(bro.height(), miny);
-      for(i=0; i<minx; i++)
-	for(j=0; j<miny; j++)
-	  bro.gene(i,j, (((count++)%2 == 0) ? dad.gene(i,j):mom.gene(i,j)));
+      for (i = 0; i < minx; i++)
+        for (j = 0; j < miny; j++)
+          bro.gene(i, j, (((count++) % 2 == 0) ? dad.gene(i, j) : mom.gene(i, j)));
     }
 
     nc = 2;
   }
-  else if(c1 || c2){
-    GA2DBinaryStringGenome &sis = (c1 ? 
-				   DYN_CAST(GA2DBinaryStringGenome&, *c1) :
-				   DYN_CAST(GA2DBinaryStringGenome&, *c2));
-    
-    if(mom.width() == dad.width() && mom.height() == dad.height() &&
-       sis.width() == mom.width() && sis.height() == mom.height()){
-      int count=0;
-      for(i=sis.width()-1; i>=0; i--){
-	for(j=sis.height()-1; j>=0; j--){
-	  sis.gene(i,j, ((count%2 == 0) ? mom.gene(i,j) : dad.gene(i,j)));
-	  count++;
-	}
+  else if (c1 || c2)
+  {
+    GA2DBinaryStringGenome &sis = (c1 ? DYN_CAST(GA2DBinaryStringGenome &, *c1) : DYN_CAST(GA2DBinaryStringGenome &, *c2));
+
+    if (mom.width() == dad.width() && mom.height() == dad.height() &&
+        sis.width() == mom.width() && sis.height() == mom.height())
+    {
+      int count = 0;
+      for (i = sis.width() - 1; i >= 0; i--)
+      {
+        for (j = sis.height() - 1; j >= 0; j--)
+        {
+          sis.gene(i, j, ((count % 2 == 0) ? mom.gene(i, j) : dad.gene(i, j)));
+          count++;
+        }
       }
     }
-    else{
+    else
+    {
       int minx = GAMin(mom.width(), dad.width());
       int miny = GAMin(mom.height(), dad.height());
       minx = GAMin(sis.width(), minx);
       miny = GAMin(sis.height(), miny);
-      for(i=minx-1; i>=0; i--)
-	for(j=miny-1; j>=0; j--)
-	  sis.gene(i,j, (((i*miny+j)%2 == 0) ? mom.gene(i,j) : dad.gene(i,j)));
+      for (i = minx - 1; i >= 0; i--)
+        for (j = miny - 1; j >= 0; j--)
+          sis.gene(i, j, (((i * miny + j) % 2 == 0) ? mom.gene(i, j) : dad.gene(i, j)));
     }
 
     nc = 1;

--- a/CPFA/source/ga-mpi/GA3DArrayGenome.C
+++ b/CPFA/source/ga-mpi/GA3DArrayGenome.C
@@ -27,13 +27,13 @@ GA3DArrayGenome<T>::className() const {return "GA3DArrayGenome";}
 template <class T> int
 GA3DArrayGenome<T>::classID() const {return GAID::ArrayGenome3D;}
 
-template <class T> 
+template <class T>
 GA3DArrayGenome<T>::
 GA3DArrayGenome(unsigned int w, unsigned int h, unsigned int d,
 		GAGenome::Evaluator f,
 		void * u) :
 GAArray<T>(w*h*d),
-GAGenome(DEFAULT_3DARRAY_INITIALIZER, 
+GAGenome(DEFAULT_3DARRAY_INITIALIZER,
 	 DEFAULT_3DARRAY_MUTATOR,
 	 DEFAULT_3DARRAY_COMPARATOR)
 {
@@ -44,7 +44,7 @@ GAGenome(DEFAULT_3DARRAY_INITIALIZER,
 }
 
 
-template <class T> 
+template <class T>
 GA3DArrayGenome<T>::
 GA3DArrayGenome(const GA3DArrayGenome<T> & orig) :
 GAArray<T>(orig.sz), GAGenome(){
@@ -78,7 +78,7 @@ GA3DArrayGenome<T>::clone(GAGenome::CloneMethod flag) const {
   }
   else{
     cpy->GAGenome::copy(*this);
-    cpy->minX = minX; cpy->minY = minY; cpy->minZ = minZ; 
+    cpy->minX = minX; cpy->minY = minY; cpy->minZ = minZ;
     cpy->maxX = maxX; cpy->maxY = maxY; cpy->maxZ = maxZ;
   }
   return cpy;
@@ -145,7 +145,7 @@ GA3DArrayGenome<T>::resize(int w, int h, int d)
 
   GAArray<T>::size(w*h*d);
 
-  if(w > STA_CAST(int,nx) && h > STA_CAST(int,ny)){ 
+  if(w > STA_CAST(int,nx) && h > STA_CAST(int,ny)){
     int z=GAMin(STA_CAST(int,nz),d);
     for(int k=z-1; k>=0; k--)
       for(int j=ny-1; j>=0; j--)
@@ -179,7 +179,7 @@ GA3DArrayGenome<T>::read(STD_ISTREAM &) {
 
 
 template <class T> int
-GA3DArrayGenome<T>::write(STD_OSTREAM & os) const 
+GA3DArrayGenome<T>::write(STD_OSTREAM & os) const
 {
   for(unsigned int k=0; k<nz; k++){
     for(unsigned int j=0; j<ny; j++){
@@ -216,7 +216,7 @@ GA3DArrayGenome<T>::resizeBehaviour(GAGenome::Dimension which) const {
 
 template <class T> int
 GA3DArrayGenome<T>::
-resizeBehaviour(GAGenome::Dimension which, 
+resizeBehaviour(GAGenome::Dimension which,
 		unsigned int lower, unsigned int upper)
 {
   if(upper < lower){
@@ -278,7 +278,7 @@ copy(const GA3DArrayGenome<T> & orig,
 }
 
 
-template <class T> int 
+template <class T> int
 GA3DArrayGenome<T>::equal(const GAGenome & c) const
 {
   if(this == &c) return 1;
@@ -312,7 +312,7 @@ GA3DArrayAlleleGenome<T>::className() const {return "GA3DArrayAlleleGenome";}
 template <class T> int
 GA3DArrayAlleleGenome<T>::classID() const {return GAID::ArrayAlleleGenome3D;}
 
-template <class T> 
+template <class T>
 GA3DArrayAlleleGenome<T>::
 GA3DArrayAlleleGenome(unsigned int w, unsigned int h, unsigned int d,
 		      const GAAlleleSet<T> & s,
@@ -328,7 +328,7 @@ GA3DArrayGenome<T>(w,h,d,f,u) {
   this->crossover(GA3DArrayAlleleGenome<T>::DEFAULT_3DARRAY_ALLELE_CROSSOVER);
 }
 
-template <class T> 
+template <class T>
 GA3DArrayAlleleGenome<T>::
 GA3DArrayAlleleGenome(unsigned int w, unsigned int h, unsigned int d,
 		      const GAAlleleSetArray<T> & sa,
@@ -346,9 +346,9 @@ GA3DArrayGenome<T>(w,h,d, f, u) {
 }
 
 
-template <class T> 
+template <class T>
 GA3DArrayAlleleGenome<T>::
-GA3DArrayAlleleGenome(const GA3DArrayAlleleGenome<T> & orig) : 
+GA3DArrayAlleleGenome(const GA3DArrayAlleleGenome<T> & orig) :
 GA3DArrayGenome<T>(orig.nx, orig.ny, orig.nz) {
   naset = 0;
   aset = (GAAlleleSet<T>*)0;
@@ -368,10 +368,10 @@ GA3DArrayAlleleGenome<T>::clone(GAGenome::CloneMethod) const {
 }
 
 
-template <class T> void 
+template <class T> void
 GA3DArrayAlleleGenome<T>::copy(const GAGenome& orig){
   if(&orig == this) return;
-  const GA3DArrayAlleleGenome<T>* c = 
+  const GA3DArrayAlleleGenome<T>* c =
     DYN_CAST(const GA3DArrayAlleleGenome<T>*, &orig);
   if(c) {
     GA3DArrayGenome<T>::copy(*c);
@@ -414,7 +414,7 @@ GA3DArrayAlleleGenome<T>::resize(int w, int h, int d){
     for(int k=z-1; k>=0; k--)
       for(int j=this->ny-1; j>=0; j--)
 	for(unsigned int i=oldx; i<this->nx; i++)
-	  this->a[k*this->ny*this->nx+j*this->nx+i] = 
+	  this->a[k*this->ny*this->nx+j*this->nx+i] =
 	    aset[(k*this->ny*this->nx+j*this->nx+i) % naset].allele();
   }
   else if(this->ny > oldy){
@@ -463,7 +463,7 @@ GA3DArrayAlleleGenome<T>::equal(const GAGenome & c) const {
    Operator definitions
 ---------------------------------------------------------------------------- */
 // this does not handle genomes with multiple allele sets!
-template <class ARRAY_TYPE> void 
+template <class ARRAY_TYPE> void
 GA3DArrayAlleleGenome<ARRAY_TYPE>::UniformInitializer(GAGenome & c)
 {
   GA3DArrayAlleleGenome<ARRAY_TYPE> &child=
@@ -476,12 +476,12 @@ GA3DArrayAlleleGenome<ARRAY_TYPE>::UniformInitializer(GAGenome & c)
 }
 
 
-template <class ARRAY_TYPE> int 
+template <class ARRAY_TYPE> int
 GA3DArrayAlleleGenome<ARRAY_TYPE>::FlipMutator(GAGenome & c, float pmut)
 {
   GA3DArrayAlleleGenome<ARRAY_TYPE> &child=
     DYN_CAST(GA3DArrayAlleleGenome<ARRAY_TYPE> &, c);
-  register int n, m, d, i, j, k;
+  int n, m, d, i, j, k;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.size());
@@ -512,11 +512,11 @@ GA3DArrayAlleleGenome<ARRAY_TYPE>::FlipMutator(GAGenome & c, float pmut)
 }
 
 
-template <class ARRAY_TYPE> int 
+template <class ARRAY_TYPE> int
 GA3DArrayGenome<ARRAY_TYPE>::SwapMutator(GAGenome & c, float pmut)
 {
   GA3DArrayGenome<ARRAY_TYPE> &child=DYN_CAST(GA3DArrayGenome<ARRAY_TYPE>&, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.size());
@@ -568,7 +568,7 @@ ElementComparator(const GAGenome& a, const GAGenome& b)
 
 
 
-// Make sure our bitmask is big enough, generate a mask, then use it to 
+// Make sure our bitmask is big enough, generate a mask, then use it to
 // extract the information from each parent to stuff the two children.
 // We don't deallocate any space for the masks under the assumption that we'll
 // have to use them again in the future.
@@ -680,12 +680,12 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
 //   This is designed only for genomes that are the same length.  If the child
 // is not the same length as the parent, or if the children are not the same
 // size, we don't do the crossover.
-//   In the interest of speed we do not do any checks for size.  Do not use 
+//   In the interest of speed we do not do any checks for size.  Do not use
 // this crossover method when the parents and children may be different sizes.
 // It might break!
 template <class T> int
 GA3DArrayGenome<T>::
-EvenOddCrossover(const GAGenome& p1, const GAGenome& p2, 
+EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
 GAGenome* c1, GAGenome* c2){
   const GA3DArrayGenome<T> &mom=DYN_CAST(const GA3DArrayGenome<T> &, p1);
   const GA3DArrayGenome<T> &dad=DYN_CAST(const GA3DArrayGenome<T> &, p2);
@@ -696,7 +696,7 @@ GAGenome* c1, GAGenome* c2){
   if(c1 && c2){
     GA3DArrayGenome<T> &sis=DYN_CAST(GA3DArrayGenome<T> &, *c1);
     GA3DArrayGenome<T> &bro=DYN_CAST(GA3DArrayGenome<T> &, *c2);
-    
+
     if(sis.width() == bro.width() && sis.height() == bro.height() &&
        sis.depth() == bro.depth() &&
        mom.width() == dad.width() && mom.height() == dad.height() &&
@@ -806,8 +806,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE){
-      if(mom.width() != dad.width() || 
-	 sis.width() != bro.width() || 
+      if(mom.width() != dad.width() ||
+	 sis.width() != bro.width() ||
 	 sis.width() != mom.width()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -828,11 +828,11 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitex = GAMin(momsitex, dadsitex);
       lenx = GAMin(momlenx, dadlenx);
     }
-    
+
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
-      if(mom.height() != dad.height() || 
-	 sis.height() != bro.height() || 
+      if(mom.height() != dad.height() ||
+	 sis.height() != bro.height() ||
 	 sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -856,8 +856,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE){
-      if(mom.depth() != dad.depth() || 
-	 sis.depth() != bro.depth() || 
+      if(mom.depth() != dad.depth() ||
+	 sis.depth() != bro.depth() ||
 	 sis.depth() != mom.depth()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -882,8 +882,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
     sis.resize(sitex+lenx, sitey+leny, sitez+lenz);
     bro.resize(sitex+lenx, sitey+leny, sitez+lenz);
 
-    sis.copy(mom, 
-	     0, 0, 0, 
+    sis.copy(mom,
+	     0, 0, 0,
 	     momsitex-sitex, momsitey-sitey, momsitez-sitez,
 	     sitex, sitey, sitez);
     sis.copy(dad,
@@ -898,8 +898,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	     sitex, sitey, 0,
 	     momsitex, momsitey, momsitez-sitez,
 	     lenx, leny, sitez);
-    sis.copy(dad, 
-	     0, 0, sitez, 
+    sis.copy(dad,
+	     0, 0, sitez,
 	     dadsitex-sitex, dadsitey-sitey, dadsitez,
 	     sitex, sitey, lenz);
     sis.copy(mom,
@@ -914,9 +914,9 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	     sitex, sitey, sitez,
 	     dadsitex, dadsitey, dadsitez,
 	     lenx, leny, lenz);
-    
-    bro.copy(dad, 
-	     0, 0, 0, 
+
+    bro.copy(dad,
+	     0, 0, 0,
 	     dadsitex-sitex, dadsitey-sitey, dadsitez-sitez,
 	     sitex, sitey, sitez);
     bro.copy(mom,
@@ -931,8 +931,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	     sitex, sitey, 0,
 	     dadsitex, dadsitey, dadsitez-sitez,
 	     lenx, leny, sitez);
-    bro.copy(mom, 
-	     0, 0, sitez, 
+    bro.copy(mom,
+	     0, 0, sitez,
 	     momsitex-sitex, momsitey-sitey, momsitez,
 	     sitex, sitey, lenz);
     bro.copy(dad,
@@ -969,7 +969,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitex = GAMin(momsitex, dadsitex);
       lenx = GAMin(momlenx, dadlenx);
     }
-    
+
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
       if(mom.height() != dad.height() || sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -1003,12 +1003,12 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitez = GAMin(momsitez, dadsitez);
       lenz = GAMin(momlenz, dadlenz);
     }
-    
+
     sis.resize(sitex+lenx, sitey+leny, sitez+lenz);
-    
+
     if(GARandomBit()){
-      sis.copy(mom, 
-	       0, 0, 0, 
+      sis.copy(mom,
+	       0, 0, 0,
 	       momsitex-sitex, momsitey-sitey, momsitez-sitez,
 	       sitex, sitey, sitez);
       sis.copy(dad,
@@ -1023,8 +1023,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	       sitex, sitey, 0,
 	       momsitex, momsitey, momsitez-sitez,
 	       lenx, leny, sitez);
-      sis.copy(dad, 
-	       0, 0, sitez, 
+      sis.copy(dad,
+	       0, 0, sitez,
 	       dadsitex-sitex, dadsitey-sitey, dadsitez,
 	       sitex, sitey, lenz);
       sis.copy(mom,
@@ -1041,8 +1041,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	       lenx, leny, lenz);
     }
     else{
-      sis.copy(dad, 
-	       0, 0, 0, 
+      sis.copy(dad,
+	       0, 0, 0,
 	       dadsitex-sitex, dadsitey-sitey, dadsitez-sitez,
 	       sitex, sitey, sitez);
       sis.copy(mom,
@@ -1057,8 +1057,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	       sitex, sitey, 0,
 	       dadsitex, dadsitey, dadsitez-sitez,
 	       lenx, leny, sitez);
-      sis.copy(mom, 
-	       0, 0, sitez, 
+      sis.copy(mom,
+	       0, 0, sitez,
 	       momsitex-sitex, momsitey-sitey, momsitez,
 	       sitex, sitey, lenz);
       sis.copy(dad,

--- a/CPFA/source/ga-mpi/GA3DBinStrGenome.C
+++ b/CPFA/source/ga-mpi/GA3DBinStrGenome.C
@@ -17,199 +17,240 @@
 #include <ga-mpi/GA3DBinStrGenome.h>
 #include <ga-mpi/GAMask.h>
 
-
 /* ----------------------------------------------------------------------------
    Genome class definition
 ---------------------------------------------------------------------------- */
 GA3DBinaryStringGenome::
-GA3DBinaryStringGenome(unsigned int width,
-		       unsigned int height,
-		       unsigned int depth,
-		       GAGenome::Evaluator f, void * u) :
-GABinaryString(width*height*depth),
-GAGenome(DEFAULT_3DBINSTR_INITIALIZER,
-	 DEFAULT_3DBINSTR_MUTATOR,
-	 DEFAULT_3DBINSTR_COMPARATOR) {
+    GA3DBinaryStringGenome(unsigned int width,
+                           unsigned int height,
+                           unsigned int depth,
+                           GAGenome::Evaluator f, void *u) : GABinaryString(width * height * depth),
+                                                             GAGenome(DEFAULT_3DBINSTR_INITIALIZER,
+                                                                      DEFAULT_3DBINSTR_MUTATOR,
+                                                                      DEFAULT_3DBINSTR_COMPARATOR)
+{
   evaluator(f);
   userData(u);
   crossover(DEFAULT_3DBINSTR_CROSSOVER);
-  nx=minX=maxX=0; ny=minY=maxY=0; nz=minZ=maxZ=0;
+  nx = minX = maxX = 0;
+  ny = minY = maxY = 0;
+  nz = minZ = maxZ = 0;
   resize(width, height, depth);
 }
 
-
 GA3DBinaryStringGenome::
-GA3DBinaryStringGenome(const GA3DBinaryStringGenome & orig) :
-GABinaryString(orig.GABinaryString::size()),
-GAGenome() {
-  nx=minX=maxX=0; ny=minY=maxY=0; nz=minZ=maxZ=0;
+    GA3DBinaryStringGenome(const GA3DBinaryStringGenome &orig) : GABinaryString(orig.GABinaryString::size()),
+                                                                 GAGenome()
+{
+  nx = minX = maxX = 0;
+  ny = minY = maxY = 0;
+  nz = minZ = maxZ = 0;
   GA3DBinaryStringGenome::copy(orig);
 }
 
-GA3DBinaryStringGenome::~GA3DBinaryStringGenome() { }
+GA3DBinaryStringGenome::~GA3DBinaryStringGenome() {}
 
 GAGenome *
-GA3DBinaryStringGenome::clone(GAGenome::CloneMethod flag) const {
-  GA3DBinaryStringGenome *cpy = new GA3DBinaryStringGenome(nx,ny,nz);
-  if(flag == CONTENTS){
+GA3DBinaryStringGenome::clone(GAGenome::CloneMethod flag) const
+{
+  GA3DBinaryStringGenome *cpy = new GA3DBinaryStringGenome(nx, ny, nz);
+  if (flag == CONTENTS)
+  {
     cpy->copy(*this);
   }
-  else{
+  else
+  {
     cpy->GAGenome::copy(*this);
-    cpy->minX = minX; cpy->minY = minY; cpy->minZ = minZ; 
-    cpy->maxX = maxX; cpy->maxY = maxY; cpy->maxZ = maxZ;
+    cpy->minX = minX;
+    cpy->minY = minY;
+    cpy->minZ = minZ;
+    cpy->maxX = maxX;
+    cpy->maxY = maxY;
+    cpy->maxZ = maxZ;
   }
   return cpy;
 }
 
-void
-GA3DBinaryStringGenome::copy(const GAGenome & orig)
+void GA3DBinaryStringGenome::copy(const GAGenome &orig)
 {
-  if(&orig == this) return;
-  const GA3DBinaryStringGenome* c = 
-    DYN_CAST(const GA3DBinaryStringGenome*, &orig);
-  if(c) {
+  if (&orig == this)
+    return;
+  const GA3DBinaryStringGenome *c =
+      DYN_CAST(const GA3DBinaryStringGenome *, &orig);
+  if (c)
+  {
     GAGenome::copy(*c);
     GABinaryString::copy(*c);
-    nx = c->nx; ny = c->ny; nz = c->nz;
-    minX = c->minX; minY = c->minY; minZ = c->minZ;
-    maxX = c->maxX; maxY = c->maxY; maxZ = c->maxZ;
+    nx = c->nx;
+    ny = c->ny;
+    nz = c->nz;
+    minX = c->minX;
+    minY = c->minY;
+    minZ = c->minZ;
+    maxX = c->maxX;
+    maxY = c->maxY;
+    maxZ = c->maxZ;
   }
 }
 
-
-int
-GA3DBinaryStringGenome::resize(int w, int h, int d)
+int GA3DBinaryStringGenome::resize(int w, int h, int d)
 {
-  if(w == STA_CAST(int,nx) && h == STA_CAST(int,ny) && d == STA_CAST(int,nz))
+  if (w == STA_CAST(int, nx) && h == STA_CAST(int, ny) && d == STA_CAST(int, nz))
     return sz;
 
-  if(w == GAGenome::ANY_SIZE)
+  if (w == GAGenome::ANY_SIZE)
     w = GARandomInt(minX, maxX);
-  else if(w < 0)
-    w = nx;		// do nothing
-  else if(minX == maxX)
-    minX=maxX = w;
-  else{
-    if(w < STA_CAST(int,minX)) w=minX;
-    if(w > STA_CAST(int,maxX)) w=maxX;
+  else if (w < 0)
+    w = nx; // do nothing
+  else if (minX == maxX)
+    minX = maxX = w;
+  else
+  {
+    if (w < STA_CAST(int, minX))
+      w = minX;
+    if (w > STA_CAST(int, maxX))
+      w = maxX;
   }
 
-  if(h == GAGenome::ANY_SIZE)
+  if (h == GAGenome::ANY_SIZE)
     h = GARandomInt(minY, maxY);
-  else if(h < 0)
-    h = ny;		// do nothing
-  else if(minY == maxY)
-    minY=maxY = h;
-  else{
-    if(h < STA_CAST(int,minY)) h=minY;
-    if(h > STA_CAST(int,maxY)) h=maxY;
+  else if (h < 0)
+    h = ny; // do nothing
+  else if (minY == maxY)
+    minY = maxY = h;
+  else
+  {
+    if (h < STA_CAST(int, minY))
+      h = minY;
+    if (h > STA_CAST(int, maxY))
+      h = maxY;
   }
 
-  if(d == GAGenome::ANY_SIZE)
+  if (d == GAGenome::ANY_SIZE)
     d = GARandomInt(minZ, maxZ);
-  else if(d < 0)
-    d = nz;		// do nothing
-  else if(minZ == maxZ)
-    minZ=maxZ = d;
-  else{
-    if(d < STA_CAST(int,minZ)) d=minZ;
-    if(d > STA_CAST(int,maxZ)) d=maxZ;
+  else if (d < 0)
+    d = nz; // do nothing
+  else if (minZ == maxZ)
+    minZ = maxZ = d;
+  else
+  {
+    if (d < STA_CAST(int, minZ))
+      d = minZ;
+    if (d > STA_CAST(int, maxZ))
+      d = maxZ;
   }
 
-  if(w < STA_CAST(int,nx) && h < STA_CAST(int,ny)){
-    int z=GAMin(STA_CAST(int,nz),d);
-    for(int k=0; k<z; k++)
-      for(int j=0; j<h; j++)
-	GABinaryString::move(k*h*w+j*w,k*ny*nx+j*nx,w);
+  if (w < STA_CAST(int, nx) && h < STA_CAST(int, ny))
+  {
+    int z = GAMin(STA_CAST(int, nz), d);
+    for (int k = 0; k < z; k++)
+      for (int j = 0; j < h; j++)
+        GABinaryString::move(k * h * w + j * w, k * ny * nx + j * nx, w);
   }
-  else if(w < STA_CAST(int,nx)){
-    int z=GAMin(STA_CAST(int,nz),d);
-    for(int k=0; k<z; k++)
-      for(int j=0; j<STA_CAST(int,ny); j++)
-	GABinaryString::move(k*ny*w+j*w,k*ny*nx+j*nx,w);
+  else if (w < STA_CAST(int, nx))
+  {
+    int z = GAMin(STA_CAST(int, nz), d);
+    for (int k = 0; k < z; k++)
+      for (int j = 0; j < STA_CAST(int, ny); j++)
+        GABinaryString::move(k * ny * w + j * w, k * ny * nx + j * nx, w);
   }
-  else if(h < STA_CAST(int,ny)){
-    int z=GAMin(STA_CAST(int,nz),d);
-    for(int k=0; k<z; k++)
-      for(int j=0; j<h; j++)
-	GABinaryString::move(k*h*nx+j*nx,k*ny*nx+j*nx,nx);
+  else if (h < STA_CAST(int, ny))
+  {
+    int z = GAMin(STA_CAST(int, nz), d);
+    for (int k = 0; k < z; k++)
+      for (int j = 0; j < h; j++)
+        GABinaryString::move(k * h * nx + j * nx, k * ny * nx + j * nx, nx);
   }
 
-  GABinaryString::resize(w*h*d);
+  GABinaryString::resize(w * h * d);
 
-  if(w > STA_CAST(int,nx) && h > STA_CAST(int,ny)){ // adjust the existing bits
-    int z=GAMin(STA_CAST(int,nz),d);
-    for(int k=z-1; k>=0; k--){
+  if (w > STA_CAST(int, nx) && h > STA_CAST(int, ny))
+  { // adjust the existing bits
+    int z = GAMin(STA_CAST(int, nz), d);
+    for (int k = z - 1; k >= 0; k--)
+    {
       int j;
-      for(j=ny-1; j>=0; j--){
-	GABinaryString::move(k*h*w+j*w,k*ny*nx+j*nx,nx);
-	for(int i=nx; i<w; i++)
-	  bit(k*h*w+j*w+i, GARandomBit());
+      for (j = ny - 1; j >= 0; j--)
+      {
+        GABinaryString::move(k * h * w + j * w, k * ny * nx + j * nx, nx);
+        for (int i = nx; i < w; i++)
+          bit(k * h * w + j * w + i, GARandomBit());
       }
-      for(j=ny; j<h; j++)
-	for(int i=0; i<w; i++)
-	  bit(k*h*w+j*w+i, GARandomBit());
+      for (j = ny; j < h; j++)
+        for (int i = 0; i < w; i++)
+          bit(k * h * w + j * w + i, GARandomBit());
     }
   }
-  else if(w > STA_CAST(int,nx)){
-    int z=GAMin(STA_CAST(int,nz),d);
-    for(int k=z-1; k>=0; k--){
-      for(int j=h-1; j>=0; j--){
-	GABinaryString::move(k*h*w+j*w,k*h*nx+j*nx,nx);
-	for(int i=nx; i<w; i++)
-	  bit(k*h*w+j*w+i, GARandomBit());
+  else if (w > STA_CAST(int, nx))
+  {
+    int z = GAMin(STA_CAST(int, nz), d);
+    for (int k = z - 1; k >= 0; k--)
+    {
+      for (int j = h - 1; j >= 0; j--)
+      {
+        GABinaryString::move(k * h * w + j * w, k * h * nx + j * nx, nx);
+        for (int i = nx; i < w; i++)
+          bit(k * h * w + j * w + i, GARandomBit());
       }
     }
   }
-  else if(h > STA_CAST(int,ny)){
-    int z=GAMin(STA_CAST(int,nz),d);
-    for(int k=z-1; k>=0; k--){
+  else if (h > STA_CAST(int, ny))
+  {
+    int z = GAMin(STA_CAST(int, nz), d);
+    for (int k = z - 1; k >= 0; k--)
+    {
       int j;
-      for(j=ny-1; j>=0; j--)
-	GABinaryString::move(k*h*w+j*w,k*ny*w+j*w,w);
-      for(j=ny; j<h; j++)
-	for(int i=0; i<w; i++)
-	  bit(k*h*w+j*w+i, GARandomBit());
+      for (j = ny - 1; j >= 0; j--)
+        GABinaryString::move(k * h * w + j * w, k * ny * w + j * w, w);
+      for (j = ny; j < h; j++)
+        for (int i = 0; i < w; i++)
+          bit(k * h * w + j * w + i, GARandomBit());
     }
   }
-  if(d > STA_CAST(int,nz)){		// change in depth is always new bits
-    for(int i=w*h*nz; i<w*h*d; i++)
+  if (d > STA_CAST(int, nz))
+  { // change in depth is always new bits
+    for (int i = w * h * nz; i < w * h * d; i++)
       bit(i, GARandomBit());
   }
 
-  nx = w; ny = h; nz = d;
+  nx = w;
+  ny = h;
+  nz = d;
   _evaluated = gaFalse;
   return sz;
 }
 
 #ifdef GALIB_USE_STREAMS
-int
-GA3DBinaryStringGenome::read(STD_ISTREAM & is)
+int GA3DBinaryStringGenome::read(STD_ISTREAM &is)
 {
   static char c;
-  unsigned int i=0, j=0, k=0;
-  while(!is.fail() && !is.eof() && k < nz) {
+  unsigned int i = 0, j = 0, k = 0;
+  while (!is.fail() && !is.eof() && k < nz)
+  {
     is >> c;
-    if(isdigit(c)){
+    if (isdigit(c))
+    {
       gene(i++, j, k, ((c == '0') ? 0 : 1));
-      if(i >= nx){
-	i=0;
-	j++;
+      if (i >= nx)
+      {
+        i = 0;
+        j++;
       }
-      if(j >= ny){
-	j=0;
-	k++;
+      if (j >= ny)
+      {
+        j = 0;
+        k++;
       }
     }
   }
 
   _evaluated = gaFalse;
 
-  if(is.eof() && 
-     ((k < nz) ||		// didn't get some lines
-      (j < ny && j != 0) ||	// didn't get some lines
-      (i < nx && i != 0))){	// didn't get some lines
+  if (is.eof() &&
+      ((k < nz) ||           // didn't get some lines
+       (j < ny && j != 0) || // didn't get some lines
+       (i < nx && i != 0)))
+  { // didn't get some lines
     GAErr(GA_LOC, className(), "read", gaErrUnexpectedEOF);
     is.clear(STD_IOS_BADBIT | is.rdstate());
     return 1;
@@ -218,16 +259,17 @@ GA3DBinaryStringGenome::read(STD_ISTREAM & is)
   return 0;
 }
 
-
-// Dump the bits to the stream with a newline at the end of each row and 
+// Dump the bits to the stream with a newline at the end of each row and
 // another at the end of each layer.  No newline at the end of the block.
-int
-GA3DBinaryStringGenome::write(STD_OSTREAM & os) const 
+int GA3DBinaryStringGenome::write(STD_OSTREAM &os) const
 {
-  for(unsigned int k=0; k<nz; k++){
-    for(unsigned int j=0; j<ny; j++){
-      for(unsigned int i=0; i<nx; i++){
-	os << gene(i,j,k);
+  for (unsigned int k = 0; k < nz; k++)
+  {
+    for (unsigned int j = 0; j < ny; j++)
+    {
+      for (unsigned int i = 0; i < nx; i++)
+      {
+        os << gene(i, j, k);
       }
       os << "\n";
     }
@@ -237,52 +279,69 @@ GA3DBinaryStringGenome::write(STD_OSTREAM & os) const
 }
 #endif
 
-
-int
-GA3DBinaryStringGenome::resizeBehaviour(GAGenome::Dimension which) const {
+int GA3DBinaryStringGenome::resizeBehaviour(GAGenome::Dimension which) const
+{
   int val = 0;
-  if(which == WIDTH) {
-    if(maxX == minX) val = FIXED_SIZE;
-    else val = maxX;
+  if (which == WIDTH)
+  {
+    if (maxX == minX)
+      val = FIXED_SIZE;
+    else
+      val = maxX;
   }
-  else if(which == HEIGHT) {
-    if(maxY == minY) val = FIXED_SIZE;
-    else val = maxY;
+  else if (which == HEIGHT)
+  {
+    if (maxY == minY)
+      val = FIXED_SIZE;
+    else
+      val = maxY;
   }
-  else if(which == DEPTH) {
-    if(maxZ == minZ) val = FIXED_SIZE;
-    else val = maxZ;
+  else if (which == DEPTH)
+  {
+    if (maxZ == minZ)
+      val = FIXED_SIZE;
+    else
+      val = maxZ;
   }
   return val;
 }
 
-
-int
-GA3DBinaryStringGenome::
-resizeBehaviour(Dimension which, unsigned int lower, unsigned int upper)
+int GA3DBinaryStringGenome::
+    resizeBehaviour(Dimension which, unsigned int lower, unsigned int upper)
 {
-  if(upper < lower){
+  if (upper < lower)
+  {
     GAErr(GA_LOC, className(), "resizeBehaviour", gaErrBadResizeBehaviour);
     return resizeBehaviour(which);
   }
 
-  switch(which){
+  switch (which)
+  {
   case WIDTH:
-    minX = lower; maxX = upper;
-    if(nx > upper) resize(upper,ny,nz);
-    if(nx < lower) resize(lower,ny,nz);
+    minX = lower;
+    maxX = upper;
+    if (nx > upper)
+      resize(upper, ny, nz);
+    if (nx < lower)
+      resize(lower, ny, nz);
     break;
 
   case HEIGHT:
-    minY = lower; maxY = upper;
-    if(ny > upper) resize(nx,upper,nz);
-    if(ny < lower) resize(nx,lower,nz);
+    minY = lower;
+    maxY = upper;
+    if (ny > upper)
+      resize(nx, upper, nz);
+    if (ny < lower)
+      resize(nx, lower, nz);
     break;
 
   case DEPTH:
-    minZ = lower; maxZ = upper;
-    if(nz > upper) resize(nx,ny,upper);
-    if(nz < lower) resize(nx,ny,lower);
+    minZ = lower;
+    maxZ = upper;
+    if (nz > upper)
+      resize(nx, ny, upper);
+    if (nz < lower)
+      resize(nx, ny, lower);
     break;
 
   default:
@@ -292,163 +351,172 @@ resizeBehaviour(Dimension which, unsigned int lower, unsigned int upper)
   return resizeBehaviour(which);
 }
 
-
-void
-GA3DBinaryStringGenome::
-copy(const GA3DBinaryStringGenome & orig,
-     unsigned int r, unsigned int s, unsigned int t,
-     unsigned int x, unsigned int y, unsigned int z,
-     unsigned int w, unsigned int h, unsigned int d)
+void GA3DBinaryStringGenome::
+    copy(const GA3DBinaryStringGenome &orig,
+         unsigned int r, unsigned int s, unsigned int t,
+         unsigned int x, unsigned int y, unsigned int z,
+         unsigned int w, unsigned int h, unsigned int d)
 {
-  if(w == 0 || x >= orig.nx || r >= nx ||
-     h == 0 || y >= orig.ny || s >= ny ||
-     d == 0 || z >= orig.nz || t >= nz) return;
-  if(x + w > orig.nx) w = orig.nx - x;
-  if(y + h > orig.ny) h = orig.ny - y;
-  if(z + d > orig.nz) d = orig.nz - z;
-  if(r + w > nx) w = nx - r;
-  if(s + h > ny) h = ny - s;
-  if(t + d > nz) d = nz - t;
+  if (w == 0 || x >= orig.nx || r >= nx ||
+      h == 0 || y >= orig.ny || s >= ny ||
+      d == 0 || z >= orig.nz || t >= nz)
+    return;
+  if (x + w > orig.nx)
+    w = orig.nx - x;
+  if (y + h > orig.ny)
+    h = orig.ny - y;
+  if (z + d > orig.nz)
+    d = orig.nz - z;
+  if (r + w > nx)
+    w = nx - r;
+  if (s + h > ny)
+    h = ny - s;
+  if (t + d > nz)
+    d = nz - t;
 
-  for(unsigned int k=0; k<d; k++)
-    for(unsigned int j=0; j<h; j++)
+  for (unsigned int k = 0; k < d; k++)
+    for (unsigned int j = 0; j < h; j++)
       GABinaryString::copy(orig,
-			   (t+k)*ny*nx + (s+j)*nx + r,
-			   (z+k)*orig.ny*orig.nx + (y+j)*orig.nx + x, w);
+                           (t + k) * ny * nx + (s + j) * nx + r,
+                           (z + k) * orig.ny * orig.nx + (y + j) * orig.nx + x, w);
   _evaluated = gaFalse;
 }
 
-
-void
-GA3DBinaryStringGenome::
-set(unsigned int x, unsigned int y, unsigned int z,
-    unsigned int w, unsigned int h, unsigned int d)
+void GA3DBinaryStringGenome::
+    set(unsigned int x, unsigned int y, unsigned int z,
+        unsigned int w, unsigned int h, unsigned int d)
 {
-  if(x + w > nx) w = nx - x;
-  if(y + h > ny) h = ny - y;
-  if(z + d > nz) d = nz - z;
+  if (x + w > nx)
+    w = nx - x;
+  if (y + h > ny)
+    h = ny - y;
+  if (z + d > nz)
+    d = nz - z;
 
-  for(unsigned int k=0; k<d; k++)
-    for(unsigned int j=0; j<h; j++)
-      GABinaryString::set((z+k)*ny*nx + (y+j)*nx + x, w);
+  for (unsigned int k = 0; k < d; k++)
+    for (unsigned int j = 0; j < h; j++)
+      GABinaryString::set((z + k) * ny * nx + (y + j) * nx + x, w);
   _evaluated = gaFalse;
 }
 
-
-void
-GA3DBinaryStringGenome::
-unset(unsigned int x, unsigned int y, unsigned int z,
-      unsigned int w, unsigned int h, unsigned int d)
+void GA3DBinaryStringGenome::
+    unset(unsigned int x, unsigned int y, unsigned int z,
+          unsigned int w, unsigned int h, unsigned int d)
 {
-  if(x + w > nx) w = nx - x;
-  if(y + h > ny) h = ny - y;
-  if(z + d > nz) d = nz - z;
+  if (x + w > nx)
+    w = nx - x;
+  if (y + h > ny)
+    h = ny - y;
+  if (z + d > nz)
+    d = nz - z;
 
-  for(unsigned int k=0; k<d; k++)
-    for(unsigned int j=0; j<h; j++)
-      GABinaryString::unset((z+k)*ny*nx + (y+j)*nx + x, w);
+  for (unsigned int k = 0; k < d; k++)
+    for (unsigned int j = 0; j < h; j++)
+      GABinaryString::unset((z + k) * ny * nx + (y + j) * nx + x, w);
   _evaluated = gaFalse;
 }
 
-
-void
-GA3DBinaryStringGenome::
-randomize(unsigned int x, unsigned int y, unsigned int z,
-	  unsigned int w, unsigned int h, unsigned int d)
+void GA3DBinaryStringGenome::
+    randomize(unsigned int x, unsigned int y, unsigned int z,
+              unsigned int w, unsigned int h, unsigned int d)
 {
-  if(x + w > nx) w = nx - x;
-  if(y + h > ny) h = ny - y;
-  if(z + d > nz) d = nz - z;
+  if (x + w > nx)
+    w = nx - x;
+  if (y + h > ny)
+    h = ny - y;
+  if (z + d > nz)
+    d = nz - z;
 
-  for(unsigned int k=0; k<d; k++)
-    for(unsigned int j=0; j<h; j++)
-      GABinaryString::randomize((z+k)*ny*nx + (y+j)*nx + x, w);
+  for (unsigned int k = 0; k < d; k++)
+    for (unsigned int j = 0; j < h; j++)
+      GABinaryString::randomize((z + k) * ny * nx + (y + j) * nx + x, w);
   _evaluated = gaFalse;
 }
 
-
-void
-GA3DBinaryStringGenome::
-move(unsigned int x, unsigned int y, unsigned int z,
-     unsigned int srcx, unsigned int srcy, unsigned int srcz,
-     unsigned int w, unsigned int h, unsigned int d)
+void GA3DBinaryStringGenome::
+    move(unsigned int x, unsigned int y, unsigned int z,
+         unsigned int srcx, unsigned int srcy, unsigned int srcz,
+         unsigned int w, unsigned int h, unsigned int d)
 {
-  if(srcx + w > nx) w = nx - srcx;
-  if(x + w > nx) w = nx - x;
-  if(srcy + h > ny) h = ny - srcy;
-  if(y + h > ny) h = ny - y;
-  if(srcz + d > nz) d = nz - srcz;
-  if(z + d > nz) d = nz - z;
+  if (srcx + w > nx)
+    w = nx - srcx;
+  if (x + w > nx)
+    w = nx - x;
+  if (srcy + h > ny)
+    h = ny - srcy;
+  if (y + h > ny)
+    h = ny - y;
+  if (srcz + d > nz)
+    d = nz - srcz;
+  if (z + d > nz)
+    d = nz - z;
 
-  if(srcz<z){
-    if(srcy<y){
-      for(int k=d-1; k>=0; k--)
-	for(int j=h-1; j>=0; j--)
-	  GABinaryString::move((z+k)*ny*nx + (y+j)*nx + x,
-			       (srcz+k)*ny*nx + (srcy+j)*nx + srcx, w);
+  if (srcz < z)
+  {
+    if (srcy < y)
+    {
+      for (int k = d - 1; k >= 0; k--)
+        for (int j = h - 1; j >= 0; j--)
+          GABinaryString::move((z + k) * ny * nx + (y + j) * nx + x,
+                               (srcz + k) * ny * nx + (srcy + j) * nx + srcx, w);
     }
-    else{
-      for(int k=d-1; k>=0; k--)
-	for(unsigned int j=0; j<h; j++)
-	  GABinaryString::move((z+k)*ny*nx + (y+j)*nx + x,
-			       (srcz+k)*ny*nx + (srcy+j)*nx + srcx, w);
-    }
-  }
-  else{
-    if(srcy<y){
-      for(unsigned int k=0; k<d; k++)
-	for(int j=h-1; j>=0; j--)
-	  GABinaryString::move((z+k)*ny*nx + (y+j)*nx + x,
-			       (srcz+k)*ny*nx + (srcy+j)*nx + srcx, w);
-    }
-    else{
-      for(unsigned int k=0; k<d; k++)
-	for(unsigned int j=0; j<h; j++)
-	  GABinaryString::move((z+k)*ny*nx + (y+j)*nx + x,
-			       (srcz+k)*ny*nx + (srcy+j)*nx + srcx, w);
+    else
+    {
+      for (int k = d - 1; k >= 0; k--)
+        for (unsigned int j = 0; j < h; j++)
+          GABinaryString::move((z + k) * ny * nx + (y + j) * nx + x,
+                               (srcz + k) * ny * nx + (srcy + j) * nx + srcx, w);
     }
   }
+  else
+  {
+    if (srcy < y)
+    {
+      for (unsigned int k = 0; k < d; k++)
+        for (int j = h - 1; j >= 0; j--)
+          GABinaryString::move((z + k) * ny * nx + (y + j) * nx + x,
+                               (srcz + k) * ny * nx + (srcy + j) * nx + srcx, w);
+    }
+    else
+    {
+      for (unsigned int k = 0; k < d; k++)
+        for (unsigned int j = 0; j < h; j++)
+          GABinaryString::move((z + k) * ny * nx + (y + j) * nx + x,
+                               (srcz + k) * ny * nx + (srcy + j) * nx + srcx, w);
+    }
+  }
   _evaluated = gaFalse;
 }
 
-
-int
-GA3DBinaryStringGenome::
-equal(const GA3DBinaryStringGenome& orig,
-      unsigned int x, unsigned int y, unsigned int z,
-      unsigned int srcx, unsigned int srcy, unsigned int srcz,
-      unsigned int w, unsigned int h, unsigned int d) const
+int GA3DBinaryStringGenome::
+    equal(const GA3DBinaryStringGenome &orig,
+          unsigned int x, unsigned int y, unsigned int z,
+          unsigned int srcx, unsigned int srcy, unsigned int srcz,
+          unsigned int w, unsigned int h, unsigned int d) const
 {
   unsigned int eq = 0;
-  for(unsigned int k=0; k<d; k++)
-    for(unsigned int j=0; j<h; j++)
+  for (unsigned int k = 0; k < d; k++)
+    for (unsigned int j = 0; j < h; j++)
       eq += GABinaryString::equal(orig,
-				  (z+k)*ny*nx + (y+j)*nx + x,
-				  (srcz+k)*ny*nx + (srcy+j)*nx + srcx, 
-				  w);
-  return eq==d*h ? 1 : 0;
+                                  (z + k) * ny * nx + (y + j) * nx + x,
+                                  (srcz + k) * ny * nx + (srcy + j) * nx + srcx,
+                                  w);
+  return eq == d * h ? 1 : 0;
 }
 
-
-int 
-GA3DBinaryStringGenome::equal(const GAGenome & c) const
+int GA3DBinaryStringGenome::equal(const GAGenome &c) const
 {
-  if(this == &c) return 1;
-  const GA3DBinaryStringGenome& b = DYN_CAST(const GA3DBinaryStringGenome&, c);
-  if(nx != b.nx || ny != b.ny || nz != b.nz) return 0;
-  int val=0;
-  for(unsigned int k=0; k<nz && val==0; k++)
-    for(unsigned int j=0; j<ny && val==0; j++)
-      val = GABinaryString::equal(b,k*ny*nx,k*ny*nx,nx) ? 0 : 1;
-  return(val ? 0 : 1);
+  if (this == &c)
+    return 1;
+  const GA3DBinaryStringGenome &b = DYN_CAST(const GA3DBinaryStringGenome &, c);
+  if (nx != b.nx || ny != b.ny || nz != b.nz)
+    return 0;
+  int val = 0;
+  for (unsigned int k = 0; k < nz && val == 0; k++)
+    for (unsigned int j = 0; j < ny && val == 0; j++)
+      val = GABinaryString::equal(b, k * ny * nx, k * ny * nx, nx) ? 0 : 1;
+  return (val ? 0 : 1);
 }
-
-
-
-
-
-
-
 
 /* ----------------------------------------------------------------------------
    Operators
@@ -459,140 +527,139 @@ GA3DBinaryStringGenome::equal(const GAGenome & c) const
 (ie depth loops before a single height increment, height loops before a single
 width increment)
 ---------------------------------------------------------------------------- */
-void 
-GA3DBinaryStringGenome::UniformInitializer(GAGenome & c)
+void GA3DBinaryStringGenome::UniformInitializer(GAGenome &c)
 {
-  GA3DBinaryStringGenome &child=DYN_CAST(GA3DBinaryStringGenome &, c);
-  child.resize(GAGenome::ANY_SIZE,GAGenome::ANY_SIZE,GAGenome::ANY_SIZE);
-  for(int i=child.width()-1; i>=0; i--)
-    for(int j=child.height()-1; j>=0; j--)
-      for(int k=child.depth()-1; k>=0; k--)
-	child.gene(i,j,k, GARandomBit());
+  GA3DBinaryStringGenome &child = DYN_CAST(GA3DBinaryStringGenome &, c);
+  child.resize(GAGenome::ANY_SIZE, GAGenome::ANY_SIZE, GAGenome::ANY_SIZE);
+  for (int i = child.width() - 1; i >= 0; i--)
+    for (int j = child.height() - 1; j >= 0; j--)
+      for (int k = child.depth() - 1; k >= 0; k--)
+        child.gene(i, j, k, GARandomBit());
 }
 
-
-void 
-GA3DBinaryStringGenome::UnsetInitializer(GAGenome & c)
+void GA3DBinaryStringGenome::UnsetInitializer(GAGenome &c)
 {
-  GA3DBinaryStringGenome &child=DYN_CAST(GA3DBinaryStringGenome &, c);
-  child.resize(GAGenome::ANY_SIZE,GAGenome::ANY_SIZE,GAGenome::ANY_SIZE);
+  GA3DBinaryStringGenome &child = DYN_CAST(GA3DBinaryStringGenome &, c);
+  child.resize(GAGenome::ANY_SIZE, GAGenome::ANY_SIZE, GAGenome::ANY_SIZE);
   child.unset(0, 0, 0, child.width(), child.height(), child.depth());
 }
 
-
-void 
-GA3DBinaryStringGenome::SetInitializer(GAGenome & c)
+void GA3DBinaryStringGenome::SetInitializer(GAGenome &c)
 {
-  GA3DBinaryStringGenome &child=DYN_CAST(GA3DBinaryStringGenome &, c);
-  child.resize(GAGenome::ANY_SIZE,GAGenome::ANY_SIZE,GAGenome::ANY_SIZE);
+  GA3DBinaryStringGenome &child = DYN_CAST(GA3DBinaryStringGenome &, c);
+  child.resize(GAGenome::ANY_SIZE, GAGenome::ANY_SIZE, GAGenome::ANY_SIZE);
   child.set(0, 0, 0, child.width(), child.height(), child.depth());
 }
 
-
-int 
-GA3DBinaryStringGenome::FlipMutator(GAGenome & c, float pmut)
+int GA3DBinaryStringGenome::FlipMutator(GAGenome &c, float pmut)
 {
-  GA3DBinaryStringGenome &child=DYN_CAST(GA3DBinaryStringGenome &, c);
-  register int n, m, i, j, k, d;
-  if(pmut <= 0.0) return(0);
+  GA3DBinaryStringGenome &child = DYN_CAST(GA3DBinaryStringGenome &, c);
+  int n, m, i, j, k, d;
+  if (pmut <= 0.0)
+    return (0);
 
-  float nMut = pmut * STA_CAST(float,child.size());
-  if(nMut < 1.0){		// we have to do a flip test on each bit
+  float nMut = pmut * STA_CAST(float, child.size());
+  if (nMut < 1.0)
+  { // we have to do a flip test on each bit
     nMut = 0;
-    for(i=child.width()-1; i>=0; i--){
-      for(j=child.height()-1; j>=0; j--){
-	for(k=child.depth()-1; k>=0; k--){
-	  if(GAFlipCoin(pmut)){
-	    child.gene(i, j, k, ((child.gene(i,j,k) == 0) ? 1 : 0));
-	    nMut++;
-	  }
-	}
+    for (i = child.width() - 1; i >= 0; i--)
+    {
+      for (j = child.height() - 1; j >= 0; j--)
+      {
+        for (k = child.depth() - 1; k >= 0; k--)
+        {
+          if (GAFlipCoin(pmut))
+          {
+            child.gene(i, j, k, ((child.gene(i, j, k) == 0) ? 1 : 0));
+            nMut++;
+          }
+        }
       }
     }
   }
-  else{				// only flip the number of bits we need to flip
-    for(n=0; n<nMut; n++){
-      m = GARandomInt(0, child.size()-1);
+  else
+  { // only flip the number of bits we need to flip
+    for (n = 0; n < nMut; n++)
+    {
+      m = GARandomInt(0, child.size() - 1);
       d = child.height() * child.depth();
       i = m / d;
       j = (m % d) / child.depth();
       k = (m % d) % child.depth();
-      child.gene(i, j, k, ((child.gene(i,j,k) == 0) ? 1 : 0));
+      child.gene(i, j, k, ((child.gene(i, j, k) == 0) ? 1 : 0));
     }
   }
-  return(STA_CAST(int,nMut));
+  return (STA_CAST(int, nMut));
 }
 
-
-float
-GA3DBinaryStringGenome::BitComparator(const GAGenome& a, const GAGenome& b){
-  const GA3DBinaryStringGenome &sis=DYN_CAST(const GA3DBinaryStringGenome&, a);
-  const GA3DBinaryStringGenome &bro=DYN_CAST(const GA3DBinaryStringGenome&, b);
-  if(sis.size() != bro.size()) return -1;
-  if(sis.size() == 0) return 0;
+float GA3DBinaryStringGenome::BitComparator(const GAGenome &a, const GAGenome &b)
+{
+  const GA3DBinaryStringGenome &sis = DYN_CAST(const GA3DBinaryStringGenome &, a);
+  const GA3DBinaryStringGenome &bro = DYN_CAST(const GA3DBinaryStringGenome &, b);
+  if (sis.size() != bro.size())
+    return -1;
+  if (sis.size() == 0)
+    return 0;
   float count = 0.0;
-  for(int i=sis.width()-1; i>=0; i--)
-    for(int j=sis.height()-1; j>=0; j--)
-      for(int k=sis.depth()-1; k>=0; k--)
-	count += ((sis.gene(i,j,k) == bro.gene(i,j,k)) ? 0 : 1);
-  return count/sis.size();
+  for (int i = sis.width() - 1; i >= 0; i--)
+    for (int j = sis.height() - 1; j >= 0; j--)
+      for (int k = sis.depth() - 1; k >= 0; k--)
+        count += ((sis.gene(i, j, k) == bro.gene(i, j, k)) ? 0 : 1);
+  return count / sis.size();
 }
 
-
-
-
-
-
-
-
-
-
-
-
-
-// Make sure our bitmask is big enough, generate a mask, then use it to 
+// Make sure our bitmask is big enough, generate a mask, then use it to
 // extract the information from each parent to stuff the two children.
 // We don't deallocate any space for the masks under the assumption that we'll
 // have to use them again in the future.
 //   For now we'll implement this only for fixed length genomes.  If you use
 // this crossover method on genomes of different sizes it might break!
-int
-GA3DBinaryStringGenome::
-UniformCrossover(const GAGenome& p1, const GAGenome& p2,
-		 GAGenome* c1, GAGenome* c2){
-  const GA3DBinaryStringGenome &mom=
-    DYN_CAST(const GA3DBinaryStringGenome &, p1);
-  const GA3DBinaryStringGenome &dad=
-    DYN_CAST(const GA3DBinaryStringGenome &, p2);
+int GA3DBinaryStringGenome::
+    UniformCrossover(const GAGenome &p1, const GAGenome &p2,
+                     GAGenome *c1, GAGenome *c2)
+{
+  const GA3DBinaryStringGenome &mom =
+      DYN_CAST(const GA3DBinaryStringGenome &, p1);
+  const GA3DBinaryStringGenome &dad =
+      DYN_CAST(const GA3DBinaryStringGenome &, p2);
 
-  int i,j,k, nc=0;;
+  int i, j, k, nc = 0;
+  ;
 
-  if(c1 && c2){
-    GA3DBinaryStringGenome &sis=DYN_CAST(GA3DBinaryStringGenome &, *c1);
-    GA3DBinaryStringGenome &bro=DYN_CAST(GA3DBinaryStringGenome &, *c2);
+  if (c1 && c2)
+  {
+    GA3DBinaryStringGenome &sis = DYN_CAST(GA3DBinaryStringGenome &, *c1);
+    GA3DBinaryStringGenome &bro = DYN_CAST(GA3DBinaryStringGenome &, *c2);
 
-    if(sis.width() == bro.width() && sis.height() == bro.height() &&
-       sis.depth() == bro.depth() &&
-       mom.width() == dad.width() && mom.height() == dad.height() &&
-       mom.depth() == dad.depth() &&
-       sis.width() == mom.width() && sis.height() == mom.height() &&
-       sis.depth() == mom.depth()){
-      for(i=sis.width()-1; i>=0; i--){
-	for(j=sis.height()-1; j>=0; j--){
-	  for(k=sis.depth()-1; k>=0; k--){
-	    if(GARandomBit()){
-	      sis.gene(i,j,k, mom.gene(i,j,k));
-	      bro.gene(i,j,k, dad.gene(i,j,k));
-	    }
-	    else{
-	      sis.gene(i,j,k, dad.gene(i,j,k));
-	      bro.gene(i,j,k, mom.gene(i,j,k));
-	    }
-	  }
-	}
+    if (sis.width() == bro.width() && sis.height() == bro.height() &&
+        sis.depth() == bro.depth() &&
+        mom.width() == dad.width() && mom.height() == dad.height() &&
+        mom.depth() == dad.depth() &&
+        sis.width() == mom.width() && sis.height() == mom.height() &&
+        sis.depth() == mom.depth())
+    {
+      for (i = sis.width() - 1; i >= 0; i--)
+      {
+        for (j = sis.height() - 1; j >= 0; j--)
+        {
+          for (k = sis.depth() - 1; k >= 0; k--)
+          {
+            if (GARandomBit())
+            {
+              sis.gene(i, j, k, mom.gene(i, j, k));
+              bro.gene(i, j, k, dad.gene(i, j, k));
+            }
+            else
+            {
+              sis.gene(i, j, k, dad.gene(i, j, k));
+              bro.gene(i, j, k, mom.gene(i, j, k));
+            }
+          }
+        }
       }
     }
-    else{
+    else
+    {
       GAMask mask;
       int maxx = GAMax(sis.width(), bro.width());
       int minx = GAMin(mom.width(), dad.width());
@@ -600,56 +667,55 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
       int miny = GAMin(mom.height(), dad.height());
       int maxz = GAMax(sis.depth(), bro.depth());
       int minz = GAMin(mom.depth(), dad.depth());
-      mask.size(maxx*maxy*maxz);
-      for(i=0; i<maxx; i++)
-	for(j=0; j<maxy; j++)
-	  for(k=0; k<maxz; k++)
-	    mask[i*maxy*maxz+j*maxz+k] = GARandomBit();
+      mask.size(maxx * maxy * maxz);
+      for (i = 0; i < maxx; i++)
+        for (j = 0; j < maxy; j++)
+          for (k = 0; k < maxz; k++)
+            mask[i * maxy * maxz + j * maxz + k] = GARandomBit();
       minx = GAMin(sis.width(), minx);
       miny = GAMin(sis.height(), miny);
       minz = GAMin(sis.depth(), minz);
-      for(i=minx-1; i>=0; i--)
-	for(j=miny-1; j>=0; j--)
-	  for(k=minz-1; k>=0; k--)
-	    sis.gene(i,j,k, (mask[i*miny*minz+j*minz+k] ?
-			     mom.gene(i,j,k) : dad.gene(i,j,k)));
+      for (i = minx - 1; i >= 0; i--)
+        for (j = miny - 1; j >= 0; j--)
+          for (k = minz - 1; k >= 0; k--)
+            sis.gene(i, j, k, (mask[i * miny * minz + j * minz + k] ? mom.gene(i, j, k) : dad.gene(i, j, k)));
       minx = GAMin(bro.width(), minx);
       miny = GAMin(bro.height(), miny);
       minz = GAMin(bro.depth(), minz);
-      for(i=minx-1; i>=0; i--)
-	for(j=miny-1; j>=0; j--)
-	  for(k=minz-1; k>=0; k--)
-	    bro.gene(i,j,k, (mask[i*miny*minz+j*minz+k] ?
-			     dad.gene(i,j,k) : mom.gene(i,j,k)));
+      for (i = minx - 1; i >= 0; i--)
+        for (j = miny - 1; j >= 0; j--)
+          for (k = minz - 1; k >= 0; k--)
+            bro.gene(i, j, k, (mask[i * miny * minz + j * minz + k] ? dad.gene(i, j, k) : mom.gene(i, j, k)));
     }
 
     nc = 2;
   }
-  else if(c1 || c2){
-    GA3DBinaryStringGenome &sis = (c1 ? 
-				   DYN_CAST(GA3DBinaryStringGenome&, *c1) : 
-				   DYN_CAST(GA3DBinaryStringGenome&, *c2));
-    
-    if(mom.width() == dad.width() && mom.height() == dad.height() &&
-       mom.depth() == dad.depth() &&
-       sis.width() == mom.width() && sis.height() == mom.height() &&
-       sis.depth() == mom.depth()){
-      for(i=sis.width()-1; i>=0; i--)
-	for(j=sis.height()-1; j>=0; j--)
-	  for(k=sis.depth()-1; k>=0; k--)
-	    sis.gene(i,j,k, (GARandomBit() ? mom.gene(i,j,k):dad.gene(i,j,k)));
+  else if (c1 || c2)
+  {
+    GA3DBinaryStringGenome &sis = (c1 ? DYN_CAST(GA3DBinaryStringGenome &, *c1) : DYN_CAST(GA3DBinaryStringGenome &, *c2));
+
+    if (mom.width() == dad.width() && mom.height() == dad.height() &&
+        mom.depth() == dad.depth() &&
+        sis.width() == mom.width() && sis.height() == mom.height() &&
+        sis.depth() == mom.depth())
+    {
+      for (i = sis.width() - 1; i >= 0; i--)
+        for (j = sis.height() - 1; j >= 0; j--)
+          for (k = sis.depth() - 1; k >= 0; k--)
+            sis.gene(i, j, k, (GARandomBit() ? mom.gene(i, j, k) : dad.gene(i, j, k)));
     }
-    else{
+    else
+    {
       int minx = GAMin(mom.width(), dad.width());
       int miny = GAMin(mom.height(), dad.height());
       int minz = GAMin(mom.depth(), dad.depth());
       minx = GAMin(sis.width(), minx);
       miny = GAMin(sis.height(), miny);
       minz = GAMin(sis.depth(), minz);
-      for(i=minx-1; i>=0; i--)
-	for(j=miny-1; j>=0; j--)
-	  for(k=minz-1; k>=0; k--)
-	    sis.gene(i,j,k, (GARandomBit() ? mom.gene(i,j,k):dad.gene(i,j,k)));
+      for (i = minx - 1; i >= 0; i--)
+        for (j = miny - 1; j >= 0; j--)
+          for (k = minz - 1; k >= 0; k--)
+            sis.gene(i, j, k, (GARandomBit() ? mom.gene(i, j, k) : dad.gene(i, j, k)));
     }
 
     nc = 1;
@@ -657,111 +723,118 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
 
   return nc;
 }
-
-
 
 // For even crossover we take the even bits from the mother (for the daughter)
 // and the odd bits from the father.  Just the opposite for the son.
 //   This is designed only for genomes that are the same length.  If the child
 // is not the same length as the parent, or if the children are not the same
 // size, we don't do the crossover.
-//   In the interest of speed we do not do any checks for size.  Do not use 
+//   In the interest of speed we do not do any checks for size.  Do not use
 // this crossover method when the parents and children may be different sizes.
 // It might break!
-int
-GA3DBinaryStringGenome::
-EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
-		 GAGenome* c1, GAGenome* c2){
-  const GA3DBinaryStringGenome &mom=
-    DYN_CAST(const GA3DBinaryStringGenome &, p1);
-  const GA3DBinaryStringGenome &dad=
-    DYN_CAST(const GA3DBinaryStringGenome &, p2);
+int GA3DBinaryStringGenome::
+    EvenOddCrossover(const GAGenome &p1, const GAGenome &p2,
+                     GAGenome *c1, GAGenome *c2)
+{
+  const GA3DBinaryStringGenome &mom =
+      DYN_CAST(const GA3DBinaryStringGenome &, p1);
+  const GA3DBinaryStringGenome &dad =
+      DYN_CAST(const GA3DBinaryStringGenome &, p2);
 
-  int nc=0;
-  int i,j,k;
+  int nc = 0;
+  int i, j, k;
 
-  if(c1 && c2){
-    GA3DBinaryStringGenome &sis=DYN_CAST(GA3DBinaryStringGenome &, *c1);
-    GA3DBinaryStringGenome &bro=DYN_CAST(GA3DBinaryStringGenome &, *c2);
+  if (c1 && c2)
+  {
+    GA3DBinaryStringGenome &sis = DYN_CAST(GA3DBinaryStringGenome &, *c1);
+    GA3DBinaryStringGenome &bro = DYN_CAST(GA3DBinaryStringGenome &, *c2);
 
-    if(sis.width() == bro.width() && sis.height() == bro.height() &&
-       sis.depth() == bro.depth() &&
-       mom.width() == dad.width() && mom.height() == dad.height() &&
-       mom.depth() == dad.depth() &&
-       sis.width() == mom.width() && sis.height() == mom.height() &&
-       sis.depth() == mom.depth()){
-      int count=0;
-      for(i=sis.width()-1; i>=0; i--){
-	for(j=sis.height()-1; j>=0; j--){
-	  for(k=sis.depth()-1; k>=0; k--){
-	    if(count%2 == 0){
-	      sis.gene(i,j,k, mom.gene(i,j,k));
-	      bro.gene(i,j,k, dad.gene(i,j,k));
-	    }
-	    else{
-	      sis.gene(i,j,k, dad.gene(i,j,k));
-	      bro.gene(i,j,k, mom.gene(i,j,k));
-	    }
-	    count++;
-	  }
-	}
+    if (sis.width() == bro.width() && sis.height() == bro.height() &&
+        sis.depth() == bro.depth() &&
+        mom.width() == dad.width() && mom.height() == dad.height() &&
+        mom.depth() == dad.depth() &&
+        sis.width() == mom.width() && sis.height() == mom.height() &&
+        sis.depth() == mom.depth())
+    {
+      int count = 0;
+      for (i = sis.width() - 1; i >= 0; i--)
+      {
+        for (j = sis.height() - 1; j >= 0; j--)
+        {
+          for (k = sis.depth() - 1; k >= 0; k--)
+          {
+            if (count % 2 == 0)
+            {
+              sis.gene(i, j, k, mom.gene(i, j, k));
+              bro.gene(i, j, k, dad.gene(i, j, k));
+            }
+            else
+            {
+              sis.gene(i, j, k, dad.gene(i, j, k));
+              bro.gene(i, j, k, mom.gene(i, j, k));
+            }
+            count++;
+          }
+        }
       }
     }
-    else{
+    else
+    {
       int minx = GAMin(mom.width(), dad.width());
       int miny = GAMin(mom.height(), dad.height());
       int minz = GAMin(mom.depth(), dad.depth());
       minx = GAMin(sis.width(), minx);
       miny = GAMin(sis.height(), miny);
       minz = GAMin(sis.depth(), minz);
-      for(i=minx-1; i>=0; i--)
-	for(j=miny-1; j>=0; j--)
-	  for(k=minz-1; k>=0; k--)
-	    sis.gene(i,j,k, (((i*miny*minz+j*minz+k)%2 == 0) ?
-			     mom.gene(i,j,k) : dad.gene(i,j,k)));
+      for (i = minx - 1; i >= 0; i--)
+        for (j = miny - 1; j >= 0; j--)
+          for (k = minz - 1; k >= 0; k--)
+            sis.gene(i, j, k, (((i * miny * minz + j * minz + k) % 2 == 0) ? mom.gene(i, j, k) : dad.gene(i, j, k)));
       minx = (bro.width() < minx) ? bro.width() : minx;
       miny = (bro.height() < miny) ? bro.height() : miny;
       minz = (bro.depth() < minz) ? bro.depth() : minz;
-      for(i=minx-1; i>=0; i--)
-	for(j=miny-1; j>=0; j--)
-	  for(k=minz-1; k>=0; k--)
-	    bro.gene(i,j,k, (((i*miny*minz+j*minz+k)%2 == 0) ?
-			     dad.gene(i,j,k) : mom.gene(i,j,k)));
+      for (i = minx - 1; i >= 0; i--)
+        for (j = miny - 1; j >= 0; j--)
+          for (k = minz - 1; k >= 0; k--)
+            bro.gene(i, j, k, (((i * miny * minz + j * minz + k) % 2 == 0) ? dad.gene(i, j, k) : mom.gene(i, j, k)));
     }
 
     nc = 2;
   }
-  else if(c1 || c2){
-    GA3DBinaryStringGenome &sis = (c1 ?
-				   DYN_CAST(GA3DBinaryStringGenome &, *c1) : 
-				   DYN_CAST(GA3DBinaryStringGenome &, *c2));
+  else if (c1 || c2)
+  {
+    GA3DBinaryStringGenome &sis = (c1 ? DYN_CAST(GA3DBinaryStringGenome &, *c1) : DYN_CAST(GA3DBinaryStringGenome &, *c2));
 
-    if(mom.width() == dad.width() && mom.height() == dad.height() &&
-       mom.depth() == dad.depth() &&
-       sis.width() == mom.width() && sis.height() == mom.height() &&
-       sis.depth() == mom.depth()){
-      int count=0;
-      for(i=sis.width()-1; i>=0; i--){
-	for(j=sis.height()-1; j>=0; j--){
-	  for(k=sis.depth()-1; k>=0; k--){
-	    sis.gene(i,j,k,((count%2 == 0) ? mom.gene(i,j,k):dad.gene(i,j,k)));
-	    count++;
-	  }
-	}
+    if (mom.width() == dad.width() && mom.height() == dad.height() &&
+        mom.depth() == dad.depth() &&
+        sis.width() == mom.width() && sis.height() == mom.height() &&
+        sis.depth() == mom.depth())
+    {
+      int count = 0;
+      for (i = sis.width() - 1; i >= 0; i--)
+      {
+        for (j = sis.height() - 1; j >= 0; j--)
+        {
+          for (k = sis.depth() - 1; k >= 0; k--)
+          {
+            sis.gene(i, j, k, ((count % 2 == 0) ? mom.gene(i, j, k) : dad.gene(i, j, k)));
+            count++;
+          }
+        }
       }
     }
-    else{
+    else
+    {
       int minx = GAMin(mom.width(), dad.width());
       int miny = GAMin(mom.height(), dad.height());
       int minz = GAMin(mom.depth(), dad.depth());
       minx = GAMin(sis.width(), minx);
       miny = GAMin(sis.height(), miny);
       minz = GAMin(sis.depth(), minz);
-      for(i=minx-1; i>=0; i--)
-	for(j=miny-1; j>=0; j--)
-	  for(k=minz-1; k>=0; k--)
-	    sis.gene(i,j, (((i*miny*minz+j*minz+k)%2 == 0) ?
-			   mom.gene(i,j,k) : dad.gene(i,j,k)));
+      for (i = minx - 1; i >= 0; i--)
+        for (j = miny - 1; j >= 0; j--)
+          for (k = minz - 1; k >= 0; k--)
+            sis.gene(i, j, (((i * miny * minz + j * minz + k) % 2 == 0) ? mom.gene(i, j, k) : dad.gene(i, j, k)));
     }
 
     nc = 1;
@@ -770,46 +843,50 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
   return nc;
 }
 
-
 // Pick a single point in the 3D block and grab alternating quadrants for each
-// child.  If the children are resizable, this crossover does clipping or 
+// child.  If the children are resizable, this crossover does clipping or
 // padding depending on the setting of the clip flag.  If we pad, we fill the
 // additional bits with random contents.
-int
-GA3DBinaryStringGenome::
-OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
-		  GAGenome* c1, GAGenome* c2){
-  const GA3DBinaryStringGenome &mom=
-    DYN_CAST(const GA3DBinaryStringGenome &, p1);
-  const GA3DBinaryStringGenome &dad=
-    DYN_CAST(const GA3DBinaryStringGenome &, p2);
+int GA3DBinaryStringGenome::
+    OnePointCrossover(const GAGenome &p1, const GAGenome &p2,
+                      GAGenome *c1, GAGenome *c2)
+{
+  const GA3DBinaryStringGenome &mom =
+      DYN_CAST(const GA3DBinaryStringGenome &, p1);
+  const GA3DBinaryStringGenome &dad =
+      DYN_CAST(const GA3DBinaryStringGenome &, p2);
 
-  int nc=0;
+  int nc = 0;
   unsigned int momsitex, momlenx, momsitey, momleny, momsitez, momlenz;
   unsigned int dadsitex, dadlenx, dadsitey, dadleny, dadsitez, dadlenz;
   unsigned int sitex, lenx, sitey, leny, sitez, lenz;
 
-  if(c1 && c2){
-    GA3DBinaryStringGenome &sis=DYN_CAST(GA3DBinaryStringGenome &, *c1);
-    GA3DBinaryStringGenome &bro=DYN_CAST(GA3DBinaryStringGenome &, *c2);
+  if (c1 && c2)
+  {
+    GA3DBinaryStringGenome &sis = DYN_CAST(GA3DBinaryStringGenome &, *c1);
+    GA3DBinaryStringGenome &bro = DYN_CAST(GA3DBinaryStringGenome &, *c2);
 
-    if(sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE &&
-       bro.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE){
-      if(mom.width() != dad.width() || 
-	 sis.width() != bro.width() || 
-	 sis.width() != mom.width()){
-	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
-	return nc;
+    if (sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE &&
+        bro.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE)
+    {
+      if (mom.width() != dad.width() ||
+          sis.width() != bro.width() ||
+          sis.width() != mom.width())
+      {
+        GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
+        return nc;
       }
       sitex = momsitex = dadsitex = GARandomInt(0, mom.width());
       lenx = momlenx = dadlenx = mom.width() - momsitex;
     }
-    else if(sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE ||
-	    bro.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE){
+    else if (sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE ||
+             bro.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE)
+    {
       GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameBehavReqd);
       return nc;
     }
-    else{
+    else
+    {
       momsitex = GARandomInt(0, mom.width());
       dadsitex = GARandomInt(0, dad.width());
       momlenx = mom.width() - momsitex;
@@ -817,24 +894,28 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitex = GAMin(momsitex, dadsitex);
       lenx = GAMin(momlenx, dadlenx);
     }
-    
-    if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE &&
-       bro.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
-      if(mom.height() != dad.height() || 
-	 sis.height() != bro.height() || 
-	 sis.height() != mom.height()){
-	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
-	return nc;
+
+    if (sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE &&
+        bro.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE)
+    {
+      if (mom.height() != dad.height() ||
+          sis.height() != bro.height() ||
+          sis.height() != mom.height())
+      {
+        GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
+        return nc;
       }
       sitey = momsitey = dadsitey = GARandomInt(0, mom.height());
       leny = momleny = dadleny = mom.height() - momsitey;
     }
-    else if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE ||
-	    bro.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
+    else if (sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE ||
+             bro.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE)
+    {
       GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameBehavReqd);
       return nc;
     }
-    else{
+    else
+    {
       momsitey = GARandomInt(0, mom.height());
       dadsitey = GARandomInt(0, dad.height());
       momleny = mom.height() - momsitey;
@@ -842,24 +923,28 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitey = GAMin(momsitey, dadsitey);
       leny = GAMin(momleny, dadleny);
     }
-    
-    if(sis.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE &&
-       bro.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE){
-      if(mom.depth() != dad.depth() || 
-	 sis.depth() != bro.depth() || 
-	 sis.depth() != mom.depth()){
-	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
-	return nc;
+
+    if (sis.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE &&
+        bro.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE)
+    {
+      if (mom.depth() != dad.depth() ||
+          sis.depth() != bro.depth() ||
+          sis.depth() != mom.depth())
+      {
+        GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
+        return nc;
       }
       sitez = momsitez = dadsitez = GARandomInt(0, mom.depth());
       lenz = momlenz = dadlenz = mom.depth() - momsitez;
     }
-    else if(sis.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE ||
-	    bro.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE){
+    else if (sis.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE ||
+             bro.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE)
+    {
       GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameBehavReqd);
       return nc;
     }
-    else{
+    else
+    {
       momsitez = GARandomInt(0, mom.depth());
       dadsitez = GARandomInt(0, dad.depth());
       momlenz = mom.depth() - momsitez;
@@ -868,91 +953,93 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       lenz = GAMin(momlenz, dadlenz);
     }
 
-    sis.resize(sitex+lenx, sitey+leny, sitez+lenz);
-    bro.resize(sitex+lenx, sitey+leny, sitez+lenz);
+    sis.resize(sitex + lenx, sitey + leny, sitez + lenz);
+    bro.resize(sitex + lenx, sitey + leny, sitez + lenz);
 
-    sis.copy(mom, 
-	     0, 0, 0, 
-	     momsitex-sitex, momsitey-sitey, momsitez-sitez,
-	     sitex, sitey, sitez);
-    sis.copy(dad,
-	     sitex, 0, 0,
-	     dadsitex, dadsitey-sitey, dadsitez-sitez,
-	     lenx, sitey, sitez);
-    sis.copy(dad,
-	     0, sitey, 0,
-	     dadsitex-sitex, dadsitey, dadsitez-sitez,
-	     sitex, leny, sitez);
     sis.copy(mom,
-	     sitex, sitey, 0,
-	     momsitex, momsitey, momsitez-sitez,
-	     lenx, leny, sitez);
-    sis.copy(dad, 
-	     0, 0, sitez, 
-	     dadsitex-sitex, dadsitey-sitey, dadsitez,
-	     sitex, sitey, lenz);
-    sis.copy(mom,
-	     sitex, 0, sitez,
-	     momsitex, momsitey-sitey, momsitez,
-	     lenx, sitey, lenz);
-    sis.copy(mom,
-	     0, sitey, sitez,
-	     momsitex-sitex, momsitey, momsitez,
-	     sitex, leny, lenz);
+             0, 0, 0,
+             momsitex - sitex, momsitey - sitey, momsitez - sitez,
+             sitex, sitey, sitez);
     sis.copy(dad,
-	     sitex, sitey, sitez,
-	     dadsitex, dadsitey, dadsitez,
-	     lenx, leny, lenz);
-    
-    bro.copy(dad, 
-	     0, 0, 0, 
-	     dadsitex-sitex, dadsitey-sitey, dadsitez-sitez,
-	     sitex, sitey, sitez);
-    bro.copy(mom,
-	     sitex, 0, 0,
-	     momsitex, momsitey-sitey, momsitez-sitez,
-	     lenx, sitey, sitez);
-    bro.copy(mom,
-	     0, sitey, 0,
-	     momsitex-sitex, momsitey, momsitez-sitez,
-	     sitex, leny, sitez);
+             sitex, 0, 0,
+             dadsitex, dadsitey - sitey, dadsitez - sitez,
+             lenx, sitey, sitez);
+    sis.copy(dad,
+             0, sitey, 0,
+             dadsitex - sitex, dadsitey, dadsitez - sitez,
+             sitex, leny, sitez);
+    sis.copy(mom,
+             sitex, sitey, 0,
+             momsitex, momsitey, momsitez - sitez,
+             lenx, leny, sitez);
+    sis.copy(dad,
+             0, 0, sitez,
+             dadsitex - sitex, dadsitey - sitey, dadsitez,
+             sitex, sitey, lenz);
+    sis.copy(mom,
+             sitex, 0, sitez,
+             momsitex, momsitey - sitey, momsitez,
+             lenx, sitey, lenz);
+    sis.copy(mom,
+             0, sitey, sitez,
+             momsitex - sitex, momsitey, momsitez,
+             sitex, leny, lenz);
+    sis.copy(dad,
+             sitex, sitey, sitez,
+             dadsitex, dadsitey, dadsitez,
+             lenx, leny, lenz);
+
     bro.copy(dad,
-	     sitex, sitey, 0,
-	     dadsitex, dadsitey, dadsitez-sitez,
-	     lenx, leny, sitez);
-    bro.copy(mom, 
-	     0, 0, sitez, 
-	     momsitex-sitex, momsitey-sitey, momsitez,
-	     sitex, sitey, lenz);
-    bro.copy(dad,
-	     sitex, 0, sitez,
-	     dadsitex, dadsitey-sitey, dadsitez,
-	     lenx, sitey, lenz);
-    bro.copy(dad,
-	     0, sitey, sitez,
-	     dadsitex-sitex, dadsitey, dadsitez,
-	     sitex, leny, lenz);
+             0, 0, 0,
+             dadsitex - sitex, dadsitey - sitey, dadsitez - sitez,
+             sitex, sitey, sitez);
     bro.copy(mom,
-	     sitex, sitey, sitez,
-	     momsitex, momsitey, momsitez,
-	     lenx, leny, lenz);
-    
+             sitex, 0, 0,
+             momsitex, momsitey - sitey, momsitez - sitez,
+             lenx, sitey, sitez);
+    bro.copy(mom,
+             0, sitey, 0,
+             momsitex - sitex, momsitey, momsitez - sitez,
+             sitex, leny, sitez);
+    bro.copy(dad,
+             sitex, sitey, 0,
+             dadsitex, dadsitey, dadsitez - sitez,
+             lenx, leny, sitez);
+    bro.copy(mom,
+             0, 0, sitez,
+             momsitex - sitex, momsitey - sitey, momsitez,
+             sitex, sitey, lenz);
+    bro.copy(dad,
+             sitex, 0, sitez,
+             dadsitex, dadsitey - sitey, dadsitez,
+             lenx, sitey, lenz);
+    bro.copy(dad,
+             0, sitey, sitez,
+             dadsitex - sitex, dadsitey, dadsitez,
+             sitex, leny, lenz);
+    bro.copy(mom,
+             sitex, sitey, sitez,
+             momsitex, momsitey, momsitez,
+             lenx, leny, lenz);
+
     nc = 2;
   }
-  else if(c1 || c2){
-    GA3DBinaryStringGenome &sis = (c1 ?
-				   DYN_CAST(GA3DBinaryStringGenome &, *c1) :
-				   DYN_CAST(GA3DBinaryStringGenome &, *c2));
+  else if (c1 || c2)
+  {
+    GA3DBinaryStringGenome &sis = (c1 ? DYN_CAST(GA3DBinaryStringGenome &, *c1) : DYN_CAST(GA3DBinaryStringGenome &, *c2));
 
-    if(sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE){
-      if(mom.width() != dad.width() || sis.width() != mom.width()){
-	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
-	return nc;
+    if (sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE)
+    {
+      if (mom.width() != dad.width() || sis.width() != mom.width())
+      {
+        GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
+        return nc;
       }
       sitex = momsitex = dadsitex = GARandomInt(0, mom.width());
       lenx = momlenx = dadlenx = mom.width() - momsitex;
     }
-    else{
+    else
+    {
       momsitex = GARandomInt(0, mom.width());
       dadsitex = GARandomInt(0, dad.width());
       momlenx = mom.width() - momsitex;
@@ -960,16 +1047,19 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitex = GAMin(momsitex, dadsitex);
       lenx = GAMin(momlenx, dadlenx);
     }
-    
-    if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
-      if(mom.height() != dad.height() || sis.height() != mom.height()){
-	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
-	return nc;
+
+    if (sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE)
+    {
+      if (mom.height() != dad.height() || sis.height() != mom.height())
+      {
+        GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
+        return nc;
       }
       sitey = momsitey = dadsitey = GARandomInt(0, mom.height());
       leny = momleny = dadleny = mom.height() - momsitey;
     }
-    else{
+    else
+    {
       momsitey = GARandomInt(0, mom.height());
       dadsitey = GARandomInt(0, dad.height());
       momleny = mom.height() - momsitey;
@@ -977,16 +1067,19 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitey = GAMin(momsitey, dadsitey);
       leny = GAMin(momleny, dadleny);
     }
-    
-    if(sis.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE){
-      if(mom.depth() != dad.depth() || sis.depth() != mom.depth()){
-	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
-	return nc;
+
+    if (sis.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE)
+    {
+      if (mom.depth() != dad.depth() || sis.depth() != mom.depth())
+      {
+        GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
+        return nc;
       }
       sitez = momsitez = dadsitez = GARandomInt(0, mom.depth());
       lenz = momlenz = dadlenz = mom.depth() - momsitez;
     }
-    else{
+    else
+    {
       momsitez = GARandomInt(0, mom.depth());
       dadsitez = GARandomInt(0, dad.depth());
       momlenz = mom.depth() - momsitez;
@@ -995,75 +1088,77 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       lenz = GAMin(momlenz, dadlenz);
     }
 
-    sis.resize(sitex+lenx, sitey+leny, sitez+lenz);
+    sis.resize(sitex + lenx, sitey + leny, sitez + lenz);
 
-    if(GARandomBit()){
-      sis.copy(mom, 
-	       0, 0, 0, 
-	       momsitex-sitex, momsitey-sitey, momsitez-sitez,
-	       sitex, sitey, sitez);
-      sis.copy(dad,
-	       sitex, 0, 0,
-	       dadsitex, dadsitey-sitey, dadsitez-sitez,
-	       lenx, sitey, sitez);
-      sis.copy(dad,
-	       0, sitey, 0,
-	       dadsitex-sitex, dadsitey, dadsitez-sitez,
-	       sitex, leny, sitez);
+    if (GARandomBit())
+    {
       sis.copy(mom,
-	       sitex, sitey, 0,
-	       momsitex, momsitey, momsitez-sitez,
-	       lenx, leny, sitez);
-      sis.copy(dad, 
-	       0, 0, sitez, 
-	       dadsitex-sitex, dadsitey-sitey, dadsitez,
-	       sitex, sitey, lenz);
-      sis.copy(mom,
-	       sitex, 0, sitez,
-	       momsitex, momsitey-sitey, momsitez,
-	       lenx, sitey, lenz);
-      sis.copy(mom,
-	       0, sitey, sitez,
-	       momsitex-sitex, momsitey, momsitez,
-	       sitex, leny, lenz);
+               0, 0, 0,
+               momsitex - sitex, momsitey - sitey, momsitez - sitez,
+               sitex, sitey, sitez);
       sis.copy(dad,
-	       sitex, sitey, sitez,
-	       dadsitex, dadsitey, dadsitez,
-	       lenx, leny, lenz);
+               sitex, 0, 0,
+               dadsitex, dadsitey - sitey, dadsitez - sitez,
+               lenx, sitey, sitez);
+      sis.copy(dad,
+               0, sitey, 0,
+               dadsitex - sitex, dadsitey, dadsitez - sitez,
+               sitex, leny, sitez);
+      sis.copy(mom,
+               sitex, sitey, 0,
+               momsitex, momsitey, momsitez - sitez,
+               lenx, leny, sitez);
+      sis.copy(dad,
+               0, 0, sitez,
+               dadsitex - sitex, dadsitey - sitey, dadsitez,
+               sitex, sitey, lenz);
+      sis.copy(mom,
+               sitex, 0, sitez,
+               momsitex, momsitey - sitey, momsitez,
+               lenx, sitey, lenz);
+      sis.copy(mom,
+               0, sitey, sitez,
+               momsitex - sitex, momsitey, momsitez,
+               sitex, leny, lenz);
+      sis.copy(dad,
+               sitex, sitey, sitez,
+               dadsitex, dadsitey, dadsitez,
+               lenx, leny, lenz);
     }
-    else{
-      sis.copy(dad, 
-	       0, 0, 0, 
-	       dadsitex-sitex, dadsitey-sitey, dadsitez-sitez,
-	       sitex, sitey, sitez);
-      sis.copy(mom,
-	       sitex, 0, 0,
-	       momsitex, momsitey-sitey, momsitez-sitez,
-	       lenx, sitey, sitez);
-      sis.copy(mom,
-	       0, sitey, 0,
-	       momsitex-sitex, momsitey, momsitez-sitez,
-	       sitex, leny, sitez);
+    else
+    {
       sis.copy(dad,
-	       sitex, sitey, 0,
-	       dadsitex, dadsitey, dadsitez-sitez,
-	       lenx, leny, sitez);
-      sis.copy(mom, 
-	       0, 0, sitez, 
-	       momsitex-sitex, momsitey-sitey, momsitez,
-	       sitex, sitey, lenz);
-      sis.copy(dad,
-	       sitex, 0, sitez,
-	       dadsitex, dadsitey-sitey, dadsitez,
-	       lenx, sitey, lenz);
-      sis.copy(dad,
-	       0, sitey, sitez,
-	       dadsitex-sitex, dadsitey, dadsitez,
-	       sitex, leny, lenz);
+               0, 0, 0,
+               dadsitex - sitex, dadsitey - sitey, dadsitez - sitez,
+               sitex, sitey, sitez);
       sis.copy(mom,
-	       sitex, sitey, sitez,
-	       momsitex, momsitey, momsitez,
-	       lenx, leny, lenz);
+               sitex, 0, 0,
+               momsitex, momsitey - sitey, momsitez - sitez,
+               lenx, sitey, sitez);
+      sis.copy(mom,
+               0, sitey, 0,
+               momsitex - sitex, momsitey, momsitez - sitez,
+               sitex, leny, sitez);
+      sis.copy(dad,
+               sitex, sitey, 0,
+               dadsitex, dadsitey, dadsitez - sitez,
+               lenx, leny, sitez);
+      sis.copy(mom,
+               0, 0, sitez,
+               momsitex - sitex, momsitey - sitey, momsitez,
+               sitex, sitey, lenz);
+      sis.copy(dad,
+               sitex, 0, sitez,
+               dadsitex, dadsitey - sitey, dadsitez,
+               lenx, sitey, lenz);
+      sis.copy(dad,
+               0, sitey, sitez,
+               dadsitex - sitex, dadsitey, dadsitez,
+               sitex, leny, lenz);
+      sis.copy(mom,
+               sitex, sitey, sitez,
+               momsitex, momsitey, momsitez,
+               lenx, leny, lenz);
     }
 
     nc = 1;

--- a/CPFA/source/ga-mpi/GAListGenome.C
+++ b/CPFA/source/ga-mpi/GAListGenome.C
@@ -17,7 +17,7 @@
 #include <ga-mpi/GAMask.h>
 #include <ga-mpi/garandom.h>
 
-template <class T> int 
+template <class T> int
 GAListIsHole(const GAListGenome<T>&, const GAListGenome<T>&, int, int, int);
 
 
@@ -30,8 +30,8 @@ GAListGenome<T>::className() const {return "GAListGenome";}
 template <class T> int
 GAListGenome<T>::classID() const {return GAID::ListGenome;}
 
-template <class T> 
-GAListGenome<T>::GAListGenome(GAGenome::Evaluator f, void * u) : 
+template <class T>
+GAListGenome<T>::GAListGenome(GAGenome::Evaluator f, void * u) :
 GAList<T>(),
 GAGenome(DEFAULT_LIST_INITIALIZER,
 	 DEFAULT_LIST_MUTATOR,
@@ -42,8 +42,8 @@ GAGenome(DEFAULT_LIST_INITIALIZER,
 }
 
 
-template <class T> 
-GAListGenome<T>::GAListGenome(const GAListGenome<T> & orig) : 
+template <class T>
+GAListGenome<T>::GAListGenome(const GAListGenome<T> & orig) :
 GAList<T>(),
 GAGenome() {
   GAListGenome<T>::copy(orig);
@@ -76,10 +76,10 @@ GAListGenome<T>::copy(const GAGenome & orig){
 
 #ifdef GALIB_USE_STREAMS
 // Traverse the list (breadth-first) and dump the contents as best we can to
-// the stream.  We don't try to write the contents of the nodes - we simply 
+// the stream.  We don't try to write the contents of the nodes - we simply
 // write a . for each node in the list.
 template <class T> int
-GAListGenome<T>::write(STD_OSTREAM & os) const 
+GAListGenome<T>::write(STD_OSTREAM & os) const
 {
   os << "node       next       prev       contents\n";
   if(!this->hd) return 0;;
@@ -105,7 +105,7 @@ GAListGenome<T>::write(STD_OSTREAM & os) const
 // then you have nothing to worry about.
 //   Neither of these operators affects the internal iterator of either
 // list genome in any way.
-template <class T> int 
+template <class T> int
 GAListGenome<T>::equal(const GAGenome & c) const
 {
   if(this == &c) return 1;
@@ -136,14 +136,14 @@ GAListGenome<T>::equal(const GAGenome & c) const
 ---------------------------------------------------------------------------- */
 // Mutate a list by nuking nodes.  Any node has a pmut chance of getting nuked.
 // This is actually kind of bogus for the second part of the if clause (if nMut
-// is greater than or equal to 1).  Nodes end up having more than pmut 
+// is greater than or equal to 1).  Nodes end up having more than pmut
 // probability of getting nuked.
 //   After the mutation the iterator is left at the head of the list.
 template <class T> int
 GAListGenome<T>::DestructiveMutator(GAGenome & c, float pmut)
 {
   GAListGenome<T> &child=DYN_CAST(GAListGenome<T> &, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return 0;
 
   n = child.size();
@@ -171,14 +171,14 @@ GAListGenome<T>::DestructiveMutator(GAGenome & c, float pmut)
 
 // Mutate a list by swapping two nodes.  Any node has a pmut chance of getting
 // swapped, and the swap could happen to any other node.  And in the case of
-// nMut < 1, the swap may generate a swap partner that is the same node, in 
+// nMut < 1, the swap may generate a swap partner that is the same node, in
 // which case no swap occurs (we don't check).
 //   After the mutation the iterator is left at the head of the list.
 template <class T> int
 GAListGenome<T>::SwapMutator(GAGenome & c, float pmut)
 {
   GAListGenome<T> &child=DYN_CAST(GAListGenome<T> &, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return 0;
 
   n = child.size();
@@ -205,7 +205,7 @@ GAListGenome<T>::SwapMutator(GAGenome & c, float pmut)
 
 // This comparator returns the number of elements that the two lists have
 // in common (both in position and in value).  If they are different lengths
-// then we just say they are completely different.  This is probably barely 
+// then we just say they are completely different.  This is probably barely
 // adequate for most applications - we really should give more credit for
 // nodes that are the same but in different positions.  But that would be
 // pretty nasty to compute.
@@ -213,7 +213,7 @@ GAListGenome<T>::SwapMutator(GAGenome & c, float pmut)
 // which to compare this diversity measure.  Its kind of hard to define this
 // one in a general way...
 template <class T> float
-GAListGenome<T>::NodeComparator(const GAGenome& a, const GAGenome& b) 
+GAListGenome<T>::NodeComparator(const GAGenome& a, const GAGenome& b)
 {
   if(&a == &b) return 0;
   const GAListGenome<T>& sis=DYN_CAST(const GAListGenome<T>&, a);
@@ -244,7 +244,7 @@ GAListGenome<T>::NodeComparator(const GAGenome& a, const GAGenome& b)
 
 #define SWAP(a,b) {unsigned int tmp=a; a=b; b=tmp;}
 
-// This crossover picks a site between nodes in each parent.  It is the same 
+// This crossover picks a site between nodes in each parent.  It is the same
 // as single point crossover on a resizeable binary string genome.  The site
 // in the mother is not necessarily the same as the site in the father!
 //   When we pick a crossover site, it is between nodes of the list (otherwise
@@ -253,7 +253,7 @@ GAListGenome<T>::NodeComparator(const GAGenome& a, const GAGenome& b)
 // whereas the cross site possibilities are numbered from 0 to size, inclusive.
 // This means we have to map the site to the list to determine whether an
 // insertion should occur before or after a node.
-//   We first copy the mother into the child (this deletes whatever contents 
+//   We first copy the mother into the child (this deletes whatever contents
 // were in the child originally).  Then we clone the father from the cross site
 // to the end of the list.  Then we delete the tail of the child from the
 // mother's cross site to the end of the list.  Finally, we insert the clone
@@ -265,7 +265,7 @@ GAListGenome<T>::NodeComparator(const GAGenome& a, const GAGenome& b)
 // do better by copying only what we need of the mother.
 template <class T> int
 GAListGenome<T>::
-OnePointCrossover(const GAGenome& p1, const GAGenome& p2, 
+OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 		  GAGenome* c1, GAGenome* c2){
   const GAListGenome<T> &mom=DYN_CAST(const GAListGenome<T> &, p1);
   const GAListGenome<T> &dad=DYN_CAST(const GAListGenome<T> &, p2);
@@ -330,13 +330,13 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 //   This version of the partial match crossover uses objects that are multiply
 // instantiated - each list genome contains its own objects in its nodes.
 // The operator== method must be defined on the object for this implementation
-// to work!  In this case, the 'object' is an int, so we're OK.  If you are 
+// to work!  In this case, the 'object' is an int, so we're OK.  If you are
 // putting your own objects in the nodes, be sure you have operator== defined
 // for your object.  You must also have operator!= defined for your object.  We
 // do not do any assignments, so operator= and/or copy is not required.
 //   We assume that none of the nodes will return a NULL pointer.  Also assume
 // that the cross site has been selected properly.
-//   First we make a copy of the mother.  Then we loop through the match 
+//   First we make a copy of the mother.  Then we loop through the match
 // section and try to swap each element in the child's match section with its
 // partner (as defined by the current node in the father's match section).
 //   Mirroring will work the same way - just swap mom & dad and you're all set.

--- a/CPFA/source/ga-mpi/GARealGenome.C
+++ b/CPFA/source/ga-mpi/GARealGenome.C
@@ -10,35 +10,43 @@
 ---------------------------------------------------------------------------- */
 #include <ga-mpi/GARealGenome.h>
 
-
 // We must also specialize the allele set so that the alleles are handled
 // properly.  Be sure to handle bounds correctly whether we are discretized
-// or continuous.  Handle the case where someone sets stupid bounds that 
+// or continuous.  Handle the case where someone sets stupid bounds that
 // might cause an infinite loop for exclusive bounds.
-template <> float
-GAAlleleSet<float>::allele() const {
+template <>
+float GAAlleleSet<float>::allele() const
+{
   float value = 0.0;
-  if(core->type == GAAllele::ENUMERATED)
-    value = core->a[GARandomInt(0, core->sz-1)];
-  else if(core->type == GAAllele::DISCRETIZED){
+  if (core->type == GAAllele::ENUMERATED)
+    value = core->a[GARandomInt(0, core->sz - 1)];
+  else if (core->type == GAAllele::DISCRETIZED)
+  {
     float n = (core->a[1] - core->a[0]) / core->a[2];
     int m = (int)n;
-    if(core->lowerb == GAAllele::EXCLUSIVE) m -= 1;
-    if(core->upperb == GAAllele::EXCLUSIVE) m -= 1;
-    value = core->a[0] + GARandomInt(0,(int)m) * core->a[2];
-    if(core->lowerb == GAAllele::EXCLUSIVE) value += core->a[2];
+    if (core->lowerb == GAAllele::EXCLUSIVE)
+      m -= 1;
+    if (core->upperb == GAAllele::EXCLUSIVE)
+      m -= 1;
+    value = core->a[0] + GARandomInt(0, (int)m) * core->a[2];
+    if (core->lowerb == GAAllele::EXCLUSIVE)
+      value += core->a[2];
   }
-  else{
-    if(core->a[0] == core->a[1] && 
-       core->lowerb == GAAllele::EXCLUSIVE && 
-       core->upperb == GAAllele::EXCLUSIVE) {
+  else
+  {
+    if (core->a[0] == core->a[1] &&
+        core->lowerb == GAAllele::EXCLUSIVE &&
+        core->upperb == GAAllele::EXCLUSIVE)
+    {
       value = core->a[0];
     }
-    else {
-      do {
-	value = GARandomFloat(core->a[0], core->a[1]);
+    else
+    {
+      do
+      {
+        value = GARandomFloat(core->a[0], core->a[1]);
       } while ((core->lowerb == GAAllele::EXCLUSIVE && value == core->a[0]) ||
-	       (core->upperb == GAAllele::EXCLUSIVE && value == core->a[1]));
+               (core->upperb == GAAllele::EXCLUSIVE && value == core->a[1]));
     }
   }
   return value;
@@ -47,42 +55,47 @@ GAAlleleSet<float>::allele() const {
 // If someone asks for a discretized item that is beyond the bounds, give them
 // one of the bounds.  If they ask for allele item when there is no
 // discretization or enumeration, then error and return lower bound.
-template <> float
-GAAlleleSet<float>::allele(unsigned int i) const {
+template <>
+float GAAlleleSet<float>::allele(unsigned int i) const
+{
   float value = 0.0;
-  if(core->type == GAAllele::ENUMERATED)
+  if (core->type == GAAllele::ENUMERATED)
     value = core->a[i % core->sz];
-  else if(core->type == GAAllele::DISCRETIZED){
-    float n = (core->a[1] - core->a[0])/core->a[2];
-    unsigned int m = (unsigned int)n;            // what about bogus limits?
-    if(core->lowerb == GAAllele::EXCLUSIVE) m -= 1;
-    if(core->upperb == GAAllele::EXCLUSIVE) m -= 1;
-    if(i > m) i = (int)m;
-    value = core->a[0] + i*core->a[2];
-    if(core->lowerb == GAAllele::EXCLUSIVE) value += core->a[2];
+  else if (core->type == GAAllele::DISCRETIZED)
+  {
+    float n = (core->a[1] - core->a[0]) / core->a[2];
+    unsigned int m = (unsigned int)n; // what about bogus limits?
+    if (core->lowerb == GAAllele::EXCLUSIVE)
+      m -= 1;
+    if (core->upperb == GAAllele::EXCLUSIVE)
+      m -= 1;
+    if (i > m)
+      i = (int)m;
+    value = core->a[0] + i * core->a[2];
+    if (core->lowerb == GAAllele::EXCLUSIVE)
+      value += core->a[2];
   }
-  else{
+  else
+  {
     GAErr(GA_LOC, "GAAlleleSet", "allele", gaErrNoAlleleIndex);
     value = core->a[0];
   }
   return value;
 }
 
-
-
-
-
 // now the specialization of the genome itself.
 
-template <> const char * 
-GA1DArrayAlleleGenome<float>::className() const {return "GARealGenome";}
-template <> int 
-GA1DArrayAlleleGenome<float>::classID() const {return GAID::FloatGenome;}
+template <>
+const char *
+GA1DArrayAlleleGenome<float>::className() const { return "GARealGenome"; }
+template <>
+int GA1DArrayAlleleGenome<float>::classID() const { return GAID::FloatGenome; }
 
-template <> GA1DArrayAlleleGenome<float>::
-GA1DArrayAlleleGenome(unsigned int length, const GAAlleleSet<float> & s,
-		      GAGenome::Evaluator f, void * u) :
-GA1DArrayGenome<float>(length, f, u){
+template <>
+GA1DArrayAlleleGenome<float>::
+    GA1DArrayAlleleGenome(unsigned int length, const GAAlleleSet<float> &s,
+                          GAGenome::Evaluator f, void *u) : GA1DArrayGenome<float>(length, f, u)
+{
   naset = 1;
   aset = new GAAlleleSet<float>[1];
   aset[0] = s;
@@ -93,13 +106,14 @@ GA1DArrayGenome<float>(length, f, u){
   crossover(DEFAULT_REAL_CROSSOVER);
 }
 
-template <> GA1DArrayAlleleGenome<float>::
-GA1DArrayAlleleGenome(const GAAlleleSetArray<float> & sa,
-		      GAGenome::Evaluator f, void * u) :
-GA1DArrayGenome<float>(sa.size(), f, u){
+template <>
+GA1DArrayAlleleGenome<float>::
+    GA1DArrayAlleleGenome(const GAAlleleSetArray<float> &sa,
+                          GAGenome::Evaluator f, void *u) : GA1DArrayGenome<float>(sa.size(), f, u)
+{
   naset = sa.size();
   aset = new GAAlleleSet<float>[naset];
-  for(int i=0; i<naset; i++)
+  for (int i = 0; i < naset; i++)
     aset[i] = sa.set(i);
 
   initializer(DEFAULT_REAL_INITIALIZER);
@@ -108,25 +122,28 @@ GA1DArrayGenome<float>(sa.size(), f, u){
   crossover(DEFAULT_REAL_CROSSOVER);
 }
 
-template <> 
-GA1DArrayAlleleGenome<float>::~GA1DArrayAlleleGenome(){
-  delete [] aset;
+template <>
+GA1DArrayAlleleGenome<float>::~GA1DArrayAlleleGenome()
+{
+  delete[] aset;
 }
-
-
 
 #ifdef GALIB_USE_STREAMS
 // The read specialization takes in each number and stuffs it into the array.
-template <> int
-GA1DArrayAlleleGenome<float>::read(STD_ISTREAM & is) {
-  unsigned int i=0;
+template <>
+int GA1DArrayAlleleGenome<float>::read(STD_ISTREAM &is)
+{
+  unsigned int i = 0;
   float val;
-  do{
+  do
+  {
     is >> val;
-    if(!is.fail()) gene(i++, val);
-  } while(!is.fail() && !is.eof() && i < nx);
+    if (!is.fail())
+      gene(i++, val);
+  } while (!is.fail() && !is.eof() && i < nx);
 
-  if(is.eof() && i < nx){
+  if (is.eof() && i < nx)
+  {
     GAErr(GA_LOC, className(), "read", gaErrUnexpectedEOF);
     is.clear(STD_IOS_BADBIT | is.rdstate());
     return 1;
@@ -137,97 +154,100 @@ GA1DArrayAlleleGenome<float>::read(STD_ISTREAM & is) {
 // No need to specialize the write method.
 #endif
 
-
-
-
-
-
-
 /* ----------------------------------------------------------------------------
    Operator specializations
 ---------------------------------------------------------------------------- */
 // The Gaussian mutator picks a new value based on a Gaussian distribution
 // around the current value.  We respect the bounds (if any).
-//*** need to figure out a way to make the stdev other than 1.0 
-int 
-GARealGaussianMutator(GAGenome& g, float pmut){
-  GA1DArrayAlleleGenome<float> &child=
-    DYN_CAST(GA1DArrayAlleleGenome<float> &, g);
-  register int n, i;
-  if(pmut <= 0.0) return(0);
+//*** need to figure out a way to make the stdev other than 1.0
+int GARealGaussianMutator(GAGenome &g, float pmut)
+{
+  GA1DArrayAlleleGenome<float> &child =
+      DYN_CAST(GA1DArrayAlleleGenome<float> &, g);
+  int n, i;
+  if (pmut <= 0.0)
+    return (0);
 
   float nMut = pmut * (float)(child.length());
-  int length = child.length()-1;
-  if(nMut < 1.0){		// we have to do a flip test on each element
+  int length = child.length() - 1;
+  if (nMut < 1.0)
+  { // we have to do a flip test on each element
     nMut = 0;
-    for(i=length; i>=0; i--){
+    for (i = length; i >= 0; i--)
+    {
       float value = child.gene(i);
-      if(GAFlipCoin(pmut)){
-	if(child.alleleset(i).type() == GAAllele::ENUMERATED ||
-	   child.alleleset(i).type() == GAAllele::DISCRETIZED)
-	  value = child.alleleset(i).allele();
-	else if(child.alleleset(i).type() == GAAllele::BOUNDED){
-	  value += GAUnitGaussian();
-	  value = GAMax(child.alleleset(i).lower(), value);
-	  value = GAMin(child.alleleset(i).upper(), value);
-	}
-	child.gene(i, value);
-	nMut++;
+      if (GAFlipCoin(pmut))
+      {
+        if (child.alleleset(i).type() == GAAllele::ENUMERATED ||
+            child.alleleset(i).type() == GAAllele::DISCRETIZED)
+          value = child.alleleset(i).allele();
+        else if (child.alleleset(i).type() == GAAllele::BOUNDED)
+        {
+          value += GAUnitGaussian();
+          value = GAMax(child.alleleset(i).lower(), value);
+          value = GAMin(child.alleleset(i).upper(), value);
+        }
+        child.gene(i, value);
+        nMut++;
       }
     }
   }
-  else{				// only mutate the ones we need to
-    for(n=0; n<nMut; n++){
-      int idx = GARandomInt(0,length);
+  else
+  { // only mutate the ones we need to
+    for (n = 0; n < nMut; n++)
+    {
+      int idx = GARandomInt(0, length);
       float value = child.gene(idx);
-      if(child.alleleset(idx).type() == GAAllele::ENUMERATED ||
-	 child.alleleset(idx).type() == GAAllele::DISCRETIZED)
-	value = child.alleleset(idx).allele();
-      else if(child.alleleset(idx).type() == GAAllele::BOUNDED){
-	value += GAUnitGaussian();
-	value = GAMax(child.alleleset(idx).lower(), value);
-	value = GAMin(child.alleleset(idx).upper(), value);
+      if (child.alleleset(idx).type() == GAAllele::ENUMERATED ||
+          child.alleleset(idx).type() == GAAllele::DISCRETIZED)
+        value = child.alleleset(idx).allele();
+      else if (child.alleleset(idx).type() == GAAllele::BOUNDED)
+      {
+        value += GAUnitGaussian();
+        value = GAMax(child.alleleset(idx).lower(), value);
+        value = GAMin(child.alleleset(idx).upper(), value);
       }
       child.gene(idx, value);
     }
   }
-  return((int)nMut);
+  return ((int)nMut);
 }
-
 
 // Arithmetic crossover generates a new value that is the average of the parent
 // values.  Note that this means both children in a sexual crossover will be
 // identical.  If parents are not the same length, the extra elements are not
 // set!  You might want to add some noise to this so that both children are not
 // the same...
-int 
-GARealArithmeticCrossover(const GAGenome& p1, const GAGenome& p2,
-			  GAGenome* c1, GAGenome* c2) {
-  const GA1DArrayGenome<float> &mom=
-    DYN_CAST(const GA1DArrayGenome<float> &, p1);
-  const GA1DArrayGenome<float> &dad=
-    DYN_CAST(const GA1DArrayGenome<float> &, p2);
+int GARealArithmeticCrossover(const GAGenome &p1, const GAGenome &p2,
+                              GAGenome *c1, GAGenome *c2)
+{
+  const GA1DArrayGenome<float> &mom =
+      DYN_CAST(const GA1DArrayGenome<float> &, p1);
+  const GA1DArrayGenome<float> &dad =
+      DYN_CAST(const GA1DArrayGenome<float> &, p2);
 
-  int n=0;
+  int n = 0;
 
-  if(c1 && c2){
-    GA1DArrayGenome<float> &sis=DYN_CAST(GA1DArrayGenome<float> &, *c1);
-    GA1DArrayGenome<float> &bro=DYN_CAST(GA1DArrayGenome<float> &, *c2);
+  if (c1 && c2)
+  {
+    GA1DArrayGenome<float> &sis = DYN_CAST(GA1DArrayGenome<float> &, *c1);
+    GA1DArrayGenome<float> &bro = DYN_CAST(GA1DArrayGenome<float> &, *c2);
 
     int len = GAMax(mom.length(), dad.length());
-    for(int i=0; i<len; i++) {
+    for (int i = 0; i < len; i++)
+    {
       sis.gene(i, 0.5 * (mom.gene(i) + dad.gene(i)));
       bro.gene(i, 0.5 * (mom.gene(i) + dad.gene(i)));
     }
     n = 2;
   }
-  else if(c1 || c2){
-    GA1DArrayGenome<float> &sis = (c1 ? 
-				   DYN_CAST(GA1DArrayGenome<float> &, *c1) : 
-				   DYN_CAST(GA1DArrayGenome<float> &, *c2));
+  else if (c1 || c2)
+  {
+    GA1DArrayGenome<float> &sis = (c1 ? DYN_CAST(GA1DArrayGenome<float> &, *c1) : DYN_CAST(GA1DArrayGenome<float> &, *c2));
 
     int len = GAMax(mom.length(), dad.length());
-    for(int i=0; i<len; i++) {
+    for (int i = 0; i < len; i++)
+    {
       sis.gene(i, 0.5 * (mom.gene(i) + dad.gene(i)));
     }
     n = 1;
@@ -236,52 +256,53 @@ GARealArithmeticCrossover(const GAGenome& p1, const GAGenome& p2,
   return n;
 }
 
-
 // Blend crossover generates a new value based on the interval between parents.
 // We generate a uniform distribution based on the distance between parent
 // values, then choose the child value based upon that distribution.
-int 
-GARealBlendCrossover(const GAGenome& p1, const GAGenome& p2,
-		     GAGenome* c1, GAGenome* c2) {
-  const GA1DArrayGenome<float> &mom=
-    DYN_CAST(const GA1DArrayGenome<float> &, p1);
-  const GA1DArrayGenome<float> &dad=
-    DYN_CAST(const GA1DArrayGenome<float> &, p2);
+int GARealBlendCrossover(const GAGenome &p1, const GAGenome &p2,
+                         GAGenome *c1, GAGenome *c2)
+{
+  const GA1DArrayGenome<float> &mom =
+      DYN_CAST(const GA1DArrayGenome<float> &, p1);
+  const GA1DArrayGenome<float> &dad =
+      DYN_CAST(const GA1DArrayGenome<float> &, p2);
 
-  int n=0;
+  int n = 0;
 
-  if(c1 && c2){
-    GA1DArrayGenome<float> &sis=DYN_CAST(GA1DArrayGenome<float> &, *c1);
-    GA1DArrayGenome<float> &bro=DYN_CAST(GA1DArrayGenome<float> &, *c2);
+  if (c1 && c2)
+  {
+    GA1DArrayGenome<float> &sis = DYN_CAST(GA1DArrayGenome<float> &, *c1);
+    GA1DArrayGenome<float> &bro = DYN_CAST(GA1DArrayGenome<float> &, *c2);
 
     int len = GAMax(mom.length(), dad.length());
-    for(int i=0; i<len; i++) {
+    for (int i = 0; i < len; i++)
+    {
       float dist = 0;
-      if(mom.gene(i) > dad.gene(i)) 
-	dist = mom.gene(i) - dad.gene(i);
-      else 
-	dist = dad.gene(i) - mom.gene(i);
-      float lo = (GAMin(mom.gene(i), dad.gene(i))) - 0.5*dist;
-      float hi = (GAMax(mom.gene(i), dad.gene(i))) + 0.5*dist;
+      if (mom.gene(i) > dad.gene(i))
+        dist = mom.gene(i) - dad.gene(i);
+      else
+        dist = dad.gene(i) - mom.gene(i);
+      float lo = (GAMin(mom.gene(i), dad.gene(i))) - 0.5 * dist;
+      float hi = (GAMax(mom.gene(i), dad.gene(i))) + 0.5 * dist;
       sis.gene(i, GARandomFloat(lo, hi));
       bro.gene(i, GARandomFloat(lo, hi));
     }
     n = 2;
   }
-  else if(c1 || c2){
-    GA1DArrayGenome<float> &sis = (c1 ?
-				   DYN_CAST(GA1DArrayGenome<float> &, *c1) :
-				   DYN_CAST(GA1DArrayGenome<float> &, *c2));
+  else if (c1 || c2)
+  {
+    GA1DArrayGenome<float> &sis = (c1 ? DYN_CAST(GA1DArrayGenome<float> &, *c1) : DYN_CAST(GA1DArrayGenome<float> &, *c2));
 
     int len = GAMax(mom.length(), dad.length());
-    for(int i=0; i<len; i++) {
+    for (int i = 0; i < len; i++)
+    {
       float dist = 0;
-      if(mom.gene(i) > dad.gene(i)) 
-	dist = mom.gene(i) - dad.gene(i);
-      else 
-	dist = dad.gene(i) - mom.gene(i);
-      float lo = (GAMin(mom.gene(i), dad.gene(i))) - 0.5*dist;
-      float hi = (GAMax(mom.gene(i), dad.gene(i))) + 0.5*dist;
+      if (mom.gene(i) > dad.gene(i))
+        dist = mom.gene(i) - dad.gene(i);
+      else
+        dist = dad.gene(i) - mom.gene(i);
+      float lo = (GAMin(mom.gene(i), dad.gene(i))) - 0.5 * dist;
+      float hi = (GAMax(mom.gene(i), dad.gene(i))) + 0.5 * dist;
       sis.gene(i, GARandomFloat(lo, hi));
     }
     n = 1;
@@ -290,15 +311,11 @@ GARealBlendCrossover(const GAGenome& p1, const GAGenome& p2,
   return n;
 }
 
-
-
-
-
 // force instantiations of this genome type.
 //
 // These must be included _after_ the specializations because some compilers
 // get all wigged out about the declaration/specialization order.  Note that
-// some compilers require a syntax different than others when forcing the 
+// some compilers require a syntax different than others when forcing the
 // instantiation (i.e. GNU wants the 'template class', borland does not).
 #ifndef GALIB_USE_AUTO_INST
 #include <ga-mpi/GAAllele.C>

--- a/CPFA/source/ga-mpi/GATreeGenome.C
+++ b/CPFA/source/ga-mpi/GATreeGenome.C
@@ -25,7 +25,7 @@ template <class T> int
 GATreeGenome<T>::classID() const {return GAID::TreeGenome;}
 
 template <class T>
-GATreeGenome<T>::GATreeGenome(GAGenome::Evaluator f, void * u) : 
+GATreeGenome<T>::GATreeGenome(GAGenome::Evaluator f, void * u) :
 GATree<T>(),
 GAGenome(DEFAULT_TREE_INITIALIZER,
 	 DEFAULT_TREE_MUTATOR,
@@ -37,7 +37,7 @@ GAGenome(DEFAULT_TREE_INITIALIZER,
 
 
 template <class T>
-GATreeGenome<T>::GATreeGenome(const GATreeGenome<T> & orig) : 
+GATreeGenome<T>::GATreeGenome(const GATreeGenome<T> & orig) :
 GATree<T>(),
 GAGenome() {
   GATreeGenome<T>::copy(orig);
@@ -70,7 +70,7 @@ GATreeGenome<T>::copy(const GAGenome & orig) {
 
 #ifdef GALIB_USE_STREAMS
 // Traverse the tree (breadth-first) and dump the contents as best we can to
-// the stream.  We don't try to write the contents of the nodes - we simply 
+// the stream.  We don't try to write the contents of the nodes - we simply
 // write a . for each node in the tree.
 //   We allocate space for x,y coord pair for each node in the tree.  Then we
 // do a depth-first traversal of the tree and assign coords to the nodes in the
@@ -102,7 +102,7 @@ _tt(STD_OSTREAM & os, GANode<T> * n)
 }
 
 template <class T> int
-GATreeGenome<T>::write(STD_OSTREAM & os) const 
+GATreeGenome<T>::write(STD_OSTREAM & os) const
 {
   os << "node       parent     child      next       prev       contents\n";
   _tt(os, (GANode<T> *)(this->rt));
@@ -111,7 +111,7 @@ GATreeGenome<T>::write(STD_OSTREAM & os) const
 #endif
 
 
-template <class T> int  
+template <class T> int
 GATreeGenome<T>::equal(const GAGenome & c) const
 {
   if(this == &c) return 1;
@@ -140,7 +140,7 @@ template <class T> int
 GATreeGenome<T>::DestructiveMutator(GAGenome & c, float pmut)
 {
   GATreeGenome<T> &child=DYN_CAST(GATreeGenome<T> &, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return 0;
 
   n = child.size();
@@ -169,14 +169,14 @@ GATreeGenome<T>::DestructiveMutator(GAGenome & c, float pmut)
 // This is a rearranging mutation operator.  It randomly picks two nodes in the
 // tree and swaps them.  Any node has a pmut chance of getting
 // swapped, and the swap could happen to any other node.  And in the case of
-// nMut < 1, the swap may generate a swap partner that is the same node, in 
+// nMut < 1, the swap may generate a swap partner that is the same node, in
 // which case no swap occurs (we don't check).
 //   After the mutation the iterator is left at the root of the tree.
 template <class T> int
 GATreeGenome<T>::SwapNodeMutator(GAGenome & c, float pmut)
 {
   GATreeGenome<T> &child=DYN_CAST(GATreeGenome<T> &, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return 0;
 
   n = child.size();
@@ -214,7 +214,7 @@ template <class T> int
 GATreeGenome<T>::SwapSubtreeMutator(GAGenome & c, float pmut)
 {
   GATreeGenome<T> &child=DYN_CAST(GATreeGenome<T> &, c);
-  register int n, i;
+  int n, i;
   int a, b;
   if(pmut <= 0.0) return 0;
 
@@ -247,7 +247,7 @@ GATreeGenome<T>::SwapSubtreeMutator(GAGenome & c, float pmut)
 // We use the recursive tree function to compare the tree structures.  This
 // does not compare the contents of the nodes.
 template <class T> float
-GATreeGenome<T>::TopologyComparator(const GAGenome& a, const GAGenome& b) 
+GATreeGenome<T>::TopologyComparator(const GAGenome& a, const GAGenome& b)
 {
   if(&a == &b) return 0;
   const GATreeGenome<T>& sis=DYN_CAST(const GATreeGenome<T>&, a);
@@ -277,7 +277,7 @@ GATreeGenome<T>::TopologyComparator(const GAGenome& a, const GAGenome& b)
 //     do the check to see if the crossover site is valid.
 template <class T> int
 GATreeGenome<T>::
-OnePointCrossover(const GAGenome& p1, const GAGenome& p2, 
+OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 		  GAGenome* c1, GAGenome* c2){
   const GATreeGenome<T> &mom=DYN_CAST(const GATreeGenome<T> &, p1);
   const GATreeGenome<T> &dad=DYN_CAST(const GATreeGenome<T> &, p2);

--- a/Dynamic_MPFA/source/evolver.cpp
+++ b/Dynamic_MPFA/source/evolver.cpp
@@ -11,7 +11,7 @@
 // For shared memory management
 #include <sys/mman.h>
 
-#include <ctime> // For clock()
+#include <ctime>  // For clock()
 #include <chrono> // For clock()
 #include <mpi.h>
 
@@ -31,12 +31,12 @@
 #include <source/CPFA/CPFA_loop_functions.h>
 
 // For timing
-#include <ctime> // For clock()
+#include <ctime>  // For clock()
 #include <chrono> // For clock()
 
 // For shared variable between child and parent process
-#include  <sys/ipc.h>
-#include  <sys/shm.h>
+#include <sys/ipc.h>
+#include <sys/shm.h>
 
 float objective(GAGenome &);
 float LaunchARGoS(GAGenome &);
@@ -44,11 +44,11 @@ float LaunchARGoS(GAGenome &);
 int mpi_tasks, mpi_rank;
 
 int elitism = 0;
-int n_trials = 20; // used by the objective function
+int n_trials = 20;            // used by the objective function
 double mutation_stdev = 1.00; // Gaussian mutation stdev - will be scaled by possible range
 string experiment_path;
 
-void CPFAInitializer(GAGenome & c);
+void CPFAInitializer(GAGenome &c);
 int GARealGaussianMutatorStdev(GAGenome &, float);
 
 std::default_random_engine generator;
@@ -62,125 +62,124 @@ int main(int argc, char **argv)
   MPI_Init(&argc, &argv);
   MPI_Comm_size(MPI_COMM_WORLD, &mpi_tasks);
   MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
-                         
-  char hostname[1024];                                                                                                       
-  hostname[1023] = '\0';                                          
+
+  char hostname[1024];
+  hostname[1023] = '\0';
   gethostname(hostname, 1023);
-  
+
   double mutation_rate = 0.01;
   double crossover_rate = 0.01;
   int population_size = 10;
   int n_generations = 10;
 
-    char c='h';
+  char c = 'h';
   // Handle command line arguments
-  while ((c = getopt (argc, argv, "t:g:p:c:m:s:h:e:x:")) != -1)
+  while ((c = getopt(argc, argv, "t:g:p:c:m:s:h:e:x:")) != -1)
     switch (c)
-      {
-      case 'x':
-	experiment_path = optarg;
+    {
+    case 'x':
+      experiment_path = optarg;
       break;
-      case 't':
-	n_trials = atoi(optarg);
-	break;
-      case 'g':
-        n_generations = atoi(optarg);
-        break;
-      case 'p':
-        population_size = atoi(optarg);
-        break;
-      case 'm':
-        mutation_rate = strtod(optarg, NULL);
-	break;
-      case 'c':
-	crossover_rate = strtod(optarg, NULL);
-	break;
-      case 's':
-        mutation_stdev = strtod(optarg, NULL);
-	break;
-      case 'e':
-        elitism = atoi(optarg);
-	break;
-      case 'h':
-	printf("Usage: %s -p {population size} -g {number of generations} -t {number of trials} -c {crossover rate} -m {mutation rate} -s {mutation standard deviation} -e {elitism 0 or 1}", argv[0]);
-	break;
-      case '?':
-        if (optopt == 'p')
-          fprintf (stderr, "Option -%c requires an argument specifying the population size.\n", optopt);
-	else if (optopt == 'g')
-	  fprintf (stderr, "Option -%c requires an argument specifying the number of generations.\n", optopt);
-	else if (optopt == 't')
-	  fprintf (stderr, "Option -%c requires an argument specifying the number of trials.\n", optopt);
-	else if (optopt == 'c')
-	  fprintf (stderr, "Option -%c requires an argument specifying the crossover rate.\n", optopt);
-	else if (optopt == 'm')
-	  fprintf (stderr, "Option -%c requires an argument specifying the mutation rate.\n", optopt);
-	else if (optopt == 's')
-	  fprintf (stderr, "Option -%c requires an argument specifying the mutation standard deviation.\n", optopt);
-        else if (isprint (optopt))
-          fprintf (stderr, "Unknown option `-%c'.\n", optopt);
-        else
-          fprintf (stderr,
-                   "Unknown option character `\\x%x'.\n",
-                   optopt);
-        return 1;
-      default:
-	printf("Usage: %s -p {population size} -g {number of generations} -t {number of trials} -c {crossover rate} -m {mutation rate} -s {mutation standard deviation}", argv[0]);
-        abort ();
-      }
+    case 't':
+      n_trials = atoi(optarg);
+      break;
+    case 'g':
+      n_generations = atoi(optarg);
+      break;
+    case 'p':
+      population_size = atoi(optarg);
+      break;
+    case 'm':
+      mutation_rate = strtod(optarg, NULL);
+      break;
+    case 'c':
+      crossover_rate = strtod(optarg, NULL);
+      break;
+    case 's':
+      mutation_stdev = strtod(optarg, NULL);
+      break;
+    case 'e':
+      elitism = atoi(optarg);
+      break;
+    case 'h':
+      printf("Usage: %s -p {population size} -g {number of generations} -t {number of trials} -c {crossover rate} -m {mutation rate} -s {mutation standard deviation} -e {elitism 0 or 1}", argv[0]);
+      break;
+    case '?':
+      if (optopt == 'p')
+        fprintf(stderr, "Option -%c requires an argument specifying the population size.\n", optopt);
+      else if (optopt == 'g')
+        fprintf(stderr, "Option -%c requires an argument specifying the number of generations.\n", optopt);
+      else if (optopt == 't')
+        fprintf(stderr, "Option -%c requires an argument specifying the number of trials.\n", optopt);
+      else if (optopt == 'c')
+        fprintf(stderr, "Option -%c requires an argument specifying the crossover rate.\n", optopt);
+      else if (optopt == 'm')
+        fprintf(stderr, "Option -%c requires an argument specifying the mutation rate.\n", optopt);
+      else if (optopt == 's')
+        fprintf(stderr, "Option -%c requires an argument specifying the mutation standard deviation.\n", optopt);
+      else if (isprint(optopt))
+        fprintf(stderr, "Unknown option `-%c'.\n", optopt);
+      else
+        fprintf(stderr,
+                "Unknown option character `\\x%x'.\n",
+                optopt);
+      return 1;
+    default:
+      printf("Usage: %s -p {population size} -g {number of generations} -t {number of trials} -c {crossover rate} -m {mutation rate} -s {mutation standard deviation}", argv[0]);
+      abort();
+    }
 
   if (experiment_path.empty())
-    {
-      printf("Usage: %s -p {population size} -g {number of generations} -t {number of trials} -c {crossover rate} -m {mutation rate} -s {mutation standard deviation} -x {argos experiment file}\n", argv[0]);
-      exit(1);
-    }
+  {
+    printf("Usage: %s -p {population size} -g {number of generations} -t {number of trials} -c {crossover rate} -m {mutation rate} -s {mutation standard deviation} -x {argos experiment file}\n", argv[0]);
+    exit(1);
+  }
 
   float max_float = std::numeric_limits<float>::max();
 
-    //printf("%s:\tworker %d ready.\n", hostname, mpi_rank);                                          
+  // printf("%s:\tworker %d ready.\n", hostname, mpi_rank);
 
   // See if we've been given a seed to use (for testing purposes).  When you
   // specify a random seed, the evolution will be exactly the same each time
   // you use that seed number
   unsigned int seed = 12345;
-  for(int i=1 ; i<argc ; i++)
-    if(strcmp(argv[i++],"seed") == 0)
+  for (int i = 1; i < argc; i++)
+    if (strcmp(argv[i++], "seed") == 0)
       seed = atoi(argv[i]);
 
   srand(seed);
   generator.seed(seed);
   // popsize / mpi_tasks must be an integer
-  population_size = mpi_tasks * int((double)population_size/(double)mpi_tasks+0.999);
-  
-  if (mpi_rank==0)
-    {
-      printf("Population size: %d\nNumber of trials: %d\nNumber of generations: %d\nCrossover rate: %f\nMutation rate: %f\nMutation stdev: %f\nAllocated MPI workers: %d\n", population_size, n_trials, n_generations, crossover_rate, mutation_rate, mutation_stdev, mpi_tasks);
-      	printf("elitism: %d\n", elitism);
-    }
+  population_size = mpi_tasks * int((double)population_size / (double)mpi_tasks + 0.999);
+
+  if (mpi_rank == 0)
+  {
+    printf("Population size: %d\nNumber of trials: %d\nNumber of generations: %d\nCrossover rate: %f\nMutation rate: %f\nMutation stdev: %f\nAllocated MPI workers: %d\n", population_size, n_trials, n_generations, crossover_rate, mutation_rate, mutation_stdev, mpi_tasks);
+    printf("elitism: %d\n", elitism);
+  }
 
   // Define the genome
   GARealAlleleSetArray allele_array;
-  
-  allele_array.add(0, 1.0); // Probability of switching to search
-  allele_array.add(0, 1.0); // Probability of returning to nest
-  allele_array.add(0, 4*M_PI); // Uninformed search variation
-  allele_array.add(0, 20); // Rate of informed search decay
-  allele_array.add(0, 20); // Rate of site fidelity
-  allele_array.add(0, 20); // Rate of laying pheremone
-  allele_array.add(0, 20); // Rate of pheremone decay
-  
-    
+
+  allele_array.add(0, 1.0);      // Probability of switching to search
+  allele_array.add(0, 1.0);      // Probability of returning to nest
+  allele_array.add(0, 4 * M_PI); // Uninformed search variation
+  allele_array.add(0, 20);       // Rate of informed search decay
+  allele_array.add(0, 20);       // Rate of site fidelity
+  allele_array.add(0, 20);       // Rate of laying pheremone
+  allele_array.add(0, 20);       // Rate of pheremone decay
+
   // Create the template genome using the phenotype map we just made.
   GARealGenome genome(allele_array, objective);
   genome.crossover(GARealUniformCrossover);
   genome.mutator(GARealGaussianMutatorStdev); // Specify our version of the Gaussuan mutator
   genome.initializer(CPFAInitializer);
- 
+
   // Now create the GA using the genome and run it.
   GASimpleGA ga(genome);
   GALinearScaling scaling;
-  ga.maximize();		// Maximize the objective
- 
+  ga.maximize(); // Maximize the objective
+
   ga.populationSize(population_size);
   ga.nGenerations(n_generations);
   ga.pMutation(mutation_rate);
@@ -190,7 +189,7 @@ int main(int argc, char **argv)
     ga.elitist(gaTrue);
   else
     ga.elitist(gaFalse);
-  if(mpi_rank == 0)
+  if (mpi_rank == 0)
     ga.scoreFilename("evolution.txt");
   else
     ga.scoreFilename("/dev/null");
@@ -198,338 +197,363 @@ int main(int argc, char **argv)
   ga.scoreFrequency(1);
   ga.flushFrequency(1);
   ga.selectScores(GAStatistics::AllScores);
-  
+
   // Pass MPI data to the GA class
   ga.mpi_rank(mpi_rank);
   ga.mpi_tasks(mpi_tasks);
-  //ga.evolve(seed); // Manual generations
+  // ga.evolve(seed); // Manual generations
 
-// initialize the ga since we are not using the evolve function
+  // initialize the ga since we are not using the evolve function
   ga.initialize(seed); // This is essential for the mpi workers to be sychronized
 
-    // Name the results file with the current time and date
- time_t t = time(0);   // get time now
-    struct tm * now = localtime( & t );
-    stringstream ss;
+  // Name the results file with the current time and date
+  time_t t = time(0); // get time now
+  struct tm *now = localtime(&t);
+  stringstream ss;
 
-    boost::filesystem::path exp_path(experiment_path);
-    
-    ss << "results/CPFA-evolution-"
-       << exp_path.stem().string() << '-'
-       <<GIT_BRANCH<<"-"<<GIT_COMMIT_HASH<<"-"
-       << (now->tm_year) << '-'
-       << (now->tm_mon + 1) << '-'
-       <<  now->tm_mday << '-'
-       <<  now->tm_hour << '-'
-       <<  now->tm_min << '-'
-       <<  now->tm_sec << ".csv";
+  boost::filesystem::path exp_path(experiment_path);
 
-    string results_file_name = ss.str();
+  ss << "results/CPFA-evolution-"
+     << exp_path.stem().string() << '-'
+     << GIT_BRANCH << "-" << GIT_COMMIT_HASH << "-"
+     << (now->tm_year) << '-'
+     << (now->tm_mon + 1) << '-'
+     << now->tm_mday << '-'
+     << now->tm_hour << '-'
+     << now->tm_min << '-'
+     << now->tm_sec << ".csv";
 
-    if (mpi_rank == 0)
-      {
+  string results_file_name = ss.str();
+
+  if (mpi_rank == 0)
+  {
     // Write output file header
     ofstream results_output_stream;
-	results_output_stream.open(results_file_name, ios::app);
-	results_output_stream << "Population size: " << population_size << "\nNumber of trials: " << n_trials << "\nNumber of generations: "<< n_generations<<"\nCrossover rate: "<< crossover_rate<<"\nMutation rate: " << mutation_rate << "\nMutation stdev: "<< mutation_stdev << "Algorithm: CPFA\n" << "Number of searchers: 6\n" << "Number of targets: 256\n" << "Target distribution: power law" << endl;
-	results_output_stream << "Generation" 
-			      << ", " << "Compute Time (s)"
-			      << ", " << "Convergence"
-			      << ", " << "Mean"
-			      << ", " << "Maximum"
-			      << ", " << "Minimum"
-			      << ", " << "Standard Deviation"
-			      << ", " << "Diversity"
-			      << ", " << "ProbabilityOfSwitchingToSearching"
-			      << ", " << "ProbabilityOfReturningToNest"
-			      << ", " << "UninformedSearchVariation"
-			      << ", " << "RateOfInformedSearchDecay"
-			      << ", " << "RateOfSiteFidelity"
-			      << ", " << "RateOfLayingPheromone"
-			      << ", " << "RateOfPheromoneDecay";
+    results_output_stream.open(results_file_name, ios::app);
+    results_output_stream << "Population size: " << population_size << "\nNumber of trials: " << n_trials << "\nNumber of generations: " << n_generations << "\nCrossover rate: " << crossover_rate << "\nMutation rate: " << mutation_rate << "\nMutation stdev: " << mutation_stdev << "Algorithm: CPFA\n"
+                          << "Number of searchers: 6\n"
+                          << "Number of targets: 256\n"
+                          << "Target distribution: power law" << endl;
+    results_output_stream << "Generation"
+                          << ", "
+                          << "Compute Time (s)"
+                          << ", "
+                          << "Convergence"
+                          << ", "
+                          << "Mean"
+                          << ", "
+                          << "Maximum"
+                          << ", "
+                          << "Minimum"
+                          << ", "
+                          << "Standard Deviation"
+                          << ", "
+                          << "Diversity"
+                          << ", "
+                          << "ProbabilityOfSwitchingToSearching"
+                          << ", "
+                          << "ProbabilityOfReturningToNest"
+                          << ", "
+                          << "UninformedSearchVariation"
+                          << ", "
+                          << "RateOfInformedSearchDecay"
+                          << ", "
+                          << "RateOfSiteFidelity"
+                          << ", "
+                          << "RateOfLayingPheromone"
+                          << ", "
+                          << "RateOfPheromoneDecay";
 
-	results_output_stream << endl;
-	results_output_stream.close();
-      }
+    results_output_stream << endl;
+    results_output_stream.close();
+  }
 
-	while(!ga.done())
-	  {
+  while (!ga.done())
+  {
 
-	    std::chrono::time_point<std::chrono::system_clock>generation_start, generation_end;
-	    if (mpi_rank == 0)
-	      {
-		generation_start = std::chrono::system_clock::now();
-	      }
-	    
-      // Calculate the generation
-      ga.step();
+    std::chrono::time_point<std::chrono::system_clock> generation_start, generation_end;
+    if (mpi_rank == 0)
+    {
+      generation_start = std::chrono::system_clock::now();
+    }
 
-    if(mpi_rank == 0)
-      {
-	generation_end = std::chrono::system_clock::now();
-	std::chrono::duration<double> generation_elapsed_seconds = generation_end-generation_start;
-	ofstream results_output_stream;
-	results_output_stream.open(results_file_name, ios::app);
-       results_output_stream << ga.statistics().generation() 
-			     << ", " << generation_elapsed_seconds.count()
-			     << ", " << ga.statistics().convergence()
-			     << ", " << ga.statistics().current(GAStatistics::Mean)
-			     << ", " << ga.statistics().current(GAStatistics::Maximum)
-			     << ", " << ga.statistics().current(GAStatistics::Minimum)
-			     << ", " << ga.statistics().current(GAStatistics::Deviation)
-			     << ", " << ga.statistics().current(GAStatistics::Diversity);
-       
-	  for (int i = 0; i < GENOME_SIZE; i++)
-	    results_output_stream << ", " << dynamic_cast<const GARealGenome&>(ga.population().best()).gene(i);
+    // Calculate the generation
+    ga.step();
 
-	  
-	  const GARealGenome& best_genome = dynamic_cast<const GARealGenome&>(ga.statistics().bestIndividual());
-	  results_output_stream << endl;
-	  
-	  results_output_stream << "The GA found an optimum at: ";
-	  results_output_stream << best_genome.gene(0);
-	  for (int i = 1; i < GENOME_SIZE; i++)
-	    results_output_stream << ", " << best_genome.gene(i);
-	  results_output_stream << " with score: " << best_genome.score();
-	  results_output_stream << endl;
-	  results_output_stream.close();
-      }
-	  }
-	// Display the GA's progress
-	if(mpi_rank == 0)
-	  {
-	    cout << ga.statistics() << " " << ga.parameters() << endl;
-	  }
-	
+    if (mpi_rank == 0)
+    {
+      generation_end = std::chrono::system_clock::now();
+      std::chrono::duration<double> generation_elapsed_seconds = generation_end - generation_start;
+      ofstream results_output_stream;
+      results_output_stream.open(results_file_name, ios::app);
+      results_output_stream << ga.statistics().generation()
+                            << ", " << generation_elapsed_seconds.count()
+                            << ", " << ga.statistics().convergence()
+                            << ", " << ga.statistics().current(GAStatistics::Mean)
+                            << ", " << ga.statistics().current(GAStatistics::Maximum)
+                            << ", " << ga.statistics().current(GAStatistics::Minimum)
+                            << ", " << ga.statistics().current(GAStatistics::Deviation)
+                            << ", " << ga.statistics().current(GAStatistics::Diversity);
+
+      for (int i = 0; i < GENOME_SIZE; i++)
+        results_output_stream << ", " << dynamic_cast<const GARealGenome &>(ga.population().best()).gene(i);
+
+      const GARealGenome &best_genome = dynamic_cast<const GARealGenome &>(ga.statistics().bestIndividual());
+      results_output_stream << endl;
+
+      results_output_stream << "The GA found an optimum at: ";
+      results_output_stream << best_genome.gene(0);
+      for (int i = 1; i < GENOME_SIZE; i++)
+        results_output_stream << ", " << best_genome.gene(i);
+      results_output_stream << " with score: " << best_genome.score();
+      results_output_stream << endl;
+      results_output_stream.close();
+    }
+  }
+  // Display the GA's progress
+  if (mpi_rank == 0)
+  {
+    cout << ga.statistics() << " " << ga.parameters() << endl;
+  }
+
   MPI_Finalize();
 
   program_end = std::chrono::system_clock::now();
- 
-  std::chrono::duration<double> program_elapsed_seconds = program_end-program_start;
 
-  if(mpi_rank == 0)
+  std::chrono::duration<double> program_elapsed_seconds = program_end - program_start;
+
+  if (mpi_rank == 0)
     printf("Run time was %f seconds\n", program_elapsed_seconds.count());
 
   return 0;
-  }
+}
 
-// Initializes the genome according to the Beyond Pheromones paper 
-void CPFAInitializer(GAGenome & c)
+// Initializes the genome according to the Beyond Pheromones paper
+void CPFAInitializer(GAGenome &c)
 {
   // For the exponential PDF needed to initialize some of the genes
-  
+
   std::exponential_distribution<double> exponential_distribution_10(10.0);
   std::exponential_distribution<double> exponential_distribution_5(5.0);
   std::uniform_real_distribution<double> uniform_distribution_0_1(0.0, 1.0);
-  std::uniform_real_distribution<double> uniform_distribution_0_4PI(0.0, 4.0*M_PI);
+  std::uniform_real_distribution<double> uniform_distribution_0_4PI(0.0, 4.0 * M_PI);
   std::uniform_real_distribution<double> uniform_distribution_0_20(0.0, 20.0);
 
-  GA1DArrayAlleleGenome<float> &child= DYN_CAST(GA1DArrayAlleleGenome<float> &, c);
+  GA1DArrayAlleleGenome<float> &child = DYN_CAST(GA1DArrayAlleleGenome<float> &, c);
   child.resize(GAGenome::ANY_SIZE); // let chrom resize if it can
-  
-  child.gene(0, uniform_distribution_0_1(generator)); // Probability of switching to search
-  child.gene(1, uniform_distribution_0_1(generator)); // Probability of returning to nest
-  child.gene(2, uniform_distribution_0_4PI(generator)); // Uninformed search variation
-  child.gene(3, exponential_distribution_5(generator)); // Rate of informed search decay
-  child.gene(4, uniform_distribution_0_20(generator)); // Rate of site fidelity
-  child.gene(5, uniform_distribution_0_20(generator)); // Rate of laying pheremone
+
+  child.gene(0, uniform_distribution_0_1(generator));    // Probability of switching to search
+  child.gene(1, uniform_distribution_0_1(generator));    // Probability of returning to nest
+  child.gene(2, uniform_distribution_0_4PI(generator));  // Uninformed search variation
+  child.gene(3, exponential_distribution_5(generator));  // Rate of informed search decay
+  child.gene(4, uniform_distribution_0_20(generator));   // Rate of site fidelity
+  child.gene(5, uniform_distribution_0_20(generator));   // Rate of laying pheremone
   child.gene(6, exponential_distribution_10(generator)); // Rate of pheremone decay
 }
 
 // The mutation operator based on the original from GALib but adds stdev
 // The Gaussian mutator picks a new value based on a Gaussian distribution
 // around the current value.  We respect the bounds (if any).
-int GARealGaussianMutatorStdev(GAGenome& g, float pmut)
+int GARealGaussianMutatorStdev(GAGenome &g, float pmut)
 {
-  GA1DArrayAlleleGenome<float> &child=
-    DYN_CAST(GA1DArrayAlleleGenome<float> &, g);
-  register int n, i;
-  if(pmut <= 0.0) return(0);
+  GA1DArrayAlleleGenome<float> &child =
+      DYN_CAST(GA1DArrayAlleleGenome<float> &, g);
+  int n, i;
+  if (pmut <= 0.0)
+    return (0);
 
   float nMut = pmut * (float)(child.length());
-  int length = child.length()-1;
-  if(nMut < 1.0){// we have to do a flip test on each element
+  int length = child.length() - 1;
+  if (nMut < 1.0)
+  { // we have to do a flip test on each element
     nMut = 0;
-    for(i=length; i>=0; i--){
+    for (i = length; i >= 0; i--)
+    {
       float value = child.gene(i);
-      if(GAFlipCoin(pmut)){
-	if(child.alleleset(i).type() == GAAllele::ENUMERATED ||
-	   child.alleleset(i).type() == GAAllele::DISCRETIZED)
-	  value = child.alleleset(i).allele();
-	else if(child.alleleset(i).type() == GAAllele::BOUNDED){
-	  value += GAUnitGaussian()*mutation_stdev;//*(child.alleleset(i).upper()-child.alleleset(i).lower()); // since the standard deviation varies proportionally to a constant multiplier 
-	  value = GAMax(child.alleleset(i).lower(), value);
-	  value = GAMin(child.alleleset(i).upper(), value);
-	}
-	child.gene(i, value);
-	nMut++;
+      if (GAFlipCoin(pmut))
+      {
+        if (child.alleleset(i).type() == GAAllele::ENUMERATED ||
+            child.alleleset(i).type() == GAAllele::DISCRETIZED)
+          value = child.alleleset(i).allele();
+        else if (child.alleleset(i).type() == GAAllele::BOUNDED)
+        {
+          value += GAUnitGaussian() * mutation_stdev; //*(child.alleleset(i).upper()-child.alleleset(i).lower()); // since the standard deviation varies proportionally to a constant multiplier
+          value = GAMax(child.alleleset(i).lower(), value);
+          value = GAMin(child.alleleset(i).upper(), value);
+        }
+        child.gene(i, value);
+        nMut++;
       }
     }
   }
-  else{// only mutate the ones we need to
-    for(n=0; n<nMut; n++){
-      int idx = GARandomInt(0,length);
+  else
+  { // only mutate the ones we need to
+    for (n = 0; n < nMut; n++)
+    {
+      int idx = GARandomInt(0, length);
       float value = child.gene(idx);
-      if(child.alleleset(idx).type() == GAAllele::ENUMERATED ||
-	 child.alleleset(idx).type() == GAAllele::DISCRETIZED)
-	value = child.alleleset(idx).allele();
-      else if(child.alleleset(idx).type() == GAAllele::BOUNDED){
-	value += GAUnitGaussian()*mutation_stdev*(child.alleleset(i).upper()-child.alleleset(i).lower()); // since the standard deviation varies proportionally to a constant multiplier 
-	value = GAMax(child.alleleset(idx).lower(), value);
-	value = GAMin(child.alleleset(idx).upper(), value);
+      if (child.alleleset(idx).type() == GAAllele::ENUMERATED ||
+          child.alleleset(idx).type() == GAAllele::DISCRETIZED)
+        value = child.alleleset(idx).allele();
+      else if (child.alleleset(idx).type() == GAAllele::BOUNDED)
+      {
+        value += GAUnitGaussian() * mutation_stdev * (child.alleleset(i).upper() - child.alleleset(i).lower()); // since the standard deviation varies proportionally to a constant multiplier
+        value = GAMax(child.alleleset(idx).lower(), value);
+        value = GAMin(child.alleleset(idx).upper(), value);
       }
       child.gene(idx, value);
     }
   }
-  return((int)nMut);
+  return ((int)nMut);
 }
-
 
 float objective(GAGenome &c)
 {
   float avg = 0;
-  
+
   // For timing
   std::chrono::time_point<std::chrono::system_clock> start, end;
   start = std::chrono::system_clock::now();
 
-  for (int i = 0; i < n_trials; i++) avg += LaunchARGoS(c);
-  
+  for (int i = 0; i < n_trials; i++)
+    avg += LaunchARGoS(c);
+
   avg /= n_trials;
 
-  
   end = std::chrono::system_clock::now();
-  
-  std::chrono::duration<double> elapsed_seconds = end-start;
 
-  MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);     
+  std::chrono::duration<double> elapsed_seconds = end - start;
 
-      char hostname[1024];              
-      hostname[1023] = '\0';                                          
-      gethostname(hostname, 1023);     
- 
-      /*
-      printf("Worker %d on %s evaluated genome [", mpi_rank, hostname);
-      for (int i = 0; i < GENOME_SIZE; i++)
-	printf("%f ",dynamic_cast<const GARealGenome&>(c).gene(i));
-      printf("] in %f seconds. ", elapsed_seconds.count());
-      printf("Fitness: %f.\n", avg );
-      */
+  MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
 
-      return avg;
+  char hostname[1024];
+  hostname[1023] = '\0';
+  gethostname(hostname, 1023);
+
+  /*
+  printf("Worker %d on %s evaluated genome [", mpi_rank, hostname);
+  for (int i = 0; i < GENOME_SIZE; i++)
+printf("%f ",dynamic_cast<const GARealGenome&>(c).gene(i));
+  printf("] in %f seconds. ", elapsed_seconds.count());
+  printf("Fitness: %f.\n", avg );
+  */
+
+  return avg;
 }
 
 /*
  * Launch ARGoS to evaluate a genome.
  */
-float LaunchARGoS(GAGenome& c_genome) 
+float LaunchARGoS(GAGenome &c_genome)
 {
   // Declate the fitness value and the shared memory segment id and address
   float fitness = 0;
-  int    ShmID;
-  float*   ShmPTR;
-  
+  int ShmID;
+  float *ShmPTR;
+
   // Allocate the shared memory to use between this process and the child argos process
   ShmID = shmget(IPC_PRIVATE, sizeof(float), IPC_CREAT | 0666);
-  if (ShmID < 0) {
+  if (ShmID < 0)
+  {
     printf("ERROR: Allocating shared memory segment in main.cpp:LaunchARGoS() failed.\n");
     exit(1);
   }
-  
+
   // Attach to the shared memory segment
-  ShmPTR = (float*) shmat(ShmID, NULL, 0);
-  if ((float*) ShmPTR == (float*)-1) 
-    {
-      printf("ERROR: Attaching to shared memory segment in main.cpp:LaunchARGoS() failed.\n");
-      exit(1);
-    }
+  ShmPTR = (float *)shmat(ShmID, NULL, 0);
+  if ((float *)ShmPTR == (float *)-1)
+  {
+    printf("ERROR: Attaching to shared memory segment in main.cpp:LaunchARGoS() failed.\n");
+    exit(1);
+  }
 
   *ShmPTR = 0; // Initialise
 
   pid_t pid = fork(); // Create the new process with a copy of this memory space
 
   if (pid == 0)
-    {
-      // In child process - run the argos3 simulation
+  {
+    // In child process - run the argos3 simulation
 
-      /* Convert the received genome to the actual genome type */
-      GARealGenome& cRealGenome = dynamic_cast<GARealGenome&>(c_genome);
-  
-      Real* cpfa_genome = new Real[GENOME_SIZE];
+    /* Convert the received genome to the actual genome type */
+    GARealGenome &cRealGenome = dynamic_cast<GARealGenome &>(c_genome);
 
-      // Convert to a convenient format for the argos controller
-      for (int i = 0; i < GENOME_SIZE; i++)
-	cpfa_genome[i] = cRealGenome.gene(i);
-       
-      /*      
-      printf("%s: worker %d started a genome evaluation. (%f, %f, %f, %f, %f, %f, %f)\n", hostname, mpi_rank, 
-	     cpfa_genome[0],
-	     cpfa_genome[1],
-	     cpfa_genome[2],
-	     cpfa_genome[3],
-	     cpfa_genome[4],
-	     cpfa_genome[5],
-	     cpfa_genome[6]);
-      */
+    Real *cpfa_genome = new Real[GENOME_SIZE];
 
-      /* Redirect LOG and LOGERR to dedicated files to prevent clutter on the screen */
-      std::ofstream cLOGFile("argos_logs/ARGoS_LOG_" + ToString(::getpid()), std::ios::out);
-      LOG.DisableColoredOutput();
-      LOG.GetStream().rdbuf(cLOGFile.rdbuf());
-      std::ofstream cLOGERRFile("argos_logs/ARGoS_LOGERR_" + ToString(::getpid()), std::ios::out);
-      LOGERR.DisableColoredOutput();
-      LOGERR.GetStream().rdbuf(cLOGERRFile.rdbuf());
+    // Convert to a convenient format for the argos controller
+    for (int i = 0; i < GENOME_SIZE; i++)
+      cpfa_genome[i] = cRealGenome.gene(i);
 
-      /*
-       * Initialize ARGoS
-       */
-      /* The CSimulator class of ARGoS is a singleton. Therefore, to
-       * manipulate an ARGoS experiment, it is enough to get its instance */
-      argos::CSimulator& cSimulator = argos::CSimulator::GetInstance();
+    /*
+    printf("%s: worker %d started a genome evaluation. (%f, %f, %f, %f, %f, %f, %f)\n", hostname, mpi_rank,
+     cpfa_genome[0],
+     cpfa_genome[1],
+     cpfa_genome[2],
+     cpfa_genome[3],
+     cpfa_genome[4],
+     cpfa_genome[5],
+     cpfa_genome[6]);
+    */
 
-      // Set the .argos configuration file
-      cSimulator.SetExperimentFileName(experiment_path);
-      
-      // Load it to configure ARGoS 
-      cSimulator.LoadExperiment();
+    /* Redirect LOG and LOGERR to dedicated files to prevent clutter on the screen */
+    std::ofstream cLOGFile("argos_logs/ARGoS_LOG_" + ToString(::getpid()), std::ios::out);
+    LOG.DisableColoredOutput();
+    LOG.GetStream().rdbuf(cLOGFile.rdbuf());
+    std::ofstream cLOGERRFile("argos_logs/ARGoS_LOGERR_" + ToString(::getpid()), std::ios::out);
+    LOGERR.DisableColoredOutput();
+    LOGERR.GetStream().rdbuf(cLOGERRFile.rdbuf());
 
-      // Get a reference to the loop functions
-      CPFA_loop_functions& cLoopFunctions = dynamic_cast<CPFA_loop_functions&>(cSimulator.GetLoopFunctions());
+    /*
+     * Initialize ARGoS
+     */
+    /* The CSimulator class of ARGoS is a singleton. Therefore, to
+     * manipulate an ARGoS experiment, it is enough to get its instance */
+    argos::CSimulator &cSimulator = argos::CSimulator::GetInstance();
 
-      // Configure the controller with the genome
-      cLoopFunctions.ConfigureFromGenome(cpfa_genome);
+    // Set the .argos configuration file
+    cSimulator.SetExperimentFileName(experiment_path);
 
-      // Run the experiment
-      cSimulator.Execute();
+    // Load it to configure ARGoS
+    cSimulator.LoadExperiment();
 
-      // Update performance and store in the shared memory segment
-      *ShmPTR = cLoopFunctions.Score();;
+    // Get a reference to the loop functions
+    CPFA_loop_functions &cLoopFunctions = dynamic_cast<CPFA_loop_functions &>(cSimulator.GetLoopFunctions());
 
-      // For testing
-      //float score = 0;
-      //for (int i = 0; i < GENOME_SIZE; i++) score += cpfa_genome[i];
-      //*ShmPTR = score;
+    // Configure the controller with the genome
+    cLoopFunctions.ConfigureFromGenome(cpfa_genome);
 
-      // Clean up the simulation
-      cSimulator.Destroy();
-      
-      // Clean up the temp genome copy
-	delete [] cpfa_genome;
+    // Run the experiment
+    cSimulator.Execute();
 
-	// Make this process exit
-      _Exit(0); 
-    }
-  
+    // Update performance and store in the shared memory segment
+    *ShmPTR = cLoopFunctions.Score();
+    ;
+
+    // For testing
+    // float score = 0;
+    // for (int i = 0; i < GENOME_SIZE; i++) score += cpfa_genome[i];
+    //*ShmPTR = score;
+
+    // Clean up the simulation
+    cSimulator.Destroy();
+
+    // Clean up the temp genome copy
+    delete[] cpfa_genome;
+
+    // Make this process exit
+    _Exit(0);
+  }
+
   // In parent - wait for child to finish
   int status = wait(&status);
 
   // Make a local copy of the shared fitness value
-  fitness = *ShmPTR;  
+  fitness = *ShmPTR;
 
   // Release shared memory
-  shmdt((void *) ShmPTR);
+  shmdt((void *)ShmPTR);
   shmctl(ShmID, IPC_RMID, NULL);
 
-  /* Return the result of the evaluation */  
+  /* Return the result of the evaluation */
   return fitness;
 }

--- a/Dynamic_MPFA/source/ga-mpi/GA1DArrayGenome.C
+++ b/Dynamic_MPFA/source/ga-mpi/GA1DArrayGenome.C
@@ -18,7 +18,7 @@
 #include <ga-mpi/GA1DArrayGenome.h>
 #include <ga-mpi/GAMask.h>
 
-template <class T> int 
+template <class T> int
 GA1DArrayIsHole(const GA1DArrayGenome<T>&, const GA1DArrayGenome<T>&,
 		int, int, int);
 
@@ -36,15 +36,15 @@ GA1DArrayGenome<T>::classID() const {return GAID::ArrayGenome;}
 // this point - initialization must be done explicitly by the user of the
 // genome (eg when the population is created or reset).  If we called the
 // initializer routine here then we could end up with multiple initializations
-// and/or calls to dummy initializers (for example when the genome is 
+// and/or calls to dummy initializers (for example when the genome is
 // created with a dummy initializer and the initializer is assigned later on).
 // Besides, we default to the no-initialization initializer by calling the
 // default genome constructor.
-template <class T> 
+template <class T>
 GA1DArrayGenome<T>::
 GA1DArrayGenome(unsigned int length, GAGenome::Evaluator f, void * u) :
 GAArray<T>(length),
-GAGenome(DEFAULT_1DARRAY_INITIALIZER, 
+GAGenome(DEFAULT_1DARRAY_INITIALIZER,
 	 DEFAULT_1DARRAY_MUTATOR,
 	 DEFAULT_1DARRAY_COMPARATOR) {
   evaluator(f);
@@ -56,9 +56,9 @@ GAGenome(DEFAULT_1DARRAY_INITIALIZER,
 
 // This is the copy initializer.  We set everything to the default values, then
 // copy the original.  The Array creator takes care of zeroing the data.
-template <class T> 
+template <class T>
 GA1DArrayGenome<T>::
-GA1DArrayGenome(const GA1DArrayGenome<T> & orig) : 
+GA1DArrayGenome(const GA1DArrayGenome<T> & orig) :
 GAArray<T>(orig.sz), GAGenome() {
   GA1DArrayGenome<T>::copy(orig);
 }
@@ -74,7 +74,7 @@ GA1DArrayGenome<T>::~GA1DArrayGenome() { }
 // what we define here - a virtual function).  We should check to be sure that
 // both genomes are the same class and same dimension.  This function tries
 // to be smart about they way it copies.  If we already have data, then we do
-// a memcpy of the one we're supposed to copy.  If we don't or we're not the 
+// a memcpy of the one we're supposed to copy.  If we don't or we're not the
 // same size as the one we're supposed to copy, then we adjust ourselves.
 //   The Array takes care of the resize in its copy method.
 template <class T> void
@@ -92,7 +92,7 @@ GA1DArrayGenome<T>::copy(const GAGenome & orig){
 template <class T> GAGenome *
 GA1DArrayGenome<T>::clone(GAGenome::CloneMethod flag) const {
   GA1DArrayGenome<T> *cpy = new GA1DArrayGenome<T>(nx);
-  if(flag == CONTENTS){ 
+  if(flag == CONTENTS){
     cpy->copy(*this);
   }
   else{
@@ -110,10 +110,10 @@ GA1DArrayGenome<T>::clone(GAGenome::CloneMethod flag) const {
 // length, then we don't do anything.
 //   We pay attention to the values of minX and maxX - they determine what kind
 // of resizing we are allowed to do.  If a resize is requested with a length
-// less than the min length specified by the behaviour, we set the minimum 
+// less than the min length specified by the behaviour, we set the minimum
 // to the length.  If the length is longer than the max length specified by
 // the behaviour, we set the max value to the length.
-//   We return the total size (in bits) of the genome after resize. 
+//   We return the total size (in bits) of the genome after resize.
 //   We don't do anything to the new contents!
 template <class T> int
 GA1DArrayGenome<T>::resize(int len)
@@ -160,7 +160,7 @@ GA1DArrayGenome<T>::write(STD_OSTREAM & os) const {
 //   Set the resize behaviour of the genome.  A genome can be fixed
 // length, resizeable with a max and min limit, or resizeable with no limits
 // (other than an implicit one that we use internally).
-//   A value of 0 means no resize, a value less than zero mean unlimited 
+//   A value of 0 means no resize, a value less than zero mean unlimited
 // resize, and a positive value means resize with that value as the limit.
 template <class T> int
 GA1DArrayGenome<T>::
@@ -183,7 +183,7 @@ GA1DArrayGenome<T>::resizeBehaviour() const {
   return val;
 }
 
-template <class T> int 
+template <class T> int
 GA1DArrayGenome<T>::equal(const GAGenome & c) const {
   const GA1DArrayGenome<T> & b = DYN_CAST(const GA1DArrayGenome<T> &, c);
   return((this == &c) ? 1 : ((nx != b.nx) ? 0 : GAArray<T>::equal(b,0,0,nx)));
@@ -205,7 +205,7 @@ its own, independent allele set.  If we clone a new genome, the new one gets a
 link to our allele set (so we don't end up with zillions of allele sets).  Same
 is true for the copy constructor.
   The array may have a single allele set or an array of allele sets, depending
-on which creator was called.  Either way, the allele set cannot be changed 
+on which creator was called.  Either way, the allele set cannot be changed
 once the array is created.
 ---------------------------------------------------------------------------- */
 template <class T> const char *
@@ -213,7 +213,7 @@ GA1DArrayAlleleGenome<T>::className() const {return "GA1DArrayAlleleGenome";}
 template <class T> int
 GA1DArrayAlleleGenome<T>::classID() const {return GAID::ArrayAlleleGenome;}
 
-template <class T> 
+template <class T>
 GA1DArrayAlleleGenome<T>::
 GA1DArrayAlleleGenome(unsigned int length, const GAAlleleSet<T> & s,
 		      GAGenome::Evaluator f, void * u) :
@@ -228,7 +228,7 @@ GA1DArrayGenome<T>(length, f, u){
   this->crossover(GA1DArrayAlleleGenome<T>::DEFAULT_1DARRAY_ALLELE_CROSSOVER);
 }
 
-template <class T> 
+template <class T>
 GA1DArrayAlleleGenome<T>::
 GA1DArrayAlleleGenome(const GAAlleleSetArray<T> & sa,
 		      GAGenome::Evaluator f, void * u) :
@@ -247,9 +247,9 @@ GA1DArrayGenome<T>(sa.size(), f, u) {
 
 // The copy constructor creates a new genome whose allele set refers to the
 // original's allele set.
-template <class T> 
+template <class T>
 GA1DArrayAlleleGenome<T>::
-GA1DArrayAlleleGenome(const GA1DArrayAlleleGenome<T>& orig) : 
+GA1DArrayAlleleGenome(const GA1DArrayAlleleGenome<T>& orig) :
 GA1DArrayGenome<T>(orig.sz) {
   naset = 0;
   aset = (GAAlleleSet<T>*)0;
@@ -265,7 +265,7 @@ GA1DArrayAlleleGenome<T>::~GA1DArrayAlleleGenome(){
 
 
 // This implementation of clone does not make use of the contents/attributes
-// capability because this whole interface isn't quite right yet...  Just 
+// capability because this whole interface isn't quite right yet...  Just
 // clone the entire thing, contents and all.
 template <class T> GAGenome *
 GA1DArrayAlleleGenome<T>::clone(GAGenome::CloneMethod) const {
@@ -273,10 +273,10 @@ GA1DArrayAlleleGenome<T>::clone(GAGenome::CloneMethod) const {
 }
 
 
-template <class T> void 
+template <class T> void
 GA1DArrayAlleleGenome<T>::copy(const GAGenome& orig){
   if(&orig == this) return;
-  const GA1DArrayAlleleGenome<T> * c = 
+  const GA1DArrayAlleleGenome<T> * c =
     DYN_CAST(const GA1DArrayAlleleGenome<T>*, &orig);
   if(c) {
     GA1DArrayGenome<T>::copy(*c);
@@ -339,7 +339,7 @@ GA1DArrayAlleleGenome<T>::equal(const GAGenome & c) const {
 ---------------------------------------------------------------------------- */
 // The random initializer sets the elements of the array based on the alleles
 // set.  We choose randomly the allele for each element.
-template <class ARRAY_TYPE> void 
+template <class ARRAY_TYPE> void
 GA1DArrayAlleleGenome<ARRAY_TYPE>::UniformInitializer(GAGenome & c)
 {
   GA1DArrayAlleleGenome<ARRAY_TYPE> &child=
@@ -354,7 +354,7 @@ GA1DArrayAlleleGenome<ARRAY_TYPE>::UniformInitializer(GAGenome & c)
 // and assign each element the next allele in the allele set.  Once each
 // element has been initialized, scramble the contents by swapping elements.
 // This assumes that there is only one allele set for the array.
-template <class ARRAY_TYPE> void 
+template <class ARRAY_TYPE> void
 GA1DArrayAlleleGenome<ARRAY_TYPE>::OrderedInitializer(GAGenome & c)
 {
   GA1DArrayAlleleGenome<ARRAY_TYPE> &child=
@@ -372,15 +372,15 @@ GA1DArrayAlleleGenome<ARRAY_TYPE>::OrderedInitializer(GAGenome & c)
 }
 
 
-// Randomly pick elements in the array then set the element to any of the 
+// Randomly pick elements in the array then set the element to any of the
 // alleles in the allele set for this genome.  This will work for any number
 // of allele sets for a given array.
-template <class ARRAY_TYPE> int 
+template <class ARRAY_TYPE> int
 GA1DArrayAlleleGenome<ARRAY_TYPE>::FlipMutator(GAGenome & c, float pmut)
 {
   GA1DArrayAlleleGenome<ARRAY_TYPE> &child=
     DYN_CAST(GA1DArrayAlleleGenome<ARRAY_TYPE> &, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.length());
@@ -404,11 +404,11 @@ GA1DArrayAlleleGenome<ARRAY_TYPE>::FlipMutator(GAGenome & c, float pmut)
 
 
 // Randomly swap elements in the array.
-template <class ARRAY_TYPE> int 
+template <class ARRAY_TYPE> int
 GA1DArrayGenome<ARRAY_TYPE>::SwapMutator(GAGenome & c, float pmut)
 {
   GA1DArrayGenome<ARRAY_TYPE> &child=DYN_CAST(GA1DArrayGenome<ARRAY_TYPE>&, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.length());
@@ -469,7 +469,7 @@ ElementComparator(const GAGenome& a, const GAGenome& b)
 #define SWAP(a,b) {unsigned int tmp=a; a=b; b=tmp;}
 
 // Randomly take bits from each parent.  For each bit we flip a coin to see if
-// that bit should come from the mother or the father.  If strings are 
+// that bit should come from the mother or the father.  If strings are
 // different lengths then we need to use the mask to get things right.
 template <class T> int
 GA1DArrayGenome<T>::
@@ -517,8 +517,8 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
     n = 2;
   }
   else if(c1 || c2){
-    GA1DArrayGenome<T> &sis = (c1 ? 
-			       DYN_CAST(GA1DArrayGenome<T> &, *c1) : 
+    GA1DArrayGenome<T> &sis = (c1 ?
+			       DYN_CAST(GA1DArrayGenome<T> &, *c1) :
 			       DYN_CAST(GA1DArrayGenome<T> &, *c2));
 
     if(mom.length() == dad.length() && sis.length() == mom.length()){
@@ -550,7 +550,7 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
 // we cannot handle that and post an error message.
 template <class T> int
 GA1DArrayGenome<T>::
-OnePointCrossover(const GAGenome& p1, const GAGenome& p2, 
+OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 		  GAGenome* c1, GAGenome* c2){
   const GA1DArrayGenome<T> &mom=DYN_CAST(const GA1DArrayGenome<T> &, p1);
   const GA1DArrayGenome<T> &dad=DYN_CAST(const GA1DArrayGenome<T> &, p2);
@@ -565,7 +565,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour() == GAGenome::FIXED_SIZE){
-      if(mom.length() != dad.length() || 
+      if(mom.length() != dad.length() ||
 	 sis.length() != bro.length() ||
 	 sis.length() != mom.length()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -587,17 +587,17 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sis.resize(momsite+dadlen);
       bro.resize(dadsite+momlen);
     }
-    
+
     sis.copy(mom, 0, 0, momsite);
     sis.copy(dad, momsite, dadsite, dadlen);
     bro.copy(dad, 0, 0, dadsite);
     bro.copy(mom, dadsite, momsite, momlen);
-  
+
     nc = 2;
   }
   else if(c1 || c2){
-    GA1DArrayGenome<T> &sis = (c1 ? 
-			       DYN_CAST(GA1DArrayGenome<T> &, *c1) : 
+    GA1DArrayGenome<T> &sis = (c1 ?
+			       DYN_CAST(GA1DArrayGenome<T> &, *c1) :
 			       DYN_CAST(GA1DArrayGenome<T> &, *c2));
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE){
@@ -615,7 +615,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       dadlen = dad.length() - dadsite;
       sis.resize(momsite+dadlen);
     }
-    
+
     if(GARandomBit()){
       sis.copy(mom, 0, 0, momsite);
       sis.copy(dad, momsite, dadsite, dadlen);
@@ -642,14 +642,14 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
 
 // Two point crossover for the 1D array genome.  Similar to the single point
-// crossover, but here we pick two points then grab the sections based upon 
+// crossover, but here we pick two points then grab the sections based upon
 // those two points.
 //   When we pick the points, it doesn't matter where they fall (one is not
 // dependent upon the other).  Make sure we get the lesser one into the first
 // position of our site array.
 template <class T> int
 GA1DArrayGenome<T>::
-TwoPointCrossover(const GAGenome& p1, const GAGenome& p2, 
+TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
 		  GAGenome* c1, GAGenome* c2){
   const GA1DArrayGenome<T> &mom=DYN_CAST(const GA1DArrayGenome<T> &, p1);
   const GA1DArrayGenome<T> &dad=DYN_CAST(const GA1DArrayGenome<T> &, p2);
@@ -664,7 +664,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour() == GAGenome::FIXED_SIZE){
-      if(mom.length() != dad.length() || 
+      if(mom.length() != dad.length() ||
 	 sis.length() != bro.length() ||
 	 sis.length() != mom.length()){
 	GAErr(GA_LOC, mom.className(), "two-point cross", gaErrSameLengthReqd);
@@ -675,7 +675,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
       if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
-      
+
       dadsite[0] = momsite[0];
       dadsite[1] = momsite[1];
       dadlen[0] = momlen[0];
@@ -691,13 +691,13 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
       if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
-      
+
       dadsite[0] = GARandomInt(0, dad.length());
       dadsite[1] = GARandomInt(0, dad.length());
       if(dadsite[0] > dadsite[1]) SWAP(dadsite[0], dadsite[1]);
       dadlen[0] = dadsite[1] - dadsite[0];
       dadlen[1] = dad.length() - dadsite[1];
-      
+
       sis.resize(momsite[0]+dadlen[0]+momlen[1]);
       bro.resize(dadsite[0]+momlen[0]+dadlen[1]);
     }
@@ -726,7 +726,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
       if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
-      
+
       dadsite[0] = momsite[0];
       dadsite[1] = momsite[1];
       dadlen[0] = momlen[0];
@@ -738,7 +738,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
       if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
-      
+
       dadsite[0] = GARandomInt(0, dad.length());
       dadsite[1] = GARandomInt(0, dad.length());
       if(dadsite[0] > dadsite[1]) SWAP(dadsite[0], dadsite[1]);
@@ -771,13 +771,13 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
 
 
 
-// Even and odd crossover for the array works just like it does for the 
+// Even and odd crossover for the array works just like it does for the
 // binary strings.  For even crossover we take the 0th element and every other
 // one after that from the mother.  The 1st and every other come from the
 // father.  For odd crossover, we do just the opposite.
 template <class T> int
 GA1DArrayGenome<T>::
-EvenOddCrossover(const GAGenome& p1, const GAGenome& p2, 
+EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
 		 GAGenome* c1, GAGenome* c2){
   const GA1DArrayGenome<T> &mom=DYN_CAST(const GA1DArrayGenome<T> &, p1);
   const GA1DArrayGenome<T> &dad=DYN_CAST(const GA1DArrayGenome<T> &, p2);
@@ -816,10 +816,10 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
     nc = 2;
   }
   else if(c1 || c2){
-    GA1DArrayGenome<T> &sis = (c1 ? 
-			       DYN_CAST(GA1DArrayGenome<T> &, *c1) : 
+    GA1DArrayGenome<T> &sis = (c1 ?
+			       DYN_CAST(GA1DArrayGenome<T> &, *c1) :
 			       DYN_CAST(GA1DArrayGenome<T> &, *c2));
-    
+
     if(mom.length() == dad.length() && sis.length() == mom.length()){
       for(i=sis.length()-1; i>=1; i-=2){
 	sis.gene(i, mom.gene(i));
@@ -853,7 +853,7 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
 //   We make sure that b will be greater than a.
 template <class T> int
 GA1DArrayGenome<T>::
-PartialMatchCrossover(const GAGenome& p1, const GAGenome& p2, 
+PartialMatchCrossover(const GAGenome& p1, const GAGenome& p2,
 		      GAGenome* c1, GAGenome* c2){
   const GA1DArrayGenome<T> &mom=DYN_CAST(const GA1DArrayGenome<T> &, p1);
   const GA1DArrayGenome<T> &dad=DYN_CAST(const GA1DArrayGenome<T> &, p2);
@@ -868,7 +868,7 @@ PartialMatchCrossover(const GAGenome& p1, const GAGenome& p2,
     GAErr(GA_LOC, mom.className(), "parial match cross", gaErrBadParentLength);
     return nc;
   }
-  
+
   if(c1 && c2){
     GA1DArrayGenome<T> &sis=DYN_CAST(GA1DArrayGenome<T> &, *c1);
     GA1DArrayGenome<T> &bro=DYN_CAST(GA1DArrayGenome<T> &, *c2);
@@ -887,8 +887,8 @@ PartialMatchCrossover(const GAGenome& p1, const GAGenome& p2,
     nc = 2;
   }
   else if(c1 || c2){
-    GA1DArrayGenome<T> &sis = (c1 ? 
-			       DYN_CAST(GA1DArrayGenome<T> &, *c1) : 
+    GA1DArrayGenome<T> &sis = (c1 ?
+			       DYN_CAST(GA1DArrayGenome<T> &, *c1) :
 			       DYN_CAST(GA1DArrayGenome<T> &, *c2));
 
     const GA1DArrayGenome<T> *parent1, *parent2;
@@ -929,7 +929,7 @@ GA1DArrayIsHole(const GA1DArrayGenome<T> &c, const GA1DArrayGenome<T> &dad,
 //   This implementation isn't terribly smart.  For example, I do a linear
 // search rather than caching and doing binary search or smarter hash tables.
 //   First we copy the mother into the sister.  Then move the 'holes' into the
-// crossover section and maintain the ordering of the non-hole elements.  
+// crossover section and maintain the ordering of the non-hole elements.
 // Finally, put the 'holes' in the proper order within the crossover section.
 // After we have done the sister, we do the brother.
 template <class T> int
@@ -949,7 +949,7 @@ OrderCrossover(const GAGenome& p1, const GAGenome& p2,
     GAErr(GA_LOC, mom.className(), "order cross", gaErrBadParentLength);
     return nc;
   }
-  
+
   if(c1 && c2){
     GA1DArrayGenome<T> &sis=DYN_CAST(GA1DArrayGenome<T> &, *c1);
     GA1DArrayGenome<T> &bro=DYN_CAST(GA1DArrayGenome<T> &, *c2);
@@ -962,7 +962,7 @@ OrderCrossover(const GAGenome& p1, const GAGenome& p2,
       if(index >= sis.size()) index=0;
       if(GA1DArrayIsHole(sis,dad,index,a,b)) break;
     }
-    
+
     for(; i<sis.size()-b+a; i++, index++){
       if(index >= sis.size()) index=0;
       j=index;
@@ -999,7 +999,7 @@ OrderCrossover(const GAGenome& p1, const GAGenome& p2,
       } while(GA1DArrayIsHole(bro,mom,j,a,b));
       bro.swap(index,j);
     }
-    
+
 // Now put the 'holes' in the proper order within the crossover section.
     for(i=a; i<b; i++){
       if(bro.gene(i) != mom.gene(i)){
@@ -1011,8 +1011,8 @@ OrderCrossover(const GAGenome& p1, const GAGenome& p2,
     nc = 2;
   }
   else if(c1 || c2){
-    GA1DArrayGenome<T> &sis = (c1 ? 
-			       DYN_CAST(GA1DArrayGenome<T> &, *c1) : 
+    GA1DArrayGenome<T> &sis = (c1 ?
+			       DYN_CAST(GA1DArrayGenome<T> &, *c1) :
 			       DYN_CAST(GA1DArrayGenome<T> &, *c2));
 
     const GA1DArrayGenome<T> *parent1, *parent2;
@@ -1053,7 +1053,7 @@ OrderCrossover(const GAGenome& p1, const GAGenome& p2,
 
 
 
-// Cycle crossover for the 1D array genome.  This is implemented as described 
+// Cycle crossover for the 1D array genome.  This is implemented as described
 // in goldberg's book.  The first is picked from mom, then cycle using dad.
 // Finally, fill in the gaps with the elements from dad.
 //   We allocate space for a temporary array in this routine.  It never frees
@@ -1063,8 +1063,8 @@ OrderCrossover(const GAGenome& p1, const GAGenome& p2,
 //  Allocate space for an array of flags.  We use this to keep track of whether
 // the child's contents came from the mother or the father.  We don't free the
 // space here, but it is not a memory leak.
-//   The first step is to cycle through mom & dad to get the cyclic part of 
-// the crossover.  Then fill in the rest of the sis with dad's contents that 
+//   The first step is to cycle through mom & dad to get the cyclic part of
+// the crossover.  Then fill in the rest of the sis with dad's contents that
 // we didn't use in the cycle.  Finally, do the same thing for the other child.
 //   Notice that this implementation makes serious use of the operator= for the
 // objects in the array.  It also requires the operator != and == comparators.
@@ -1139,7 +1139,7 @@ CycleCrossover(const GAGenome& p1, const GAGenome& p2,
     GAMask mask;
     mask.size(sis.length());
     mask.clear();
-    
+
     sis.gene(0, parent1->gene(0));
     mask[0] = 1;
     while(parent2->gene(current) != parent1->gene(0)){

--- a/Dynamic_MPFA/source/ga-mpi/GA1DBinStrGenome.C
+++ b/Dynamic_MPFA/source/ga-mpi/GA1DBinStrGenome.C
@@ -27,13 +27,13 @@
 // this point - initialization must be done explicitly by the user of the
 // genome (eg when the population is created or reset).  If we called the
 // initializer routine here then we could end up with multiple initializations
-// and/or calls to dummy initializers (for example when the genome is 
+// and/or calls to dummy initializers (for example when the genome is
 // created with a dummy initializer and the initializer is assigned later on).
 GA1DBinaryStringGenome::
-GA1DBinaryStringGenome(unsigned int len, 
+GA1DBinaryStringGenome(unsigned int len,
 		       GAGenome::Evaluator f, void * u) :
 GABinaryString(len),
-GAGenome(DEFAULT_1DBINSTR_INITIALIZER, 
+GAGenome(DEFAULT_1DBINSTR_INITIALIZER,
 	 DEFAULT_1DBINSTR_MUTATOR,
 	 DEFAULT_1DBINSTR_COMPARATOR) {
   evaluator(f);
@@ -60,7 +60,7 @@ GA1DBinaryStringGenome::~GA1DBinaryStringGenome() {
 
 
 // The clone member creates a duplicate (exact or just attributes, depending
-// on the flag).  The caller is responsible for freeing the memory that is 
+// on the flag).  The caller is responsible for freeing the memory that is
 // allocated by this method.
 GAGenome*
 GA1DBinaryStringGenome::clone(GAGenome::CloneMethod flag) const {
@@ -81,7 +81,7 @@ GA1DBinaryStringGenome::clone(GAGenome::CloneMethod flag) const {
 // what we define here - a virtual function).  We should check to be sure that
 // both genomes are the same class and same dimension.  This function tries
 // to be smart about they way it copies.  If we already have data, then we do
-// a memcpy of the one we're supposed to copy.  If we don't or we're not the 
+// a memcpy of the one we're supposed to copy.  If we don't or we're not the
 // same size as the one we're supposed to copy, then we adjust ourselves.
 //   The BinaryStringGenome takes care of the resize in its copy method.
 // It also copies the bitstring for us.
@@ -89,7 +89,7 @@ void
 GA1DBinaryStringGenome::copy(const GAGenome & orig)
 {
   if(&orig == this) return;
-  const GA1DBinaryStringGenome* c = 
+  const GA1DBinaryStringGenome* c =
     DYN_CAST(const GA1DBinaryStringGenome*, &orig);
   if(c) {
     GAGenome::copy(*c);
@@ -173,7 +173,7 @@ GA1DBinaryStringGenome::write(STD_OSTREAM & os) const
 //   Set the resize behaviour of the genome.  A genome can be fixed
 // length, resizeable with a max and min limit, or resizeable with no limits
 // (other than an implicit one that we use internally).
-//   A value of 0 means no resize, a value less than zero mean unlimited 
+//   A value of 0 means no resize, a value less than zero mean unlimited
 // resize, and a positive value means resize with that value as the limit.
 //   We return the upper limit of the genome's size.
 int
@@ -190,21 +190,21 @@ resizeBehaviour(unsigned int lower, unsigned int upper)
   return resizeBehaviour();
 }
 
-int 
+int
 GA1DBinaryStringGenome::resizeBehaviour() const {
   int val = maxX;
   if(maxX == minX) val = FIXED_SIZE;
   return val;
 }
 
-int 
+int
 GA1DBinaryStringGenome::
 equal(const GA1DBinaryStringGenome& c,
       unsigned int dest, unsigned int src, unsigned int len) const {
   return GABinaryString::equal(c,dest,src,len);
 }
 
-int 
+int
 GA1DBinaryStringGenome::equal(const GAGenome & c) const {
   if(this == &c) return 1;
   const GA1DBinaryStringGenome* b = DYN_CAST(const GA1DBinaryStringGenome*,&c);
@@ -231,7 +231,7 @@ GA1DBinaryStringGenome::equal(const GAGenome & c) const {
 // random bit function so we don't have to worry about machine-specific stuff.
 //   We also do a resize so the genome can resize itself (randomly) if it
 // is a resizeable genome.
-void 
+void
 GA1DBinaryStringGenome::UniformInitializer(GAGenome & c)
 {
   GA1DBinaryStringGenome &child=DYN_CAST(GA1DBinaryStringGenome &, c);
@@ -242,7 +242,7 @@ GA1DBinaryStringGenome::UniformInitializer(GAGenome & c)
 
 
 //   Unset all of the bits in the genome.
-void 
+void
 GA1DBinaryStringGenome::UnsetInitializer(GAGenome & c)
 {
   GA1DBinaryStringGenome &child=DYN_CAST(GA1DBinaryStringGenome &, c);
@@ -252,7 +252,7 @@ GA1DBinaryStringGenome::UnsetInitializer(GAGenome & c)
 
 
 //   Set all of the bits in the genome.
-void 
+void
 GA1DBinaryStringGenome::SetInitializer(GAGenome & c)
 {
   GA1DBinaryStringGenome &child=DYN_CAST(GA1DBinaryStringGenome &, c);
@@ -271,11 +271,11 @@ GA1DBinaryStringGenome::SetInitializer(GAGenome & c)
 // better the chance that it will match the desired mutation rate.
 //   If nMut is greater than 1, then we round up, so a mutation of 2.2 would
 // be 3 mutations, and 2.9 would be 3 as well.  nMut of 3 would be 3 mutations.
-int 
+int
 GA1DBinaryStringGenome::FlipMutator(GAGenome & c, float pmut)
 {
   GA1DBinaryStringGenome &child=DYN_CAST(GA1DBinaryStringGenome &, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float, child.length());
@@ -298,10 +298,10 @@ GA1DBinaryStringGenome::FlipMutator(GAGenome & c, float pmut)
 }
 
 
-// Return a number from 0 to 1 to indicate how similar two genomes are.  For 
+// Return a number from 0 to 1 to indicate how similar two genomes are.  For
 // the binary strings we compare bits.  We count the number of bits that are
 // the same then divide by the number of bits.  If the genomes are different
-// length then we return a -1 to indicate that we cannot calculate the 
+// length then we return a -1 to indicate that we cannot calculate the
 // similarity.
 //   Normal hamming distance makes use of population information - this is not
 // a hamming measure!  This is a similarity measure of two individuals, not
@@ -334,7 +334,7 @@ GA1DBinaryStringGenome::BitComparator(const GAGenome& a, const GAGenome& b){
 
 
 // Randomly take bits from each parent.  For each bit we flip a coin to see if
-// that bit should come from the mother or the father.  This operator can be 
+// that bit should come from the mother or the father.  This operator can be
 // used on genomes of different lengths, but the crossover is truncated to the
 // shorter of the parents and child.
 int
@@ -385,8 +385,8 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
     n = 2;
   }
   else if(c1 || c2){
-    GA1DBinaryStringGenome &sis = (c1 ? 
-				   DYN_CAST(GA1DBinaryStringGenome&, *c1) : 
+    GA1DBinaryStringGenome &sis = (c1 ?
+				   DYN_CAST(GA1DBinaryStringGenome&, *c1) :
 				   DYN_CAST(GA1DBinaryStringGenome&, *c2));
 
     if(mom.length() == dad.length() && sis.length() == mom.length()){
@@ -434,7 +434,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour() == GAGenome::FIXED_SIZE){
-      if(mom.length() != dad.length() || 
+      if(mom.length() != dad.length() ||
 	 sis.length() != bro.length() ||
 	 sis.length() != mom.length()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -461,12 +461,12 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
     sis.copy(dad, momsite, dadsite, dadlen);
     bro.copy(dad, 0, 0, dadsite);
     bro.copy(mom, dadsite, momsite, momlen);
-  
+
     n = 2;
   }
   else if(c1 || c2){
-    GA1DBinaryStringGenome &sis = (c1 ? 
-				   DYN_CAST(GA1DBinaryStringGenome&, *c1) : 
+    GA1DBinaryStringGenome &sis = (c1 ?
+				   DYN_CAST(GA1DBinaryStringGenome&, *c1) :
 				   DYN_CAST(GA1DBinaryStringGenome&, *c2));
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE){
@@ -530,7 +530,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour() == GAGenome::FIXED_SIZE){
-      if(mom.length() != dad.length() || 
+      if(mom.length() != dad.length() ||
 	 sis.length() != bro.length() ||
 	 sis.length() != mom.length()){
 	GAErr(GA_LOC, mom.className(), "two-point cross", gaErrSameLengthReqd);
@@ -558,7 +558,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
       if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
-      
+
       dadsite[0] = GARandomInt(0, dad.length());
       dadsite[1] = GARandomInt(0, dad.length());
       if(dadsite[0] > dadsite[1]) SWAP(dadsite[0], dadsite[1]);
@@ -579,8 +579,8 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
     n = 2;
   }
   else if(c1 || c2){
-    GA1DBinaryStringGenome &sis = (c1 ? 
-				   DYN_CAST(GA1DBinaryStringGenome&, *c1) : 
+    GA1DBinaryStringGenome &sis = (c1 ?
+				   DYN_CAST(GA1DBinaryStringGenome&, *c1) :
 				   DYN_CAST(GA1DBinaryStringGenome&, *c2));
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE){
@@ -605,7 +605,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
       if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
-      
+
       dadsite[0] = GARandomInt(0, dad.length());
       dadsite[1] = GARandomInt(0, dad.length());
       if(dadsite[0] > dadsite[1]) SWAP(dadsite[0], dadsite[1]);
@@ -639,10 +639,10 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
 //   Even and odd crossovers take alternating bits from the mother and father.
 // For even crossover, we take every even bit from the mother and every odd bit
 // from the father (the first bit is the 0th bit, so it is even).  Odd
-// crossover is just the opposite.  
+// crossover is just the opposite.
 int
 GA1DBinaryStringGenome::
-EvenOddCrossover(const GAGenome& p1, const GAGenome& p2, 
+EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
 		 GAGenome* c1, GAGenome* c2){
   const GA1DBinaryStringGenome &mom=
     DYN_CAST(const GA1DBinaryStringGenome &, p1);
@@ -685,7 +685,7 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
   }
   else if(c1 || c2){
     GA1DBinaryStringGenome &sis = (c1 ?
-				   DYN_CAST(GA1DBinaryStringGenome&, *c1) : 
+				   DYN_CAST(GA1DBinaryStringGenome&, *c1) :
 				   DYN_CAST(GA1DBinaryStringGenome&, *c2));
 
     if(mom.length() == dad.length() && sis.length() == mom.length()){

--- a/Dynamic_MPFA/source/ga-mpi/GA2DArrayGenome.C
+++ b/Dynamic_MPFA/source/ga-mpi/GA2DArrayGenome.C
@@ -27,13 +27,13 @@ GA2DArrayGenome<T>::className() const {return "GA2DArrayGenome";}
 template <class T> int
 GA2DArrayGenome<T>::classID() const {return GAID::ArrayGenome2D;}
 
-template <class T> 
+template <class T>
 GA2DArrayGenome<T>::
-GA2DArrayGenome(unsigned int width, unsigned int height, 
+GA2DArrayGenome(unsigned int width, unsigned int height,
 		GAGenome::Evaluator f,
 		void * u) :
 GAArray<T>(width*height),
-GAGenome(DEFAULT_2DARRAY_INITIALIZER, 
+GAGenome(DEFAULT_2DARRAY_INITIALIZER,
 	 DEFAULT_2DARRAY_MUTATOR,
 	 DEFAULT_2DARRAY_COMPARATOR)
 {
@@ -44,7 +44,7 @@ GAGenome(DEFAULT_2DARRAY_INITIALIZER,
 }
 
 
-template <class T> 
+template <class T>
 GA2DArrayGenome<T>::
 GA2DArrayGenome(const GA2DArrayGenome<T> & orig) : GAArray<T>(orig.sz){
   GA2DArrayGenome<T>::copy(orig);
@@ -62,10 +62,10 @@ GA2DArrayGenome<T>::copy(const GAGenome & orig){
   if(c) {
     GAGenome::copy(*c);
     GAArray<T>::copy(*c);
-    nx = c->nx; ny = c->ny; 
-    minX = c->minX; minY = c->minY; 
+    nx = c->nx; ny = c->ny;
+    minX = c->minX; minY = c->minY;
     maxX = c->maxX; maxY = c->maxY;
-  } 
+  }
 }
 
 
@@ -77,8 +77,8 @@ GA2DArrayGenome<T>::clone(GAGenome::CloneMethod flag) const {
   }
   else{
     cpy->GAGenome::copy(*this);
-    cpy->minX = minX; cpy->minY = minY; 
-    cpy->maxX = maxX; cpy->maxY = maxY; 
+    cpy->minX = minX; cpy->minY = minY;
+    cpy->maxX = maxX; cpy->maxY = maxY;
   }
   return cpy;
 }
@@ -137,7 +137,7 @@ GA2DArrayGenome<T>::read(STD_ISTREAM &) {
 
 
 template <class T> int
-GA2DArrayGenome<T>::write(STD_OSTREAM & os) const 
+GA2DArrayGenome<T>::write(STD_OSTREAM & os) const
 {
   for(unsigned int j=0; j<ny; j++){
     for(unsigned int i=0; i<nx; i++){
@@ -167,7 +167,7 @@ GA2DArrayGenome<T>::resizeBehaviour(GAGenome::Dimension which) const {
 
 template <class T> int
 GA2DArrayGenome<T>::
-resizeBehaviour(GAGenome::Dimension which, 
+resizeBehaviour(GAGenome::Dimension which,
 		unsigned int lower, unsigned int upper)
 {
   if(upper < lower){
@@ -212,12 +212,12 @@ GA2DArrayGenome<T>::copy(const GA2DArrayGenome<T> & orig,
   for(unsigned int j=0; j<h; j++)
     GAArray<T>::copy(orig, (s+j)*nx+r, (y+j)*orig.nx+x, w);
 
-  _evaluated = gaFalse; 
+  _evaluated = gaFalse;
 }
 
 
 
-template <class T> int 
+template <class T> int
 GA2DArrayGenome<T>::equal(const GAGenome & c) const
 {
   if(this == &c) return 1;
@@ -259,9 +259,9 @@ GA2DArrayAlleleGenome<T>::className() const {return "GA2DArrayAlleleGenome";}
 template <class T> int
 GA2DArrayAlleleGenome<T>::classID() const {return GAID::ArrayAlleleGenome2D;}
 
-template <class T> 
+template <class T>
 GA2DArrayAlleleGenome<T>::
-GA2DArrayAlleleGenome(unsigned int width, unsigned int height, 
+GA2DArrayAlleleGenome(unsigned int width, unsigned int height,
 		      const GAAlleleSet<T> & s,
 		      GAGenome::Evaluator f, void * u) :
 GA2DArrayGenome<T>(width,height,f,u){
@@ -275,9 +275,9 @@ GA2DArrayGenome<T>(width,height,f,u){
   this->crossover(GA2DArrayAlleleGenome<T>::DEFAULT_2DARRAY_ALLELE_CROSSOVER);
 }
 
-template <class T> 
+template <class T>
 GA2DArrayAlleleGenome<T>::
-GA2DArrayAlleleGenome(unsigned int width, unsigned int height, 
+GA2DArrayAlleleGenome(unsigned int width, unsigned int height,
 		      const GAAlleleSetArray<T> & sa,
 		      GAGenome::Evaluator f, void * u) :
 GA2DArrayGenome<T>(width,height, f, u) {
@@ -293,9 +293,9 @@ GA2DArrayGenome<T>(width,height, f, u) {
 }
 
 
-template <class T> 
+template <class T>
 GA2DArrayAlleleGenome<T>::
-GA2DArrayAlleleGenome(const GA2DArrayAlleleGenome<T> & orig) : 
+GA2DArrayAlleleGenome(const GA2DArrayAlleleGenome<T> & orig) :
 GA2DArrayGenome<T>(orig.nx, orig.ny) {
   naset = 0;
   aset = (GAAlleleSet<T>*)0;
@@ -315,10 +315,10 @@ GA2DArrayAlleleGenome<T>::clone(GAGenome::CloneMethod) const {
 }
 
 
-template <class T> void 
+template <class T> void
 GA2DArrayAlleleGenome<T>::copy(const GAGenome& orig){
   if(&orig == this) return;
-  const GA2DArrayAlleleGenome<T>* c = 
+  const GA2DArrayAlleleGenome<T>* c =
     DYN_CAST(const GA2DArrayAlleleGenome<T>*, &orig);
   if(c) {
     GA2DArrayGenome<T>::copy(*c);
@@ -386,24 +386,24 @@ GA2DArrayAlleleGenome<T>::equal(const GAGenome & c) const {
    Operator definitions
 ---------------------------------------------------------------------------- */
 // this does not handle genomes with multiple allele sets!
-template <class ARRAY_TYPE> void 
+template <class ARRAY_TYPE> void
 GA2DArrayAlleleGenome<ARRAY_TYPE>::UniformInitializer(GAGenome & c)
 {
   GA2DArrayAlleleGenome<ARRAY_TYPE> &child=
     DYN_CAST(GA2DArrayAlleleGenome<ARRAY_TYPE> &, c);
-  child.resize(GAGenome::ANY_SIZE,GAGenome::ANY_SIZE); 
+  child.resize(GAGenome::ANY_SIZE,GAGenome::ANY_SIZE);
   for(int i=child.width()-1; i>=0; i--)
     for(int j=child.height()-1; j>=0; j--)
       child.gene(i, j, child.alleleset().allele());
 }
 
 
-template <class ARRAY_TYPE> int 
+template <class ARRAY_TYPE> int
 GA2DArrayAlleleGenome<ARRAY_TYPE>::FlipMutator(GAGenome & c, float pmut)
 {
   GA2DArrayAlleleGenome<ARRAY_TYPE> &child=
     DYN_CAST(GA2DArrayAlleleGenome<ARRAY_TYPE> &, c);
-  register int n, m, i, j;
+  int n, m, i, j;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.size());
@@ -430,11 +430,11 @@ GA2DArrayAlleleGenome<ARRAY_TYPE>::FlipMutator(GAGenome & c, float pmut)
 }
 
 
-template <class ARRAY_TYPE> int 
+template <class ARRAY_TYPE> int
 GA2DArrayGenome<ARRAY_TYPE>::SwapMutator(GAGenome & c, float pmut)
 {
   GA2DArrayGenome<ARRAY_TYPE> &child=DYN_CAST(GA2DArrayGenome<ARRAY_TYPE>&, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.size());
@@ -496,7 +496,7 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
   if(c1 && c2){
     GA2DArrayGenome<T> &sis=DYN_CAST(GA2DArrayGenome<T> &, *c1);
     GA2DArrayGenome<T> &bro=DYN_CAST(GA2DArrayGenome<T> &, *c2);
-    
+
     if(sis.width() == bro.width() && sis.height() == bro.height() &&
        mom.width() == dad.width() && mom.height() == dad.height() &&
        sis.width() == mom.width() && sis.height() == mom.height()){
@@ -567,7 +567,7 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
 
 
 // This crossover does clipping (no padding) for resizables.  Notice that this
-// means that any resizable children of two parents will have identical 
+// means that any resizable children of two parents will have identical
 // dimensions no matter what.
 template <class T> int
 GA2DArrayGenome<T>::
@@ -587,8 +587,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE){
-      if(mom.width() != dad.width() || 
-	 sis.width() != bro.width() || 
+      if(mom.width() != dad.width() ||
+	 sis.width() != bro.width() ||
 	 sis.width() != mom.width()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -612,8 +612,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
-      if(mom.height() != dad.height() || 
-	 sis.height() != bro.height() || 
+      if(mom.height() != dad.height() ||
+	 sis.height() != bro.height() ||
 	 sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -637,12 +637,12 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     sis.resize(sitex+lenx, sitey+leny);
     bro.resize(sitex+lenx, sitey+leny);
-    
+
     sis.copy(mom, 0, 0, momsitex-sitex, momsitey-sitey, sitex, sitey);
     sis.copy(dad, sitex, 0, dadsitex, dadsitey-sitey, lenx, sitey);
     sis.copy(dad, 0, sitey, dadsitex-sitex, dadsitey, sitex, leny);
     sis.copy(mom, sitex, sitey, momsitex, momsitey, lenx, leny);
-    
+
     bro.copy(dad, 0, 0, dadsitex-sitex, dadsitey-sitey, sitex, sitey);
     bro.copy(mom, sitex, 0, momsitex, momsitey-sitey, lenx, sitey);
     bro.copy(mom, 0, sitey, momsitex-sitex, momsitey, sitex, leny);
@@ -652,7 +652,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
   }
   else if(c1){
     GA2DArrayGenome<T> &sis=DYN_CAST(GA2DArrayGenome<T> &, *c1);
-    
+
     if(sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE){
       if(mom.width() != dad.width() || sis.width() != mom.width()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -669,7 +669,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitex = GAMin(momsitex, dadsitex);
       lenx = GAMin(momlenx, dadlenx);
     }
-    
+
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
       if(mom.height() != dad.height() || sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -686,9 +686,9 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitey = GAMin(momsitey, dadsitey);
       leny = GAMin(momleny, dadleny);
     }
-    
+
     sis.resize(sitex+lenx, sitey+leny);
-    
+
     if(GARandomBit()){
       sis.copy(mom, 0, 0, momsitex-sitex, momsitey-sitey, sitex, sitey);
       sis.copy(dad, sitex, 0, dadsitex, dadsitey-sitey, lenx, sitey);
@@ -759,7 +759,7 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
   }
   else if(c1){
     GA2DArrayGenome<T> &sis=DYN_CAST(GA2DArrayGenome<T> &, *c1);
-    
+
     if(mom.width() == dad.width() && mom.height() == dad.height() &&
        sis.width() == mom.width() && sis.height() == mom.height()){
       int count=0;

--- a/Dynamic_MPFA/source/ga-mpi/GA2DBinStrGenome.C
+++ b/Dynamic_MPFA/source/ga-mpi/GA2DBinStrGenome.C
@@ -21,7 +21,7 @@
    Genome class definition
 ---------------------------------------------------------------------------- */
 GA2DBinaryStringGenome::
-GA2DBinaryStringGenome(unsigned int width, unsigned int height, 
+GA2DBinaryStringGenome(unsigned int width, unsigned int height,
 		       GAGenome::Evaluator f, void * u) :
 GABinaryString(width*height),
 GAGenome(DEFAULT_2DBINSTR_INITIALIZER,
@@ -54,8 +54,8 @@ GA2DBinaryStringGenome::clone(GAGenome::CloneMethod flag) const {
   }
   else{
     cpy->GAGenome::copy(*this);
-    cpy->minX = minX; cpy->minY = minY; 
-    cpy->maxX = maxX; cpy->maxY = maxY; 
+    cpy->minX = minX; cpy->minY = minY;
+    cpy->maxX = maxX; cpy->maxY = maxY;
   }
   return cpy;
 }
@@ -69,10 +69,10 @@ GA2DBinaryStringGenome::copy(const GAGenome & orig)
   if(c) {
     GAGenome::copy(*c);
     GABinaryString::copy(*c);
-    nx = c->nx; ny = c->ny; 
-    minX = c->minX; minY = c->minY; 
+    nx = c->nx; ny = c->ny;
+    minX = c->minX; minY = c->minY;
     maxX = c->maxX; maxY = c->maxY;
-  } 
+  }
 }
 
 
@@ -105,7 +105,7 @@ GA2DBinaryStringGenome::resize(int w, int h)
 
 // Move the bits into the right position.  If we're smaller, then shift to
 // the smaller size before we do the resize (the resize method maintains bit
-// integrety).  If we're larger, do the move after the resize.  If we're the 
+// integrety).  If we're larger, do the move after the resize.  If we're the
 // same size the we don't do anything.  When we're adding more bits, the new
 // bits get set randomly to 0 or 1.
 
@@ -153,7 +153,7 @@ GA2DBinaryStringGenome::read(STD_ISTREAM & is)
 
   _evaluated = gaFalse;
 
-  if(is.eof() && 
+  if(is.eof() &&
      ((j < ny) ||	     // didn't get some lines
       (i < nx && i != 0))){   // stopped early on a row
     GAErr(GA_LOC, className(), "read", gaErrUnexpectedEOF);
@@ -168,7 +168,7 @@ GA2DBinaryStringGenome::read(STD_ISTREAM & is)
 // Dump the digits to the stream with a newline between each row.  No newline
 // at the end of the whole thing.
 int
-GA2DBinaryStringGenome::write(STD_OSTREAM & os) const 
+GA2DBinaryStringGenome::write(STD_OSTREAM & os) const
 {
   for(unsigned int j=0; j<ny; j++){
     for(unsigned int i=0; i<nx; i++)
@@ -180,7 +180,7 @@ GA2DBinaryStringGenome::write(STD_OSTREAM & os) const
 #endif
 
 
-int 
+int
 GA2DBinaryStringGenome::resizeBehaviour(GAGenome::Dimension which) const {
   int val = 0;
   if(which == WIDTH) {
@@ -318,7 +318,7 @@ GA2DBinaryStringGenome::equal(const GA2DBinaryStringGenome& orig,
 }
 
 
-int 
+int
 GA2DBinaryStringGenome::equal(const GAGenome & c) const
 {
   if(this == &c) return 1;
@@ -344,7 +344,7 @@ GA2DBinaryStringGenome::equal(const GAGenome & c) const
   The order for looping through indices is height-then-width (ie height loops
 before a single width increment)
 ---------------------------------------------------------------------------- */
-void 
+void
 GA2DBinaryStringGenome::UniformInitializer(GAGenome & c)
 {
   GA2DBinaryStringGenome &child=DYN_CAST(GA2DBinaryStringGenome &, c);
@@ -355,7 +355,7 @@ GA2DBinaryStringGenome::UniformInitializer(GAGenome & c)
 }
 
 
-void 
+void
 GA2DBinaryStringGenome::UnsetInitializer(GAGenome & c)
 {
   GA2DBinaryStringGenome &child=DYN_CAST(GA2DBinaryStringGenome &, c);
@@ -364,20 +364,20 @@ GA2DBinaryStringGenome::UnsetInitializer(GAGenome & c)
 }
 
 
-void 
+void
 GA2DBinaryStringGenome::SetInitializer(GAGenome & c)
 {
   GA2DBinaryStringGenome &child=DYN_CAST(GA2DBinaryStringGenome &, c);
-  child.resize(GAGenome::ANY_SIZE, GAGenome::ANY_SIZE);	
+  child.resize(GAGenome::ANY_SIZE, GAGenome::ANY_SIZE);
   child.set(0, 0, child.width(), child.height());
 }
 
 
-int 
+int
 GA2DBinaryStringGenome::FlipMutator(GAGenome & c, float pmut)
 {
   GA2DBinaryStringGenome &child=DYN_CAST(GA2DBinaryStringGenome &, c);
-  register int n, m, i, j;
+  int n, m, i, j;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float, child.size());
@@ -431,7 +431,7 @@ GA2DBinaryStringGenome::BitComparator(const GAGenome& a, const GAGenome& b){
 
 int
 GA2DBinaryStringGenome::
-UniformCrossover(const GAGenome& p1, const GAGenome& p2, 
+UniformCrossover(const GAGenome& p1, const GAGenome& p2,
 		 GAGenome* c1, GAGenome* c2){
   const GA2DBinaryStringGenome &mom=
     DYN_CAST(const GA2DBinaryStringGenome &, p1);
@@ -486,8 +486,8 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
     nc = 2;
   }
   else if(c1 || c2){
-    GA2DBinaryStringGenome &sis = (c1 ? 
-				   DYN_CAST(GA2DBinaryStringGenome&, *c1) : 
+    GA2DBinaryStringGenome &sis = (c1 ?
+				   DYN_CAST(GA2DBinaryStringGenome&, *c1) :
 				   DYN_CAST(GA2DBinaryStringGenome&, *c2));
 
     if(mom.width() == dad.width() && mom.height() == dad.height() &&
@@ -515,13 +515,13 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
 
 //   When we do single point crossover on resizable 2D genomes we can either
 // clip or pad to make the mismatching geometries work out.  Either way, both
-// children end up with the same dimensions (the children have the same 
+// children end up with the same dimensions (the children have the same
 // dimensions as each other, not the same as if they were clipped/padded).
 //   When we pad, the extra space is filled with random bits.  This
 // implementation does only clipping, no padding!
 int
 GA2DBinaryStringGenome::
-OnePointCrossover(const GAGenome& p1, const GAGenome& p2, 
+OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 		  GAGenome* c1, GAGenome* c2){
   const GA2DBinaryStringGenome &mom=
     DYN_CAST(const GA2DBinaryStringGenome &, p1);
@@ -539,8 +539,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE){
-      if(mom.width() != dad.width() || 
-	 sis.width() != bro.width() || 
+      if(mom.width() != dad.width() ||
+	 sis.width() != bro.width() ||
 	 sis.width() != mom.width()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -564,8 +564,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
-      if(mom.height() != dad.height() || 
-	 sis.height() != bro.height() || 
+      if(mom.height() != dad.height() ||
+	 sis.height() != bro.height() ||
 	 sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -640,9 +640,9 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitey = GAMin(momsitey, dadsitey);
       leny = GAMin(momleny, dadleny);
     }
-    
+
     sis.resize(sitex+lenx, sitey+leny);
-    
+
     if(GARandomBit()){
       sis.copy(mom, 0, 0, momsitex-sitex, momsitey-sitey, sitex, sitey);
       sis.copy(dad, sitex, 0, dadsitex, dadsitey-sitey, lenx, sitey);
@@ -666,7 +666,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
 int
 GA2DBinaryStringGenome::
-EvenOddCrossover(const GAGenome& p1, const GAGenome& p2, 
+EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
 		 GAGenome* c1, GAGenome* c2){
   const GA2DBinaryStringGenome &mom=
     DYN_CAST(const GA2DBinaryStringGenome &, p1);
@@ -679,7 +679,7 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
   if(c1 && c2){
     GA2DBinaryStringGenome &sis=DYN_CAST(GA2DBinaryStringGenome &, *c1);
     GA2DBinaryStringGenome &bro=DYN_CAST(GA2DBinaryStringGenome &, *c2);
-    
+
     if(sis.width() == bro.width() && sis.height() == bro.height() &&
        mom.width() == dad.width() && mom.height() == dad.height() &&
        sis.width() == mom.width() && sis.height() == mom.height()){
@@ -719,10 +719,10 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
     nc = 2;
   }
   else if(c1 || c2){
-    GA2DBinaryStringGenome &sis = (c1 ? 
+    GA2DBinaryStringGenome &sis = (c1 ?
 				   DYN_CAST(GA2DBinaryStringGenome&, *c1) :
 				   DYN_CAST(GA2DBinaryStringGenome&, *c2));
-    
+
     if(mom.width() == dad.width() && mom.height() == dad.height() &&
        sis.width() == mom.width() && sis.height() == mom.height()){
       int count=0;

--- a/Dynamic_MPFA/source/ga-mpi/GA3DArrayGenome.C
+++ b/Dynamic_MPFA/source/ga-mpi/GA3DArrayGenome.C
@@ -27,13 +27,13 @@ GA3DArrayGenome<T>::className() const {return "GA3DArrayGenome";}
 template <class T> int
 GA3DArrayGenome<T>::classID() const {return GAID::ArrayGenome3D;}
 
-template <class T> 
+template <class T>
 GA3DArrayGenome<T>::
 GA3DArrayGenome(unsigned int w, unsigned int h, unsigned int d,
 		GAGenome::Evaluator f,
 		void * u) :
 GAArray<T>(w*h*d),
-GAGenome(DEFAULT_3DARRAY_INITIALIZER, 
+GAGenome(DEFAULT_3DARRAY_INITIALIZER,
 	 DEFAULT_3DARRAY_MUTATOR,
 	 DEFAULT_3DARRAY_COMPARATOR)
 {
@@ -44,7 +44,7 @@ GAGenome(DEFAULT_3DARRAY_INITIALIZER,
 }
 
 
-template <class T> 
+template <class T>
 GA3DArrayGenome<T>::
 GA3DArrayGenome(const GA3DArrayGenome<T> & orig) :
 GAArray<T>(orig.sz), GAGenome(){
@@ -78,7 +78,7 @@ GA3DArrayGenome<T>::clone(GAGenome::CloneMethod flag) const {
   }
   else{
     cpy->GAGenome::copy(*this);
-    cpy->minX = minX; cpy->minY = minY; cpy->minZ = minZ; 
+    cpy->minX = minX; cpy->minY = minY; cpy->minZ = minZ;
     cpy->maxX = maxX; cpy->maxY = maxY; cpy->maxZ = maxZ;
   }
   return cpy;
@@ -145,7 +145,7 @@ GA3DArrayGenome<T>::resize(int w, int h, int d)
 
   GAArray<T>::size(w*h*d);
 
-  if(w > STA_CAST(int,nx) && h > STA_CAST(int,ny)){ 
+  if(w > STA_CAST(int,nx) && h > STA_CAST(int,ny)){
     int z=GAMin(STA_CAST(int,nz),d);
     for(int k=z-1; k>=0; k--)
       for(int j=ny-1; j>=0; j--)
@@ -179,7 +179,7 @@ GA3DArrayGenome<T>::read(STD_ISTREAM &) {
 
 
 template <class T> int
-GA3DArrayGenome<T>::write(STD_OSTREAM & os) const 
+GA3DArrayGenome<T>::write(STD_OSTREAM & os) const
 {
   for(unsigned int k=0; k<nz; k++){
     for(unsigned int j=0; j<ny; j++){
@@ -216,7 +216,7 @@ GA3DArrayGenome<T>::resizeBehaviour(GAGenome::Dimension which) const {
 
 template <class T> int
 GA3DArrayGenome<T>::
-resizeBehaviour(GAGenome::Dimension which, 
+resizeBehaviour(GAGenome::Dimension which,
 		unsigned int lower, unsigned int upper)
 {
   if(upper < lower){
@@ -278,7 +278,7 @@ copy(const GA3DArrayGenome<T> & orig,
 }
 
 
-template <class T> int 
+template <class T> int
 GA3DArrayGenome<T>::equal(const GAGenome & c) const
 {
   if(this == &c) return 1;
@@ -312,7 +312,7 @@ GA3DArrayAlleleGenome<T>::className() const {return "GA3DArrayAlleleGenome";}
 template <class T> int
 GA3DArrayAlleleGenome<T>::classID() const {return GAID::ArrayAlleleGenome3D;}
 
-template <class T> 
+template <class T>
 GA3DArrayAlleleGenome<T>::
 GA3DArrayAlleleGenome(unsigned int w, unsigned int h, unsigned int d,
 		      const GAAlleleSet<T> & s,
@@ -328,7 +328,7 @@ GA3DArrayGenome<T>(w,h,d,f,u) {
   this->crossover(GA3DArrayAlleleGenome<T>::DEFAULT_3DARRAY_ALLELE_CROSSOVER);
 }
 
-template <class T> 
+template <class T>
 GA3DArrayAlleleGenome<T>::
 GA3DArrayAlleleGenome(unsigned int w, unsigned int h, unsigned int d,
 		      const GAAlleleSetArray<T> & sa,
@@ -346,9 +346,9 @@ GA3DArrayGenome<T>(w,h,d, f, u) {
 }
 
 
-template <class T> 
+template <class T>
 GA3DArrayAlleleGenome<T>::
-GA3DArrayAlleleGenome(const GA3DArrayAlleleGenome<T> & orig) : 
+GA3DArrayAlleleGenome(const GA3DArrayAlleleGenome<T> & orig) :
 GA3DArrayGenome<T>(orig.nx, orig.ny, orig.nz) {
   naset = 0;
   aset = (GAAlleleSet<T>*)0;
@@ -368,10 +368,10 @@ GA3DArrayAlleleGenome<T>::clone(GAGenome::CloneMethod) const {
 }
 
 
-template <class T> void 
+template <class T> void
 GA3DArrayAlleleGenome<T>::copy(const GAGenome& orig){
   if(&orig == this) return;
-  const GA3DArrayAlleleGenome<T>* c = 
+  const GA3DArrayAlleleGenome<T>* c =
     DYN_CAST(const GA3DArrayAlleleGenome<T>*, &orig);
   if(c) {
     GA3DArrayGenome<T>::copy(*c);
@@ -414,7 +414,7 @@ GA3DArrayAlleleGenome<T>::resize(int w, int h, int d){
     for(int k=z-1; k>=0; k--)
       for(int j=this->ny-1; j>=0; j--)
 	for(unsigned int i=oldx; i<this->nx; i++)
-	  this->a[k*this->ny*this->nx+j*this->nx+i] = 
+	  this->a[k*this->ny*this->nx+j*this->nx+i] =
 	    aset[(k*this->ny*this->nx+j*this->nx+i) % naset].allele();
   }
   else if(this->ny > oldy){
@@ -463,7 +463,7 @@ GA3DArrayAlleleGenome<T>::equal(const GAGenome & c) const {
    Operator definitions
 ---------------------------------------------------------------------------- */
 // this does not handle genomes with multiple allele sets!
-template <class ARRAY_TYPE> void 
+template <class ARRAY_TYPE> void
 GA3DArrayAlleleGenome<ARRAY_TYPE>::UniformInitializer(GAGenome & c)
 {
   GA3DArrayAlleleGenome<ARRAY_TYPE> &child=
@@ -476,12 +476,12 @@ GA3DArrayAlleleGenome<ARRAY_TYPE>::UniformInitializer(GAGenome & c)
 }
 
 
-template <class ARRAY_TYPE> int 
+template <class ARRAY_TYPE> int
 GA3DArrayAlleleGenome<ARRAY_TYPE>::FlipMutator(GAGenome & c, float pmut)
 {
   GA3DArrayAlleleGenome<ARRAY_TYPE> &child=
     DYN_CAST(GA3DArrayAlleleGenome<ARRAY_TYPE> &, c);
-  register int n, m, d, i, j, k;
+  int n, m, d, i, j, k;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.size());
@@ -512,11 +512,11 @@ GA3DArrayAlleleGenome<ARRAY_TYPE>::FlipMutator(GAGenome & c, float pmut)
 }
 
 
-template <class ARRAY_TYPE> int 
+template <class ARRAY_TYPE> int
 GA3DArrayGenome<ARRAY_TYPE>::SwapMutator(GAGenome & c, float pmut)
 {
   GA3DArrayGenome<ARRAY_TYPE> &child=DYN_CAST(GA3DArrayGenome<ARRAY_TYPE>&, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.size());
@@ -568,7 +568,7 @@ ElementComparator(const GAGenome& a, const GAGenome& b)
 
 
 
-// Make sure our bitmask is big enough, generate a mask, then use it to 
+// Make sure our bitmask is big enough, generate a mask, then use it to
 // extract the information from each parent to stuff the two children.
 // We don't deallocate any space for the masks under the assumption that we'll
 // have to use them again in the future.
@@ -680,12 +680,12 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
 //   This is designed only for genomes that are the same length.  If the child
 // is not the same length as the parent, or if the children are not the same
 // size, we don't do the crossover.
-//   In the interest of speed we do not do any checks for size.  Do not use 
+//   In the interest of speed we do not do any checks for size.  Do not use
 // this crossover method when the parents and children may be different sizes.
 // It might break!
 template <class T> int
 GA3DArrayGenome<T>::
-EvenOddCrossover(const GAGenome& p1, const GAGenome& p2, 
+EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
 GAGenome* c1, GAGenome* c2){
   const GA3DArrayGenome<T> &mom=DYN_CAST(const GA3DArrayGenome<T> &, p1);
   const GA3DArrayGenome<T> &dad=DYN_CAST(const GA3DArrayGenome<T> &, p2);
@@ -696,7 +696,7 @@ GAGenome* c1, GAGenome* c2){
   if(c1 && c2){
     GA3DArrayGenome<T> &sis=DYN_CAST(GA3DArrayGenome<T> &, *c1);
     GA3DArrayGenome<T> &bro=DYN_CAST(GA3DArrayGenome<T> &, *c2);
-    
+
     if(sis.width() == bro.width() && sis.height() == bro.height() &&
        sis.depth() == bro.depth() &&
        mom.width() == dad.width() && mom.height() == dad.height() &&
@@ -806,8 +806,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE){
-      if(mom.width() != dad.width() || 
-	 sis.width() != bro.width() || 
+      if(mom.width() != dad.width() ||
+	 sis.width() != bro.width() ||
 	 sis.width() != mom.width()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -828,11 +828,11 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitex = GAMin(momsitex, dadsitex);
       lenx = GAMin(momlenx, dadlenx);
     }
-    
+
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
-      if(mom.height() != dad.height() || 
-	 sis.height() != bro.height() || 
+      if(mom.height() != dad.height() ||
+	 sis.height() != bro.height() ||
 	 sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -856,8 +856,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE){
-      if(mom.depth() != dad.depth() || 
-	 sis.depth() != bro.depth() || 
+      if(mom.depth() != dad.depth() ||
+	 sis.depth() != bro.depth() ||
 	 sis.depth() != mom.depth()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -882,8 +882,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
     sis.resize(sitex+lenx, sitey+leny, sitez+lenz);
     bro.resize(sitex+lenx, sitey+leny, sitez+lenz);
 
-    sis.copy(mom, 
-	     0, 0, 0, 
+    sis.copy(mom,
+	     0, 0, 0,
 	     momsitex-sitex, momsitey-sitey, momsitez-sitez,
 	     sitex, sitey, sitez);
     sis.copy(dad,
@@ -898,8 +898,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	     sitex, sitey, 0,
 	     momsitex, momsitey, momsitez-sitez,
 	     lenx, leny, sitez);
-    sis.copy(dad, 
-	     0, 0, sitez, 
+    sis.copy(dad,
+	     0, 0, sitez,
 	     dadsitex-sitex, dadsitey-sitey, dadsitez,
 	     sitex, sitey, lenz);
     sis.copy(mom,
@@ -914,9 +914,9 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	     sitex, sitey, sitez,
 	     dadsitex, dadsitey, dadsitez,
 	     lenx, leny, lenz);
-    
-    bro.copy(dad, 
-	     0, 0, 0, 
+
+    bro.copy(dad,
+	     0, 0, 0,
 	     dadsitex-sitex, dadsitey-sitey, dadsitez-sitez,
 	     sitex, sitey, sitez);
     bro.copy(mom,
@@ -931,8 +931,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	     sitex, sitey, 0,
 	     dadsitex, dadsitey, dadsitez-sitez,
 	     lenx, leny, sitez);
-    bro.copy(mom, 
-	     0, 0, sitez, 
+    bro.copy(mom,
+	     0, 0, sitez,
 	     momsitex-sitex, momsitey-sitey, momsitez,
 	     sitex, sitey, lenz);
     bro.copy(dad,
@@ -969,7 +969,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitex = GAMin(momsitex, dadsitex);
       lenx = GAMin(momlenx, dadlenx);
     }
-    
+
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
       if(mom.height() != dad.height() || sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -1003,12 +1003,12 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitez = GAMin(momsitez, dadsitez);
       lenz = GAMin(momlenz, dadlenz);
     }
-    
+
     sis.resize(sitex+lenx, sitey+leny, sitez+lenz);
-    
+
     if(GARandomBit()){
-      sis.copy(mom, 
-	       0, 0, 0, 
+      sis.copy(mom,
+	       0, 0, 0,
 	       momsitex-sitex, momsitey-sitey, momsitez-sitez,
 	       sitex, sitey, sitez);
       sis.copy(dad,
@@ -1023,8 +1023,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	       sitex, sitey, 0,
 	       momsitex, momsitey, momsitez-sitez,
 	       lenx, leny, sitez);
-      sis.copy(dad, 
-	       0, 0, sitez, 
+      sis.copy(dad,
+	       0, 0, sitez,
 	       dadsitex-sitex, dadsitey-sitey, dadsitez,
 	       sitex, sitey, lenz);
       sis.copy(mom,
@@ -1041,8 +1041,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	       lenx, leny, lenz);
     }
     else{
-      sis.copy(dad, 
-	       0, 0, 0, 
+      sis.copy(dad,
+	       0, 0, 0,
 	       dadsitex-sitex, dadsitey-sitey, dadsitez-sitez,
 	       sitex, sitey, sitez);
       sis.copy(mom,
@@ -1057,8 +1057,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	       sitex, sitey, 0,
 	       dadsitex, dadsitey, dadsitez-sitez,
 	       lenx, leny, sitez);
-      sis.copy(mom, 
-	       0, 0, sitez, 
+      sis.copy(mom,
+	       0, 0, sitez,
 	       momsitex-sitex, momsitey-sitey, momsitez,
 	       sitex, sitey, lenz);
       sis.copy(dad,

--- a/Dynamic_MPFA/source/ga-mpi/GA3DBinStrGenome.C
+++ b/Dynamic_MPFA/source/ga-mpi/GA3DBinStrGenome.C
@@ -56,7 +56,7 @@ GA3DBinaryStringGenome::clone(GAGenome::CloneMethod flag) const {
   }
   else{
     cpy->GAGenome::copy(*this);
-    cpy->minX = minX; cpy->minY = minY; cpy->minZ = minZ; 
+    cpy->minX = minX; cpy->minY = minY; cpy->minZ = minZ;
     cpy->maxX = maxX; cpy->maxY = maxY; cpy->maxZ = maxZ;
   }
   return cpy;
@@ -66,7 +66,7 @@ void
 GA3DBinaryStringGenome::copy(const GAGenome & orig)
 {
   if(&orig == this) return;
-  const GA3DBinaryStringGenome* c = 
+  const GA3DBinaryStringGenome* c =
     DYN_CAST(const GA3DBinaryStringGenome*, &orig);
   if(c) {
     GAGenome::copy(*c);
@@ -206,7 +206,7 @@ GA3DBinaryStringGenome::read(STD_ISTREAM & is)
 
   _evaluated = gaFalse;
 
-  if(is.eof() && 
+  if(is.eof() &&
      ((k < nz) ||		// didn't get some lines
       (j < ny && j != 0) ||	// didn't get some lines
       (i < nx && i != 0))){	// didn't get some lines
@@ -219,10 +219,10 @@ GA3DBinaryStringGenome::read(STD_ISTREAM & is)
 }
 
 
-// Dump the bits to the stream with a newline at the end of each row and 
+// Dump the bits to the stream with a newline at the end of each row and
 // another at the end of each layer.  No newline at the end of the block.
 int
-GA3DBinaryStringGenome::write(STD_OSTREAM & os) const 
+GA3DBinaryStringGenome::write(STD_OSTREAM & os) const
 {
   for(unsigned int k=0; k<nz; k++){
     for(unsigned int j=0; j<ny; j++){
@@ -424,13 +424,13 @@ equal(const GA3DBinaryStringGenome& orig,
     for(unsigned int j=0; j<h; j++)
       eq += GABinaryString::equal(orig,
 				  (z+k)*ny*nx + (y+j)*nx + x,
-				  (srcz+k)*ny*nx + (srcy+j)*nx + srcx, 
+				  (srcz+k)*ny*nx + (srcy+j)*nx + srcx,
 				  w);
   return eq==d*h ? 1 : 0;
 }
 
 
-int 
+int
 GA3DBinaryStringGenome::equal(const GAGenome & c) const
 {
   if(this == &c) return 1;
@@ -459,7 +459,7 @@ GA3DBinaryStringGenome::equal(const GAGenome & c) const
 (ie depth loops before a single height increment, height loops before a single
 width increment)
 ---------------------------------------------------------------------------- */
-void 
+void
 GA3DBinaryStringGenome::UniformInitializer(GAGenome & c)
 {
   GA3DBinaryStringGenome &child=DYN_CAST(GA3DBinaryStringGenome &, c);
@@ -471,7 +471,7 @@ GA3DBinaryStringGenome::UniformInitializer(GAGenome & c)
 }
 
 
-void 
+void
 GA3DBinaryStringGenome::UnsetInitializer(GAGenome & c)
 {
   GA3DBinaryStringGenome &child=DYN_CAST(GA3DBinaryStringGenome &, c);
@@ -480,7 +480,7 @@ GA3DBinaryStringGenome::UnsetInitializer(GAGenome & c)
 }
 
 
-void 
+void
 GA3DBinaryStringGenome::SetInitializer(GAGenome & c)
 {
   GA3DBinaryStringGenome &child=DYN_CAST(GA3DBinaryStringGenome &, c);
@@ -489,11 +489,11 @@ GA3DBinaryStringGenome::SetInitializer(GAGenome & c)
 }
 
 
-int 
+int
 GA3DBinaryStringGenome::FlipMutator(GAGenome & c, float pmut)
 {
   GA3DBinaryStringGenome &child=DYN_CAST(GA3DBinaryStringGenome &, c);
-  register int n, m, i, j, k, d;
+  int n, m, i, j, k, d;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.size());
@@ -550,7 +550,7 @@ GA3DBinaryStringGenome::BitComparator(const GAGenome& a, const GAGenome& b){
 
 
 
-// Make sure our bitmask is big enough, generate a mask, then use it to 
+// Make sure our bitmask is big enough, generate a mask, then use it to
 // extract the information from each parent to stuff the two children.
 // We don't deallocate any space for the masks under the assumption that we'll
 // have to use them again in the future.
@@ -626,10 +626,10 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
     nc = 2;
   }
   else if(c1 || c2){
-    GA3DBinaryStringGenome &sis = (c1 ? 
-				   DYN_CAST(GA3DBinaryStringGenome&, *c1) : 
+    GA3DBinaryStringGenome &sis = (c1 ?
+				   DYN_CAST(GA3DBinaryStringGenome&, *c1) :
 				   DYN_CAST(GA3DBinaryStringGenome&, *c2));
-    
+
     if(mom.width() == dad.width() && mom.height() == dad.height() &&
        mom.depth() == dad.depth() &&
        sis.width() == mom.width() && sis.height() == mom.height() &&
@@ -665,7 +665,7 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
 //   This is designed only for genomes that are the same length.  If the child
 // is not the same length as the parent, or if the children are not the same
 // size, we don't do the crossover.
-//   In the interest of speed we do not do any checks for size.  Do not use 
+//   In the interest of speed we do not do any checks for size.  Do not use
 // this crossover method when the parents and children may be different sizes.
 // It might break!
 int
@@ -733,7 +733,7 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
   }
   else if(c1 || c2){
     GA3DBinaryStringGenome &sis = (c1 ?
-				   DYN_CAST(GA3DBinaryStringGenome &, *c1) : 
+				   DYN_CAST(GA3DBinaryStringGenome &, *c1) :
 				   DYN_CAST(GA3DBinaryStringGenome &, *c2));
 
     if(mom.width() == dad.width() && mom.height() == dad.height() &&
@@ -772,7 +772,7 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
 
 
 // Pick a single point in the 3D block and grab alternating quadrants for each
-// child.  If the children are resizable, this crossover does clipping or 
+// child.  If the children are resizable, this crossover does clipping or
 // padding depending on the setting of the clip flag.  If we pad, we fill the
 // additional bits with random contents.
 int
@@ -795,8 +795,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE){
-      if(mom.width() != dad.width() || 
-	 sis.width() != bro.width() || 
+      if(mom.width() != dad.width() ||
+	 sis.width() != bro.width() ||
 	 sis.width() != mom.width()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -817,11 +817,11 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitex = GAMin(momsitex, dadsitex);
       lenx = GAMin(momlenx, dadlenx);
     }
-    
+
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
-      if(mom.height() != dad.height() || 
-	 sis.height() != bro.height() || 
+      if(mom.height() != dad.height() ||
+	 sis.height() != bro.height() ||
 	 sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -842,11 +842,11 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitey = GAMin(momsitey, dadsitey);
       leny = GAMin(momleny, dadleny);
     }
-    
+
     if(sis.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE){
-      if(mom.depth() != dad.depth() || 
-	 sis.depth() != bro.depth() || 
+      if(mom.depth() != dad.depth() ||
+	 sis.depth() != bro.depth() ||
 	 sis.depth() != mom.depth()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -871,8 +871,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
     sis.resize(sitex+lenx, sitey+leny, sitez+lenz);
     bro.resize(sitex+lenx, sitey+leny, sitez+lenz);
 
-    sis.copy(mom, 
-	     0, 0, 0, 
+    sis.copy(mom,
+	     0, 0, 0,
 	     momsitex-sitex, momsitey-sitey, momsitez-sitez,
 	     sitex, sitey, sitez);
     sis.copy(dad,
@@ -887,8 +887,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	     sitex, sitey, 0,
 	     momsitex, momsitey, momsitez-sitez,
 	     lenx, leny, sitez);
-    sis.copy(dad, 
-	     0, 0, sitez, 
+    sis.copy(dad,
+	     0, 0, sitez,
 	     dadsitex-sitex, dadsitey-sitey, dadsitez,
 	     sitex, sitey, lenz);
     sis.copy(mom,
@@ -903,9 +903,9 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	     sitex, sitey, sitez,
 	     dadsitex, dadsitey, dadsitez,
 	     lenx, leny, lenz);
-    
-    bro.copy(dad, 
-	     0, 0, 0, 
+
+    bro.copy(dad,
+	     0, 0, 0,
 	     dadsitex-sitex, dadsitey-sitey, dadsitez-sitez,
 	     sitex, sitey, sitez);
     bro.copy(mom,
@@ -920,8 +920,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	     sitex, sitey, 0,
 	     dadsitex, dadsitey, dadsitez-sitez,
 	     lenx, leny, sitez);
-    bro.copy(mom, 
-	     0, 0, sitez, 
+    bro.copy(mom,
+	     0, 0, sitez,
 	     momsitex-sitex, momsitey-sitey, momsitez,
 	     sitex, sitey, lenz);
     bro.copy(dad,
@@ -936,7 +936,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	     sitex, sitey, sitez,
 	     momsitex, momsitey, momsitez,
 	     lenx, leny, lenz);
-    
+
     nc = 2;
   }
   else if(c1 || c2){
@@ -960,7 +960,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitex = GAMin(momsitex, dadsitex);
       lenx = GAMin(momlenx, dadlenx);
     }
-    
+
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
       if(mom.height() != dad.height() || sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -977,7 +977,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitey = GAMin(momsitey, dadsitey);
       leny = GAMin(momleny, dadleny);
     }
-    
+
     if(sis.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE){
       if(mom.depth() != dad.depth() || sis.depth() != mom.depth()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -998,8 +998,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
     sis.resize(sitex+lenx, sitey+leny, sitez+lenz);
 
     if(GARandomBit()){
-      sis.copy(mom, 
-	       0, 0, 0, 
+      sis.copy(mom,
+	       0, 0, 0,
 	       momsitex-sitex, momsitey-sitey, momsitez-sitez,
 	       sitex, sitey, sitez);
       sis.copy(dad,
@@ -1014,8 +1014,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	       sitex, sitey, 0,
 	       momsitex, momsitey, momsitez-sitez,
 	       lenx, leny, sitez);
-      sis.copy(dad, 
-	       0, 0, sitez, 
+      sis.copy(dad,
+	       0, 0, sitez,
 	       dadsitex-sitex, dadsitey-sitey, dadsitez,
 	       sitex, sitey, lenz);
       sis.copy(mom,
@@ -1032,8 +1032,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	       lenx, leny, lenz);
     }
     else{
-      sis.copy(dad, 
-	       0, 0, 0, 
+      sis.copy(dad,
+	       0, 0, 0,
 	       dadsitex-sitex, dadsitey-sitey, dadsitez-sitez,
 	       sitex, sitey, sitez);
       sis.copy(mom,
@@ -1048,8 +1048,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	       sitex, sitey, 0,
 	       dadsitex, dadsitey, dadsitez-sitez,
 	       lenx, leny, sitez);
-      sis.copy(mom, 
-	       0, 0, sitez, 
+      sis.copy(mom,
+	       0, 0, sitez,
 	       momsitex-sitex, momsitey-sitey, momsitez,
 	       sitex, sitey, lenz);
       sis.copy(dad,

--- a/Dynamic_MPFA/source/ga-mpi/GAListGenome.C
+++ b/Dynamic_MPFA/source/ga-mpi/GAListGenome.C
@@ -17,7 +17,7 @@
 #include <ga-mpi/GAMask.h>
 #include <ga-mpi/garandom.h>
 
-template <class T> int 
+template <class T> int
 GAListIsHole(const GAListGenome<T>&, const GAListGenome<T>&, int, int, int);
 
 
@@ -30,8 +30,8 @@ GAListGenome<T>::className() const {return "GAListGenome";}
 template <class T> int
 GAListGenome<T>::classID() const {return GAID::ListGenome;}
 
-template <class T> 
-GAListGenome<T>::GAListGenome(GAGenome::Evaluator f, void * u) : 
+template <class T>
+GAListGenome<T>::GAListGenome(GAGenome::Evaluator f, void * u) :
 GAList<T>(),
 GAGenome(DEFAULT_LIST_INITIALIZER,
 	 DEFAULT_LIST_MUTATOR,
@@ -42,8 +42,8 @@ GAGenome(DEFAULT_LIST_INITIALIZER,
 }
 
 
-template <class T> 
-GAListGenome<T>::GAListGenome(const GAListGenome<T> & orig) : 
+template <class T>
+GAListGenome<T>::GAListGenome(const GAListGenome<T> & orig) :
 GAList<T>(),
 GAGenome() {
   GAListGenome<T>::copy(orig);
@@ -76,10 +76,10 @@ GAListGenome<T>::copy(const GAGenome & orig){
 
 #ifdef GALIB_USE_STREAMS
 // Traverse the list (breadth-first) and dump the contents as best we can to
-// the stream.  We don't try to write the contents of the nodes - we simply 
+// the stream.  We don't try to write the contents of the nodes - we simply
 // write a . for each node in the list.
 template <class T> int
-GAListGenome<T>::write(STD_OSTREAM & os) const 
+GAListGenome<T>::write(STD_OSTREAM & os) const
 {
   os << "node       next       prev       contents\n";
   if(!this->hd) return 0;;
@@ -105,7 +105,7 @@ GAListGenome<T>::write(STD_OSTREAM & os) const
 // then you have nothing to worry about.
 //   Neither of these operators affects the internal iterator of either
 // list genome in any way.
-template <class T> int 
+template <class T> int
 GAListGenome<T>::equal(const GAGenome & c) const
 {
   if(this == &c) return 1;
@@ -136,14 +136,14 @@ GAListGenome<T>::equal(const GAGenome & c) const
 ---------------------------------------------------------------------------- */
 // Mutate a list by nuking nodes.  Any node has a pmut chance of getting nuked.
 // This is actually kind of bogus for the second part of the if clause (if nMut
-// is greater than or equal to 1).  Nodes end up having more than pmut 
+// is greater than or equal to 1).  Nodes end up having more than pmut
 // probability of getting nuked.
 //   After the mutation the iterator is left at the head of the list.
 template <class T> int
 GAListGenome<T>::DestructiveMutator(GAGenome & c, float pmut)
 {
   GAListGenome<T> &child=DYN_CAST(GAListGenome<T> &, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return 0;
 
   n = child.size();
@@ -171,14 +171,14 @@ GAListGenome<T>::DestructiveMutator(GAGenome & c, float pmut)
 
 // Mutate a list by swapping two nodes.  Any node has a pmut chance of getting
 // swapped, and the swap could happen to any other node.  And in the case of
-// nMut < 1, the swap may generate a swap partner that is the same node, in 
+// nMut < 1, the swap may generate a swap partner that is the same node, in
 // which case no swap occurs (we don't check).
 //   After the mutation the iterator is left at the head of the list.
 template <class T> int
 GAListGenome<T>::SwapMutator(GAGenome & c, float pmut)
 {
   GAListGenome<T> &child=DYN_CAST(GAListGenome<T> &, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return 0;
 
   n = child.size();
@@ -205,7 +205,7 @@ GAListGenome<T>::SwapMutator(GAGenome & c, float pmut)
 
 // This comparator returns the number of elements that the two lists have
 // in common (both in position and in value).  If they are different lengths
-// then we just say they are completely different.  This is probably barely 
+// then we just say they are completely different.  This is probably barely
 // adequate for most applications - we really should give more credit for
 // nodes that are the same but in different positions.  But that would be
 // pretty nasty to compute.
@@ -213,7 +213,7 @@ GAListGenome<T>::SwapMutator(GAGenome & c, float pmut)
 // which to compare this diversity measure.  Its kind of hard to define this
 // one in a general way...
 template <class T> float
-GAListGenome<T>::NodeComparator(const GAGenome& a, const GAGenome& b) 
+GAListGenome<T>::NodeComparator(const GAGenome& a, const GAGenome& b)
 {
   if(&a == &b) return 0;
   const GAListGenome<T>& sis=DYN_CAST(const GAListGenome<T>&, a);
@@ -244,7 +244,7 @@ GAListGenome<T>::NodeComparator(const GAGenome& a, const GAGenome& b)
 
 #define SWAP(a,b) {unsigned int tmp=a; a=b; b=tmp;}
 
-// This crossover picks a site between nodes in each parent.  It is the same 
+// This crossover picks a site between nodes in each parent.  It is the same
 // as single point crossover on a resizeable binary string genome.  The site
 // in the mother is not necessarily the same as the site in the father!
 //   When we pick a crossover site, it is between nodes of the list (otherwise
@@ -253,7 +253,7 @@ GAListGenome<T>::NodeComparator(const GAGenome& a, const GAGenome& b)
 // whereas the cross site possibilities are numbered from 0 to size, inclusive.
 // This means we have to map the site to the list to determine whether an
 // insertion should occur before or after a node.
-//   We first copy the mother into the child (this deletes whatever contents 
+//   We first copy the mother into the child (this deletes whatever contents
 // were in the child originally).  Then we clone the father from the cross site
 // to the end of the list.  Then we delete the tail of the child from the
 // mother's cross site to the end of the list.  Finally, we insert the clone
@@ -265,7 +265,7 @@ GAListGenome<T>::NodeComparator(const GAGenome& a, const GAGenome& b)
 // do better by copying only what we need of the mother.
 template <class T> int
 GAListGenome<T>::
-OnePointCrossover(const GAGenome& p1, const GAGenome& p2, 
+OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 		  GAGenome* c1, GAGenome* c2){
   const GAListGenome<T> &mom=DYN_CAST(const GAListGenome<T> &, p1);
   const GAListGenome<T> &dad=DYN_CAST(const GAListGenome<T> &, p2);
@@ -330,13 +330,13 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 //   This version of the partial match crossover uses objects that are multiply
 // instantiated - each list genome contains its own objects in its nodes.
 // The operator== method must be defined on the object for this implementation
-// to work!  In this case, the 'object' is an int, so we're OK.  If you are 
+// to work!  In this case, the 'object' is an int, so we're OK.  If you are
 // putting your own objects in the nodes, be sure you have operator== defined
 // for your object.  You must also have operator!= defined for your object.  We
 // do not do any assignments, so operator= and/or copy is not required.
 //   We assume that none of the nodes will return a NULL pointer.  Also assume
 // that the cross site has been selected properly.
-//   First we make a copy of the mother.  Then we loop through the match 
+//   First we make a copy of the mother.  Then we loop through the match
 // section and try to swap each element in the child's match section with its
 // partner (as defined by the current node in the father's match section).
 //   Mirroring will work the same way - just swap mom & dad and you're all set.

--- a/Dynamic_MPFA/source/ga-mpi/GARealGenome.C
+++ b/Dynamic_MPFA/source/ga-mpi/GARealGenome.C
@@ -13,7 +13,7 @@
 
 // We must also specialize the allele set so that the alleles are handled
 // properly.  Be sure to handle bounds correctly whether we are discretized
-// or continuous.  Handle the case where someone sets stupid bounds that 
+// or continuous.  Handle the case where someone sets stupid bounds that
 // might cause an infinite loop for exclusive bounds.
 template <> float
 GAAlleleSet<float>::allele() const {
@@ -29,8 +29,8 @@ GAAlleleSet<float>::allele() const {
     if(core->lowerb == GAAllele::EXCLUSIVE) value += core->a[2];
   }
   else{
-    if(core->a[0] == core->a[1] && 
-       core->lowerb == GAAllele::EXCLUSIVE && 
+    if(core->a[0] == core->a[1] &&
+       core->lowerb == GAAllele::EXCLUSIVE &&
        core->upperb == GAAllele::EXCLUSIVE) {
       value = core->a[0];
     }
@@ -74,9 +74,9 @@ GAAlleleSet<float>::allele(unsigned int i) const {
 
 // now the specialization of the genome itself.
 
-template <> const char * 
+template <> const char *
 GA1DArrayAlleleGenome<float>::className() const {return "GARealGenome";}
-template <> int 
+template <> int
 GA1DArrayAlleleGenome<float>::classID() const {return GAID::FloatGenome;}
 
 template <> GA1DArrayAlleleGenome<float>::
@@ -108,7 +108,7 @@ GA1DArrayGenome<float>(sa.size(), f, u){
   crossover(DEFAULT_REAL_CROSSOVER);
 }
 
-template <> 
+template <>
 GA1DArrayAlleleGenome<float>::~GA1DArrayAlleleGenome(){
   delete [] aset;
 }
@@ -148,12 +148,12 @@ GA1DArrayAlleleGenome<float>::read(STD_ISTREAM & is) {
 ---------------------------------------------------------------------------- */
 // The Gaussian mutator picks a new value based on a Gaussian distribution
 // around the current value.  We respect the bounds (if any).
-//*** need to figure out a way to make the stdev other than 1.0 
-int 
+//*** need to figure out a way to make the stdev other than 1.0
+int
 GARealGaussianMutator(GAGenome& g, float pmut){
   GA1DArrayAlleleGenome<float> &child=
     DYN_CAST(GA1DArrayAlleleGenome<float> &, g);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * (float)(child.length());
@@ -200,7 +200,7 @@ GARealGaussianMutator(GAGenome& g, float pmut){
 // identical.  If parents are not the same length, the extra elements are not
 // set!  You might want to add some noise to this so that both children are not
 // the same...
-int 
+int
 GARealArithmeticCrossover(const GAGenome& p1, const GAGenome& p2,
 			  GAGenome* c1, GAGenome* c2) {
   const GA1DArrayGenome<float> &mom=
@@ -222,8 +222,8 @@ GARealArithmeticCrossover(const GAGenome& p1, const GAGenome& p2,
     n = 2;
   }
   else if(c1 || c2){
-    GA1DArrayGenome<float> &sis = (c1 ? 
-				   DYN_CAST(GA1DArrayGenome<float> &, *c1) : 
+    GA1DArrayGenome<float> &sis = (c1 ?
+				   DYN_CAST(GA1DArrayGenome<float> &, *c1) :
 				   DYN_CAST(GA1DArrayGenome<float> &, *c2));
 
     int len = GAMax(mom.length(), dad.length());
@@ -240,7 +240,7 @@ GARealArithmeticCrossover(const GAGenome& p1, const GAGenome& p2,
 // Blend crossover generates a new value based on the interval between parents.
 // We generate a uniform distribution based on the distance between parent
 // values, then choose the child value based upon that distribution.
-int 
+int
 GARealBlendCrossover(const GAGenome& p1, const GAGenome& p2,
 		     GAGenome* c1, GAGenome* c2) {
   const GA1DArrayGenome<float> &mom=
@@ -257,9 +257,9 @@ GARealBlendCrossover(const GAGenome& p1, const GAGenome& p2,
     int len = GAMax(mom.length(), dad.length());
     for(int i=0; i<len; i++) {
       float dist = 0;
-      if(mom.gene(i) > dad.gene(i)) 
+      if(mom.gene(i) > dad.gene(i))
 	dist = mom.gene(i) - dad.gene(i);
-      else 
+      else
 	dist = dad.gene(i) - mom.gene(i);
       float lo = (GAMin(mom.gene(i), dad.gene(i))) - 0.5*dist;
       float hi = (GAMax(mom.gene(i), dad.gene(i))) + 0.5*dist;
@@ -276,9 +276,9 @@ GARealBlendCrossover(const GAGenome& p1, const GAGenome& p2,
     int len = GAMax(mom.length(), dad.length());
     for(int i=0; i<len; i++) {
       float dist = 0;
-      if(mom.gene(i) > dad.gene(i)) 
+      if(mom.gene(i) > dad.gene(i))
 	dist = mom.gene(i) - dad.gene(i);
-      else 
+      else
 	dist = dad.gene(i) - mom.gene(i);
       float lo = (GAMin(mom.gene(i), dad.gene(i))) - 0.5*dist;
       float hi = (GAMax(mom.gene(i), dad.gene(i))) + 0.5*dist;
@@ -298,7 +298,7 @@ GARealBlendCrossover(const GAGenome& p1, const GAGenome& p2,
 //
 // These must be included _after_ the specializations because some compilers
 // get all wigged out about the declaration/specialization order.  Note that
-// some compilers require a syntax different than others when forcing the 
+// some compilers require a syntax different than others when forcing the
 // instantiation (i.e. GNU wants the 'template class', borland does not).
 #ifndef GALIB_USE_AUTO_INST
 #include <ga-mpi/GAAllele.C>

--- a/Dynamic_MPFA/source/ga-mpi/GATreeGenome.C
+++ b/Dynamic_MPFA/source/ga-mpi/GATreeGenome.C
@@ -25,7 +25,7 @@ template <class T> int
 GATreeGenome<T>::classID() const {return GAID::TreeGenome;}
 
 template <class T>
-GATreeGenome<T>::GATreeGenome(GAGenome::Evaluator f, void * u) : 
+GATreeGenome<T>::GATreeGenome(GAGenome::Evaluator f, void * u) :
 GATree<T>(),
 GAGenome(DEFAULT_TREE_INITIALIZER,
 	 DEFAULT_TREE_MUTATOR,
@@ -37,7 +37,7 @@ GAGenome(DEFAULT_TREE_INITIALIZER,
 
 
 template <class T>
-GATreeGenome<T>::GATreeGenome(const GATreeGenome<T> & orig) : 
+GATreeGenome<T>::GATreeGenome(const GATreeGenome<T> & orig) :
 GATree<T>(),
 GAGenome() {
   GATreeGenome<T>::copy(orig);
@@ -70,7 +70,7 @@ GATreeGenome<T>::copy(const GAGenome & orig) {
 
 #ifdef GALIB_USE_STREAMS
 // Traverse the tree (breadth-first) and dump the contents as best we can to
-// the stream.  We don't try to write the contents of the nodes - we simply 
+// the stream.  We don't try to write the contents of the nodes - we simply
 // write a . for each node in the tree.
 //   We allocate space for x,y coord pair for each node in the tree.  Then we
 // do a depth-first traversal of the tree and assign coords to the nodes in the
@@ -102,7 +102,7 @@ _tt(STD_OSTREAM & os, GANode<T> * n)
 }
 
 template <class T> int
-GATreeGenome<T>::write(STD_OSTREAM & os) const 
+GATreeGenome<T>::write(STD_OSTREAM & os) const
 {
   os << "node       parent     child      next       prev       contents\n";
   _tt(os, (GANode<T> *)(this->rt));
@@ -111,7 +111,7 @@ GATreeGenome<T>::write(STD_OSTREAM & os) const
 #endif
 
 
-template <class T> int  
+template <class T> int
 GATreeGenome<T>::equal(const GAGenome & c) const
 {
   if(this == &c) return 1;
@@ -140,7 +140,7 @@ template <class T> int
 GATreeGenome<T>::DestructiveMutator(GAGenome & c, float pmut)
 {
   GATreeGenome<T> &child=DYN_CAST(GATreeGenome<T> &, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return 0;
 
   n = child.size();
@@ -169,14 +169,14 @@ GATreeGenome<T>::DestructiveMutator(GAGenome & c, float pmut)
 // This is a rearranging mutation operator.  It randomly picks two nodes in the
 // tree and swaps them.  Any node has a pmut chance of getting
 // swapped, and the swap could happen to any other node.  And in the case of
-// nMut < 1, the swap may generate a swap partner that is the same node, in 
+// nMut < 1, the swap may generate a swap partner that is the same node, in
 // which case no swap occurs (we don't check).
 //   After the mutation the iterator is left at the root of the tree.
 template <class T> int
 GATreeGenome<T>::SwapNodeMutator(GAGenome & c, float pmut)
 {
   GATreeGenome<T> &child=DYN_CAST(GATreeGenome<T> &, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return 0;
 
   n = child.size();
@@ -214,7 +214,7 @@ template <class T> int
 GATreeGenome<T>::SwapSubtreeMutator(GAGenome & c, float pmut)
 {
   GATreeGenome<T> &child=DYN_CAST(GATreeGenome<T> &, c);
-  register int n, i;
+  int n, i;
   int a, b;
   if(pmut <= 0.0) return 0;
 
@@ -247,7 +247,7 @@ GATreeGenome<T>::SwapSubtreeMutator(GAGenome & c, float pmut)
 // We use the recursive tree function to compare the tree structures.  This
 // does not compare the contents of the nodes.
 template <class T> float
-GATreeGenome<T>::TopologyComparator(const GAGenome& a, const GAGenome& b) 
+GATreeGenome<T>::TopologyComparator(const GAGenome& a, const GAGenome& b)
 {
   if(&a == &b) return 0;
   const GATreeGenome<T>& sis=DYN_CAST(const GATreeGenome<T>&, a);
@@ -277,7 +277,7 @@ GATreeGenome<T>::TopologyComparator(const GAGenome& a, const GAGenome& b)
 //     do the check to see if the crossover site is valid.
 template <class T> int
 GATreeGenome<T>::
-OnePointCrossover(const GAGenome& p1, const GAGenome& p2, 
+OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 		  GAGenome* c1, GAGenome* c2){
   const GATreeGenome<T> &mom=DYN_CAST(const GATreeGenome<T> &, p1);
   const GATreeGenome<T> &dad=DYN_CAST(const GATreeGenome<T> &, p2);

--- a/Global_dynamic_MPFA/source/evolver.cpp
+++ b/Global_dynamic_MPFA/source/evolver.cpp
@@ -11,7 +11,7 @@
 // For shared memory management
 #include <sys/mman.h>
 
-#include <ctime> // For clock()
+#include <ctime>  // For clock()
 #include <chrono> // For clock()
 #include <mpi.h>
 
@@ -31,12 +31,12 @@
 #include <source/CPFA/CPFA_loop_functions.h>
 
 // For timing
-#include <ctime> // For clock()
+#include <ctime>  // For clock()
 #include <chrono> // For clock()
 
 // For shared variable between child and parent process
-#include  <sys/ipc.h>
-#include  <sys/shm.h>
+#include <sys/ipc.h>
+#include <sys/shm.h>
 
 float objective(GAGenome &);
 float LaunchARGoS(GAGenome &);
@@ -44,11 +44,11 @@ float LaunchARGoS(GAGenome &);
 int mpi_tasks, mpi_rank;
 
 int elitism = 0;
-int n_trials = 20; // used by the objective function
+int n_trials = 20;            // used by the objective function
 double mutation_stdev = 1.00; // Gaussian mutation stdev - will be scaled by possible range
 string experiment_path;
 
-void CPFAInitializer(GAGenome & c);
+void CPFAInitializer(GAGenome &c);
 int GARealGaussianMutatorStdev(GAGenome &, float);
 
 std::default_random_engine generator;
@@ -62,125 +62,124 @@ int main(int argc, char **argv)
   MPI_Init(&argc, &argv);
   MPI_Comm_size(MPI_COMM_WORLD, &mpi_tasks);
   MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
-                         
-  char hostname[1024];                                                                                                       
-  hostname[1023] = '\0';                                          
+
+  char hostname[1024];
+  hostname[1023] = '\0';
   gethostname(hostname, 1023);
-  
+
   double mutation_rate = 0.01;
   double crossover_rate = 0.01;
   int population_size = 10;
   int n_generations = 10;
 
-    char c='h';
+  char c = 'h';
   // Handle command line arguments
-  while ((c = getopt (argc, argv, "t:g:p:c:m:s:h:e:x:")) != -1)
+  while ((c = getopt(argc, argv, "t:g:p:c:m:s:h:e:x:")) != -1)
     switch (c)
-      {
-      case 'x':
-	experiment_path = optarg;
+    {
+    case 'x':
+      experiment_path = optarg;
       break;
-      case 't':
-	n_trials = atoi(optarg);
-	break;
-      case 'g':
-        n_generations = atoi(optarg);
-        break;
-      case 'p':
-        population_size = atoi(optarg);
-        break;
-      case 'm':
-        mutation_rate = strtod(optarg, NULL);
-	break;
-      case 'c':
-	crossover_rate = strtod(optarg, NULL);
-	break;
-      case 's':
-        mutation_stdev = strtod(optarg, NULL);
-	break;
-      case 'e':
-        elitism = atoi(optarg);
-	break;
-      case 'h':
-	printf("Usage: %s -p {population size} -g {number of generations} -t {number of trials} -c {crossover rate} -m {mutation rate} -s {mutation standard deviation} -e {elitism 0 or 1}", argv[0]);
-	break;
-      case '?':
-        if (optopt == 'p')
-          fprintf (stderr, "Option -%c requires an argument specifying the population size.\n", optopt);
-	else if (optopt == 'g')
-	  fprintf (stderr, "Option -%c requires an argument specifying the number of generations.\n", optopt);
-	else if (optopt == 't')
-	  fprintf (stderr, "Option -%c requires an argument specifying the number of trials.\n", optopt);
-	else if (optopt == 'c')
-	  fprintf (stderr, "Option -%c requires an argument specifying the crossover rate.\n", optopt);
-	else if (optopt == 'm')
-	  fprintf (stderr, "Option -%c requires an argument specifying the mutation rate.\n", optopt);
-	else if (optopt == 's')
-	  fprintf (stderr, "Option -%c requires an argument specifying the mutation standard deviation.\n", optopt);
-        else if (isprint (optopt))
-          fprintf (stderr, "Unknown option `-%c'.\n", optopt);
-        else
-          fprintf (stderr,
-                   "Unknown option character `\\x%x'.\n",
-                   optopt);
-        return 1;
-      default:
-	printf("Usage: %s -p {population size} -g {number of generations} -t {number of trials} -c {crossover rate} -m {mutation rate} -s {mutation standard deviation}", argv[0]);
-        abort ();
-      }
+    case 't':
+      n_trials = atoi(optarg);
+      break;
+    case 'g':
+      n_generations = atoi(optarg);
+      break;
+    case 'p':
+      population_size = atoi(optarg);
+      break;
+    case 'm':
+      mutation_rate = strtod(optarg, NULL);
+      break;
+    case 'c':
+      crossover_rate = strtod(optarg, NULL);
+      break;
+    case 's':
+      mutation_stdev = strtod(optarg, NULL);
+      break;
+    case 'e':
+      elitism = atoi(optarg);
+      break;
+    case 'h':
+      printf("Usage: %s -p {population size} -g {number of generations} -t {number of trials} -c {crossover rate} -m {mutation rate} -s {mutation standard deviation} -e {elitism 0 or 1}", argv[0]);
+      break;
+    case '?':
+      if (optopt == 'p')
+        fprintf(stderr, "Option -%c requires an argument specifying the population size.\n", optopt);
+      else if (optopt == 'g')
+        fprintf(stderr, "Option -%c requires an argument specifying the number of generations.\n", optopt);
+      else if (optopt == 't')
+        fprintf(stderr, "Option -%c requires an argument specifying the number of trials.\n", optopt);
+      else if (optopt == 'c')
+        fprintf(stderr, "Option -%c requires an argument specifying the crossover rate.\n", optopt);
+      else if (optopt == 'm')
+        fprintf(stderr, "Option -%c requires an argument specifying the mutation rate.\n", optopt);
+      else if (optopt == 's')
+        fprintf(stderr, "Option -%c requires an argument specifying the mutation standard deviation.\n", optopt);
+      else if (isprint(optopt))
+        fprintf(stderr, "Unknown option `-%c'.\n", optopt);
+      else
+        fprintf(stderr,
+                "Unknown option character `\\x%x'.\n",
+                optopt);
+      return 1;
+    default:
+      printf("Usage: %s -p {population size} -g {number of generations} -t {number of trials} -c {crossover rate} -m {mutation rate} -s {mutation standard deviation}", argv[0]);
+      abort();
+    }
 
   if (experiment_path.empty())
-    {
-      printf("Usage: %s -p {population size} -g {number of generations} -t {number of trials} -c {crossover rate} -m {mutation rate} -s {mutation standard deviation} -x {argos experiment file}\n", argv[0]);
-      exit(1);
-    }
+  {
+    printf("Usage: %s -p {population size} -g {number of generations} -t {number of trials} -c {crossover rate} -m {mutation rate} -s {mutation standard deviation} -x {argos experiment file}\n", argv[0]);
+    exit(1);
+  }
 
   float max_float = std::numeric_limits<float>::max();
 
-    //printf("%s:\tworker %d ready.\n", hostname, mpi_rank);                                          
+  // printf("%s:\tworker %d ready.\n", hostname, mpi_rank);
 
   // See if we've been given a seed to use (for testing purposes).  When you
   // specify a random seed, the evolution will be exactly the same each time
   // you use that seed number
   unsigned int seed = 12345;
-  for(int i=1 ; i<argc ; i++)
-    if(strcmp(argv[i++],"seed") == 0)
+  for (int i = 1; i < argc; i++)
+    if (strcmp(argv[i++], "seed") == 0)
       seed = atoi(argv[i]);
 
   srand(seed);
   generator.seed(seed);
   // popsize / mpi_tasks must be an integer
-  population_size = mpi_tasks * int((double)population_size/(double)mpi_tasks+0.999);
-  
-  if (mpi_rank==0)
-    {
-      printf("Population size: %d\nNumber of trials: %d\nNumber of generations: %d\nCrossover rate: %f\nMutation rate: %f\nMutation stdev: %f\nAllocated MPI workers: %d\n", population_size, n_trials, n_generations, crossover_rate, mutation_rate, mutation_stdev, mpi_tasks);
-      	printf("elitism: %d\n", elitism);
-    }
+  population_size = mpi_tasks * int((double)population_size / (double)mpi_tasks + 0.999);
+
+  if (mpi_rank == 0)
+  {
+    printf("Population size: %d\nNumber of trials: %d\nNumber of generations: %d\nCrossover rate: %f\nMutation rate: %f\nMutation stdev: %f\nAllocated MPI workers: %d\n", population_size, n_trials, n_generations, crossover_rate, mutation_rate, mutation_stdev, mpi_tasks);
+    printf("elitism: %d\n", elitism);
+  }
 
   // Define the genome
   GARealAlleleSetArray allele_array;
-  
-  allele_array.add(0, 1.0); // Probability of switching to search
-  allele_array.add(0, 1.0); // Probability of returning to nest
-  allele_array.add(0, 4*M_PI); // Uninformed search variation
-  allele_array.add(0, 20); // Rate of informed search decay
-  allele_array.add(0, 20); // Rate of site fidelity
-  allele_array.add(0, 20); // Rate of laying pheremone
-  allele_array.add(0, 20); // Rate of pheremone decay
-  
-    
+
+  allele_array.add(0, 1.0);      // Probability of switching to search
+  allele_array.add(0, 1.0);      // Probability of returning to nest
+  allele_array.add(0, 4 * M_PI); // Uninformed search variation
+  allele_array.add(0, 20);       // Rate of informed search decay
+  allele_array.add(0, 20);       // Rate of site fidelity
+  allele_array.add(0, 20);       // Rate of laying pheremone
+  allele_array.add(0, 20);       // Rate of pheremone decay
+
   // Create the template genome using the phenotype map we just made.
   GARealGenome genome(allele_array, objective);
   genome.crossover(GARealUniformCrossover);
   genome.mutator(GARealGaussianMutatorStdev); // Specify our version of the Gaussuan mutator
   genome.initializer(CPFAInitializer);
- 
+
   // Now create the GA using the genome and run it.
   GASimpleGA ga(genome);
   GALinearScaling scaling;
-  ga.maximize();		// Maximize the objective
- 
+  ga.maximize(); // Maximize the objective
+
   ga.populationSize(population_size);
   ga.nGenerations(n_generations);
   ga.pMutation(mutation_rate);
@@ -190,7 +189,7 @@ int main(int argc, char **argv)
     ga.elitist(gaTrue);
   else
     ga.elitist(gaFalse);
-  if(mpi_rank == 0)
+  if (mpi_rank == 0)
     ga.scoreFilename("evolution.txt");
   else
     ga.scoreFilename("/dev/null");
@@ -198,338 +197,363 @@ int main(int argc, char **argv)
   ga.scoreFrequency(1);
   ga.flushFrequency(1);
   ga.selectScores(GAStatistics::AllScores);
-  
+
   // Pass MPI data to the GA class
   ga.mpi_rank(mpi_rank);
   ga.mpi_tasks(mpi_tasks);
-  //ga.evolve(seed); // Manual generations
+  // ga.evolve(seed); // Manual generations
 
-// initialize the ga since we are not using the evolve function
+  // initialize the ga since we are not using the evolve function
   ga.initialize(seed); // This is essential for the mpi workers to be sychronized
 
-    // Name the results file with the current time and date
- time_t t = time(0);   // get time now
-    struct tm * now = localtime( & t );
-    stringstream ss;
+  // Name the results file with the current time and date
+  time_t t = time(0); // get time now
+  struct tm *now = localtime(&t);
+  stringstream ss;
 
-    boost::filesystem::path exp_path(experiment_path);
-    
-    ss << "results/CPFA-evolution-"
-       << exp_path.stem().string() << '-'
-       <<GIT_BRANCH<<"-"<<GIT_COMMIT_HASH<<"-"
-       << (now->tm_year) << '-'
-       << (now->tm_mon + 1) << '-'
-       <<  now->tm_mday << '-'
-       <<  now->tm_hour << '-'
-       <<  now->tm_min << '-'
-       <<  now->tm_sec << ".csv";
+  boost::filesystem::path exp_path(experiment_path);
 
-    string results_file_name = ss.str();
+  ss << "results/CPFA-evolution-"
+     << exp_path.stem().string() << '-'
+     << GIT_BRANCH << "-" << GIT_COMMIT_HASH << "-"
+     << (now->tm_year) << '-'
+     << (now->tm_mon + 1) << '-'
+     << now->tm_mday << '-'
+     << now->tm_hour << '-'
+     << now->tm_min << '-'
+     << now->tm_sec << ".csv";
 
-    if (mpi_rank == 0)
-      {
+  string results_file_name = ss.str();
+
+  if (mpi_rank == 0)
+  {
     // Write output file header
     ofstream results_output_stream;
-	results_output_stream.open(results_file_name, ios::app);
-	results_output_stream << "Population size: " << population_size << "\nNumber of trials: " << n_trials << "\nNumber of generations: "<< n_generations<<"\nCrossover rate: "<< crossover_rate<<"\nMutation rate: " << mutation_rate << "\nMutation stdev: "<< mutation_stdev << "Algorithm: CPFA\n" << "Number of searchers: 6\n" << "Number of targets: 256\n" << "Target distribution: power law" << endl;
-	results_output_stream << "Generation" 
-			      << ", " << "Compute Time (s)"
-			      << ", " << "Convergence"
-			      << ", " << "Mean"
-			      << ", " << "Maximum"
-			      << ", " << "Minimum"
-			      << ", " << "Standard Deviation"
-			      << ", " << "Diversity"
-			      << ", " << "ProbabilityOfSwitchingToSearching"
-			      << ", " << "ProbabilityOfReturningToNest"
-			      << ", " << "UninformedSearchVariation"
-			      << ", " << "RateOfInformedSearchDecay"
-			      << ", " << "RateOfSiteFidelity"
-			      << ", " << "RateOfLayingPheromone"
-			      << ", " << "RateOfPheromoneDecay";
+    results_output_stream.open(results_file_name, ios::app);
+    results_output_stream << "Population size: " << population_size << "\nNumber of trials: " << n_trials << "\nNumber of generations: " << n_generations << "\nCrossover rate: " << crossover_rate << "\nMutation rate: " << mutation_rate << "\nMutation stdev: " << mutation_stdev << "Algorithm: CPFA\n"
+                          << "Number of searchers: 6\n"
+                          << "Number of targets: 256\n"
+                          << "Target distribution: power law" << endl;
+    results_output_stream << "Generation"
+                          << ", "
+                          << "Compute Time (s)"
+                          << ", "
+                          << "Convergence"
+                          << ", "
+                          << "Mean"
+                          << ", "
+                          << "Maximum"
+                          << ", "
+                          << "Minimum"
+                          << ", "
+                          << "Standard Deviation"
+                          << ", "
+                          << "Diversity"
+                          << ", "
+                          << "ProbabilityOfSwitchingToSearching"
+                          << ", "
+                          << "ProbabilityOfReturningToNest"
+                          << ", "
+                          << "UninformedSearchVariation"
+                          << ", "
+                          << "RateOfInformedSearchDecay"
+                          << ", "
+                          << "RateOfSiteFidelity"
+                          << ", "
+                          << "RateOfLayingPheromone"
+                          << ", "
+                          << "RateOfPheromoneDecay";
 
-	results_output_stream << endl;
-	results_output_stream.close();
-      }
+    results_output_stream << endl;
+    results_output_stream.close();
+  }
 
-	while(!ga.done())
-	  {
+  while (!ga.done())
+  {
 
-	    std::chrono::time_point<std::chrono::system_clock>generation_start, generation_end;
-	    if (mpi_rank == 0)
-	      {
-		generation_start = std::chrono::system_clock::now();
-	      }
-	    
-      // Calculate the generation
-      ga.step();
+    std::chrono::time_point<std::chrono::system_clock> generation_start, generation_end;
+    if (mpi_rank == 0)
+    {
+      generation_start = std::chrono::system_clock::now();
+    }
 
-    if(mpi_rank == 0)
-      {
-	generation_end = std::chrono::system_clock::now();
-	std::chrono::duration<double> generation_elapsed_seconds = generation_end-generation_start;
-	ofstream results_output_stream;
-	results_output_stream.open(results_file_name, ios::app);
-       results_output_stream << ga.statistics().generation() 
-			     << ", " << generation_elapsed_seconds.count()
-			     << ", " << ga.statistics().convergence()
-			     << ", " << ga.statistics().current(GAStatistics::Mean)
-			     << ", " << ga.statistics().current(GAStatistics::Maximum)
-			     << ", " << ga.statistics().current(GAStatistics::Minimum)
-			     << ", " << ga.statistics().current(GAStatistics::Deviation)
-			     << ", " << ga.statistics().current(GAStatistics::Diversity);
-       
-	  for (int i = 0; i < GENOME_SIZE; i++)
-	    results_output_stream << ", " << dynamic_cast<const GARealGenome&>(ga.population().best()).gene(i);
+    // Calculate the generation
+    ga.step();
 
-	  
-	  const GARealGenome& best_genome = dynamic_cast<const GARealGenome&>(ga.statistics().bestIndividual());
-	  results_output_stream << endl;
-	  
-	  results_output_stream << "The GA found an optimum at: ";
-	  results_output_stream << best_genome.gene(0);
-	  for (int i = 1; i < GENOME_SIZE; i++)
-	    results_output_stream << ", " << best_genome.gene(i);
-	  results_output_stream << " with score: " << best_genome.score();
-	  results_output_stream << endl;
-	  results_output_stream.close();
-      }
-	  }
-	// Display the GA's progress
-	if(mpi_rank == 0)
-	  {
-	    cout << ga.statistics() << " " << ga.parameters() << endl;
-	  }
-	
+    if (mpi_rank == 0)
+    {
+      generation_end = std::chrono::system_clock::now();
+      std::chrono::duration<double> generation_elapsed_seconds = generation_end - generation_start;
+      ofstream results_output_stream;
+      results_output_stream.open(results_file_name, ios::app);
+      results_output_stream << ga.statistics().generation()
+                            << ", " << generation_elapsed_seconds.count()
+                            << ", " << ga.statistics().convergence()
+                            << ", " << ga.statistics().current(GAStatistics::Mean)
+                            << ", " << ga.statistics().current(GAStatistics::Maximum)
+                            << ", " << ga.statistics().current(GAStatistics::Minimum)
+                            << ", " << ga.statistics().current(GAStatistics::Deviation)
+                            << ", " << ga.statistics().current(GAStatistics::Diversity);
+
+      for (int i = 0; i < GENOME_SIZE; i++)
+        results_output_stream << ", " << dynamic_cast<const GARealGenome &>(ga.population().best()).gene(i);
+
+      const GARealGenome &best_genome = dynamic_cast<const GARealGenome &>(ga.statistics().bestIndividual());
+      results_output_stream << endl;
+
+      results_output_stream << "The GA found an optimum at: ";
+      results_output_stream << best_genome.gene(0);
+      for (int i = 1; i < GENOME_SIZE; i++)
+        results_output_stream << ", " << best_genome.gene(i);
+      results_output_stream << " with score: " << best_genome.score();
+      results_output_stream << endl;
+      results_output_stream.close();
+    }
+  }
+  // Display the GA's progress
+  if (mpi_rank == 0)
+  {
+    cout << ga.statistics() << " " << ga.parameters() << endl;
+  }
+
   MPI_Finalize();
 
   program_end = std::chrono::system_clock::now();
- 
-  std::chrono::duration<double> program_elapsed_seconds = program_end-program_start;
 
-  if(mpi_rank == 0)
+  std::chrono::duration<double> program_elapsed_seconds = program_end - program_start;
+
+  if (mpi_rank == 0)
     printf("Run time was %f seconds\n", program_elapsed_seconds.count());
 
   return 0;
-  }
+}
 
-// Initializes the genome according to the Beyond Pheromones paper 
-void CPFAInitializer(GAGenome & c)
+// Initializes the genome according to the Beyond Pheromones paper
+void CPFAInitializer(GAGenome &c)
 {
   // For the exponential PDF needed to initialize some of the genes
-  
+
   std::exponential_distribution<double> exponential_distribution_10(10.0);
   std::exponential_distribution<double> exponential_distribution_5(5.0);
   std::uniform_real_distribution<double> uniform_distribution_0_1(0.0, 1.0);
-  std::uniform_real_distribution<double> uniform_distribution_0_4PI(0.0, 4.0*M_PI);
+  std::uniform_real_distribution<double> uniform_distribution_0_4PI(0.0, 4.0 * M_PI);
   std::uniform_real_distribution<double> uniform_distribution_0_20(0.0, 20.0);
 
-  GA1DArrayAlleleGenome<float> &child= DYN_CAST(GA1DArrayAlleleGenome<float> &, c);
+  GA1DArrayAlleleGenome<float> &child = DYN_CAST(GA1DArrayAlleleGenome<float> &, c);
   child.resize(GAGenome::ANY_SIZE); // let chrom resize if it can
-  
-  child.gene(0, uniform_distribution_0_1(generator)); // Probability of switching to search
-  child.gene(1, uniform_distribution_0_1(generator)); // Probability of returning to nest
-  child.gene(2, uniform_distribution_0_4PI(generator)); // Uninformed search variation
-  child.gene(3, exponential_distribution_5(generator)); // Rate of informed search decay
-  child.gene(4, uniform_distribution_0_20(generator)); // Rate of site fidelity
-  child.gene(5, uniform_distribution_0_20(generator)); // Rate of laying pheremone
+
+  child.gene(0, uniform_distribution_0_1(generator));    // Probability of switching to search
+  child.gene(1, uniform_distribution_0_1(generator));    // Probability of returning to nest
+  child.gene(2, uniform_distribution_0_4PI(generator));  // Uninformed search variation
+  child.gene(3, exponential_distribution_5(generator));  // Rate of informed search decay
+  child.gene(4, uniform_distribution_0_20(generator));   // Rate of site fidelity
+  child.gene(5, uniform_distribution_0_20(generator));   // Rate of laying pheremone
   child.gene(6, exponential_distribution_10(generator)); // Rate of pheremone decay
 }
 
 // The mutation operator based on the original from GALib but adds stdev
 // The Gaussian mutator picks a new value based on a Gaussian distribution
 // around the current value.  We respect the bounds (if any).
-int GARealGaussianMutatorStdev(GAGenome& g, float pmut)
+int GARealGaussianMutatorStdev(GAGenome &g, float pmut)
 {
-  GA1DArrayAlleleGenome<float> &child=
-    DYN_CAST(GA1DArrayAlleleGenome<float> &, g);
-  register int n, i;
-  if(pmut <= 0.0) return(0);
+  GA1DArrayAlleleGenome<float> &child =
+      DYN_CAST(GA1DArrayAlleleGenome<float> &, g);
+  int n, i;
+  if (pmut <= 0.0)
+    return (0);
 
   float nMut = pmut * (float)(child.length());
-  int length = child.length()-1;
-  if(nMut < 1.0){// we have to do a flip test on each element
+  int length = child.length() - 1;
+  if (nMut < 1.0)
+  { // we have to do a flip test on each element
     nMut = 0;
-    for(i=length; i>=0; i--){
+    for (i = length; i >= 0; i--)
+    {
       float value = child.gene(i);
-      if(GAFlipCoin(pmut)){
-	if(child.alleleset(i).type() == GAAllele::ENUMERATED ||
-	   child.alleleset(i).type() == GAAllele::DISCRETIZED)
-	  value = child.alleleset(i).allele();
-	else if(child.alleleset(i).type() == GAAllele::BOUNDED){
-	  value += GAUnitGaussian()*mutation_stdev;//*(child.alleleset(i).upper()-child.alleleset(i).lower()); // since the standard deviation varies proportionally to a constant multiplier 
-	  value = GAMax(child.alleleset(i).lower(), value);
-	  value = GAMin(child.alleleset(i).upper(), value);
-	}
-	child.gene(i, value);
-	nMut++;
+      if (GAFlipCoin(pmut))
+      {
+        if (child.alleleset(i).type() == GAAllele::ENUMERATED ||
+            child.alleleset(i).type() == GAAllele::DISCRETIZED)
+          value = child.alleleset(i).allele();
+        else if (child.alleleset(i).type() == GAAllele::BOUNDED)
+        {
+          value += GAUnitGaussian() * mutation_stdev; //*(child.alleleset(i).upper()-child.alleleset(i).lower()); // since the standard deviation varies proportionally to a constant multiplier
+          value = GAMax(child.alleleset(i).lower(), value);
+          value = GAMin(child.alleleset(i).upper(), value);
+        }
+        child.gene(i, value);
+        nMut++;
       }
     }
   }
-  else{// only mutate the ones we need to
-    for(n=0; n<nMut; n++){
-      int idx = GARandomInt(0,length);
+  else
+  { // only mutate the ones we need to
+    for (n = 0; n < nMut; n++)
+    {
+      int idx = GARandomInt(0, length);
       float value = child.gene(idx);
-      if(child.alleleset(idx).type() == GAAllele::ENUMERATED ||
-	 child.alleleset(idx).type() == GAAllele::DISCRETIZED)
-	value = child.alleleset(idx).allele();
-      else if(child.alleleset(idx).type() == GAAllele::BOUNDED){
-	value += GAUnitGaussian()*mutation_stdev*(child.alleleset(i).upper()-child.alleleset(i).lower()); // since the standard deviation varies proportionally to a constant multiplier 
-	value = GAMax(child.alleleset(idx).lower(), value);
-	value = GAMin(child.alleleset(idx).upper(), value);
+      if (child.alleleset(idx).type() == GAAllele::ENUMERATED ||
+          child.alleleset(idx).type() == GAAllele::DISCRETIZED)
+        value = child.alleleset(idx).allele();
+      else if (child.alleleset(idx).type() == GAAllele::BOUNDED)
+      {
+        value += GAUnitGaussian() * mutation_stdev * (child.alleleset(i).upper() - child.alleleset(i).lower()); // since the standard deviation varies proportionally to a constant multiplier
+        value = GAMax(child.alleleset(idx).lower(), value);
+        value = GAMin(child.alleleset(idx).upper(), value);
       }
       child.gene(idx, value);
     }
   }
-  return((int)nMut);
+  return ((int)nMut);
 }
-
 
 float objective(GAGenome &c)
 {
   float avg = 0;
-  
+
   // For timing
   std::chrono::time_point<std::chrono::system_clock> start, end;
   start = std::chrono::system_clock::now();
 
-  for (int i = 0; i < n_trials; i++) avg += LaunchARGoS(c);
-  
+  for (int i = 0; i < n_trials; i++)
+    avg += LaunchARGoS(c);
+
   avg /= n_trials;
 
-  
   end = std::chrono::system_clock::now();
-  
-  std::chrono::duration<double> elapsed_seconds = end-start;
 
-  MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);     
+  std::chrono::duration<double> elapsed_seconds = end - start;
 
-      char hostname[1024];              
-      hostname[1023] = '\0';                                          
-      gethostname(hostname, 1023);     
- 
-      /*
-      printf("Worker %d on %s evaluated genome [", mpi_rank, hostname);
-      for (int i = 0; i < GENOME_SIZE; i++)
-	printf("%f ",dynamic_cast<const GARealGenome&>(c).gene(i));
-      printf("] in %f seconds. ", elapsed_seconds.count());
-      printf("Fitness: %f.\n", avg );
-      */
+  MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
 
-      return avg;
+  char hostname[1024];
+  hostname[1023] = '\0';
+  gethostname(hostname, 1023);
+
+  /*
+  printf("Worker %d on %s evaluated genome [", mpi_rank, hostname);
+  for (int i = 0; i < GENOME_SIZE; i++)
+printf("%f ",dynamic_cast<const GARealGenome&>(c).gene(i));
+  printf("] in %f seconds. ", elapsed_seconds.count());
+  printf("Fitness: %f.\n", avg );
+  */
+
+  return avg;
 }
 
 /*
  * Launch ARGoS to evaluate a genome.
  */
-float LaunchARGoS(GAGenome& c_genome) 
+float LaunchARGoS(GAGenome &c_genome)
 {
   // Declate the fitness value and the shared memory segment id and address
   float fitness = 0;
-  int    ShmID;
-  float*   ShmPTR;
-  
+  int ShmID;
+  float *ShmPTR;
+
   // Allocate the shared memory to use between this process and the child argos process
   ShmID = shmget(IPC_PRIVATE, sizeof(float), IPC_CREAT | 0666);
-  if (ShmID < 0) {
+  if (ShmID < 0)
+  {
     printf("ERROR: Allocating shared memory segment in main.cpp:LaunchARGoS() failed.\n");
     exit(1);
   }
-  
+
   // Attach to the shared memory segment
-  ShmPTR = (float*) shmat(ShmID, NULL, 0);
-  if ((float*) ShmPTR == (float*)-1) 
-    {
-      printf("ERROR: Attaching to shared memory segment in main.cpp:LaunchARGoS() failed.\n");
-      exit(1);
-    }
+  ShmPTR = (float *)shmat(ShmID, NULL, 0);
+  if ((float *)ShmPTR == (float *)-1)
+  {
+    printf("ERROR: Attaching to shared memory segment in main.cpp:LaunchARGoS() failed.\n");
+    exit(1);
+  }
 
   *ShmPTR = 0; // Initialise
 
   pid_t pid = fork(); // Create the new process with a copy of this memory space
 
   if (pid == 0)
-    {
-      // In child process - run the argos3 simulation
+  {
+    // In child process - run the argos3 simulation
 
-      /* Convert the received genome to the actual genome type */
-      GARealGenome& cRealGenome = dynamic_cast<GARealGenome&>(c_genome);
-  
-      Real* cpfa_genome = new Real[GENOME_SIZE];
+    /* Convert the received genome to the actual genome type */
+    GARealGenome &cRealGenome = dynamic_cast<GARealGenome &>(c_genome);
 
-      // Convert to a convenient format for the argos controller
-      for (int i = 0; i < GENOME_SIZE; i++)
-	cpfa_genome[i] = cRealGenome.gene(i);
-       
-      /*      
-      printf("%s: worker %d started a genome evaluation. (%f, %f, %f, %f, %f, %f, %f)\n", hostname, mpi_rank, 
-	     cpfa_genome[0],
-	     cpfa_genome[1],
-	     cpfa_genome[2],
-	     cpfa_genome[3],
-	     cpfa_genome[4],
-	     cpfa_genome[5],
-	     cpfa_genome[6]);
-      */
+    Real *cpfa_genome = new Real[GENOME_SIZE];
 
-      /* Redirect LOG and LOGERR to dedicated files to prevent clutter on the screen */
-      std::ofstream cLOGFile("argos_logs/ARGoS_LOG_" + ToString(::getpid()), std::ios::out);
-      LOG.DisableColoredOutput();
-      LOG.GetStream().rdbuf(cLOGFile.rdbuf());
-      std::ofstream cLOGERRFile("argos_logs/ARGoS_LOGERR_" + ToString(::getpid()), std::ios::out);
-      LOGERR.DisableColoredOutput();
-      LOGERR.GetStream().rdbuf(cLOGERRFile.rdbuf());
+    // Convert to a convenient format for the argos controller
+    for (int i = 0; i < GENOME_SIZE; i++)
+      cpfa_genome[i] = cRealGenome.gene(i);
 
-      /*
-       * Initialize ARGoS
-       */
-      /* The CSimulator class of ARGoS is a singleton. Therefore, to
-       * manipulate an ARGoS experiment, it is enough to get its instance */
-      argos::CSimulator& cSimulator = argos::CSimulator::GetInstance();
+    /*
+    printf("%s: worker %d started a genome evaluation. (%f, %f, %f, %f, %f, %f, %f)\n", hostname, mpi_rank,
+     cpfa_genome[0],
+     cpfa_genome[1],
+     cpfa_genome[2],
+     cpfa_genome[3],
+     cpfa_genome[4],
+     cpfa_genome[5],
+     cpfa_genome[6]);
+    */
 
-      // Set the .argos configuration file
-      cSimulator.SetExperimentFileName(experiment_path);
-      
-      // Load it to configure ARGoS 
-      cSimulator.LoadExperiment();
+    /* Redirect LOG and LOGERR to dedicated files to prevent clutter on the screen */
+    std::ofstream cLOGFile("argos_logs/ARGoS_LOG_" + ToString(::getpid()), std::ios::out);
+    LOG.DisableColoredOutput();
+    LOG.GetStream().rdbuf(cLOGFile.rdbuf());
+    std::ofstream cLOGERRFile("argos_logs/ARGoS_LOGERR_" + ToString(::getpid()), std::ios::out);
+    LOGERR.DisableColoredOutput();
+    LOGERR.GetStream().rdbuf(cLOGERRFile.rdbuf());
 
-      // Get a reference to the loop functions
-      CPFA_loop_functions& cLoopFunctions = dynamic_cast<CPFA_loop_functions&>(cSimulator.GetLoopFunctions());
+    /*
+     * Initialize ARGoS
+     */
+    /* The CSimulator class of ARGoS is a singleton. Therefore, to
+     * manipulate an ARGoS experiment, it is enough to get its instance */
+    argos::CSimulator &cSimulator = argos::CSimulator::GetInstance();
 
-      // Configure the controller with the genome
-      cLoopFunctions.ConfigureFromGenome(cpfa_genome);
+    // Set the .argos configuration file
+    cSimulator.SetExperimentFileName(experiment_path);
 
-      // Run the experiment
-      cSimulator.Execute();
+    // Load it to configure ARGoS
+    cSimulator.LoadExperiment();
 
-      // Update performance and store in the shared memory segment
-      *ShmPTR = cLoopFunctions.Score();;
+    // Get a reference to the loop functions
+    CPFA_loop_functions &cLoopFunctions = dynamic_cast<CPFA_loop_functions &>(cSimulator.GetLoopFunctions());
 
-      // For testing
-      //float score = 0;
-      //for (int i = 0; i < GENOME_SIZE; i++) score += cpfa_genome[i];
-      //*ShmPTR = score;
+    // Configure the controller with the genome
+    cLoopFunctions.ConfigureFromGenome(cpfa_genome);
 
-      // Clean up the simulation
-      cSimulator.Destroy();
-      
-      // Clean up the temp genome copy
-	delete [] cpfa_genome;
+    // Run the experiment
+    cSimulator.Execute();
 
-	// Make this process exit
-      _Exit(0); 
-    }
-  
+    // Update performance and store in the shared memory segment
+    *ShmPTR = cLoopFunctions.Score();
+    ;
+
+    // For testing
+    // float score = 0;
+    // for (int i = 0; i < GENOME_SIZE; i++) score += cpfa_genome[i];
+    //*ShmPTR = score;
+
+    // Clean up the simulation
+    cSimulator.Destroy();
+
+    // Clean up the temp genome copy
+    delete[] cpfa_genome;
+
+    // Make this process exit
+    _Exit(0);
+  }
+
   // In parent - wait for child to finish
   int status = wait(&status);
 
   // Make a local copy of the shared fitness value
-  fitness = *ShmPTR;  
+  fitness = *ShmPTR;
 
   // Release shared memory
-  shmdt((void *) ShmPTR);
+  shmdt((void *)ShmPTR);
   shmctl(ShmID, IPC_RMID, NULL);
 
-  /* Return the result of the evaluation */  
+  /* Return the result of the evaluation */
   return fitness;
 }

--- a/Global_dynamic_MPFA/source/ga-mpi/GA1DArrayGenome.C
+++ b/Global_dynamic_MPFA/source/ga-mpi/GA1DArrayGenome.C
@@ -18,7 +18,7 @@
 #include <ga-mpi/GA1DArrayGenome.h>
 #include <ga-mpi/GAMask.h>
 
-template <class T> int 
+template <class T> int
 GA1DArrayIsHole(const GA1DArrayGenome<T>&, const GA1DArrayGenome<T>&,
 		int, int, int);
 
@@ -36,15 +36,15 @@ GA1DArrayGenome<T>::classID() const {return GAID::ArrayGenome;}
 // this point - initialization must be done explicitly by the user of the
 // genome (eg when the population is created or reset).  If we called the
 // initializer routine here then we could end up with multiple initializations
-// and/or calls to dummy initializers (for example when the genome is 
+// and/or calls to dummy initializers (for example when the genome is
 // created with a dummy initializer and the initializer is assigned later on).
 // Besides, we default to the no-initialization initializer by calling the
 // default genome constructor.
-template <class T> 
+template <class T>
 GA1DArrayGenome<T>::
 GA1DArrayGenome(unsigned int length, GAGenome::Evaluator f, void * u) :
 GAArray<T>(length),
-GAGenome(DEFAULT_1DARRAY_INITIALIZER, 
+GAGenome(DEFAULT_1DARRAY_INITIALIZER,
 	 DEFAULT_1DARRAY_MUTATOR,
 	 DEFAULT_1DARRAY_COMPARATOR) {
   evaluator(f);
@@ -56,9 +56,9 @@ GAGenome(DEFAULT_1DARRAY_INITIALIZER,
 
 // This is the copy initializer.  We set everything to the default values, then
 // copy the original.  The Array creator takes care of zeroing the data.
-template <class T> 
+template <class T>
 GA1DArrayGenome<T>::
-GA1DArrayGenome(const GA1DArrayGenome<T> & orig) : 
+GA1DArrayGenome(const GA1DArrayGenome<T> & orig) :
 GAArray<T>(orig.sz), GAGenome() {
   GA1DArrayGenome<T>::copy(orig);
 }
@@ -74,7 +74,7 @@ GA1DArrayGenome<T>::~GA1DArrayGenome() { }
 // what we define here - a virtual function).  We should check to be sure that
 // both genomes are the same class and same dimension.  This function tries
 // to be smart about they way it copies.  If we already have data, then we do
-// a memcpy of the one we're supposed to copy.  If we don't or we're not the 
+// a memcpy of the one we're supposed to copy.  If we don't or we're not the
 // same size as the one we're supposed to copy, then we adjust ourselves.
 //   The Array takes care of the resize in its copy method.
 template <class T> void
@@ -92,7 +92,7 @@ GA1DArrayGenome<T>::copy(const GAGenome & orig){
 template <class T> GAGenome *
 GA1DArrayGenome<T>::clone(GAGenome::CloneMethod flag) const {
   GA1DArrayGenome<T> *cpy = new GA1DArrayGenome<T>(nx);
-  if(flag == CONTENTS){ 
+  if(flag == CONTENTS){
     cpy->copy(*this);
   }
   else{
@@ -110,10 +110,10 @@ GA1DArrayGenome<T>::clone(GAGenome::CloneMethod flag) const {
 // length, then we don't do anything.
 //   We pay attention to the values of minX and maxX - they determine what kind
 // of resizing we are allowed to do.  If a resize is requested with a length
-// less than the min length specified by the behaviour, we set the minimum 
+// less than the min length specified by the behaviour, we set the minimum
 // to the length.  If the length is longer than the max length specified by
 // the behaviour, we set the max value to the length.
-//   We return the total size (in bits) of the genome after resize. 
+//   We return the total size (in bits) of the genome after resize.
 //   We don't do anything to the new contents!
 template <class T> int
 GA1DArrayGenome<T>::resize(int len)
@@ -160,7 +160,7 @@ GA1DArrayGenome<T>::write(STD_OSTREAM & os) const {
 //   Set the resize behaviour of the genome.  A genome can be fixed
 // length, resizeable with a max and min limit, or resizeable with no limits
 // (other than an implicit one that we use internally).
-//   A value of 0 means no resize, a value less than zero mean unlimited 
+//   A value of 0 means no resize, a value less than zero mean unlimited
 // resize, and a positive value means resize with that value as the limit.
 template <class T> int
 GA1DArrayGenome<T>::
@@ -183,7 +183,7 @@ GA1DArrayGenome<T>::resizeBehaviour() const {
   return val;
 }
 
-template <class T> int 
+template <class T> int
 GA1DArrayGenome<T>::equal(const GAGenome & c) const {
   const GA1DArrayGenome<T> & b = DYN_CAST(const GA1DArrayGenome<T> &, c);
   return((this == &c) ? 1 : ((nx != b.nx) ? 0 : GAArray<T>::equal(b,0,0,nx)));
@@ -205,7 +205,7 @@ its own, independent allele set.  If we clone a new genome, the new one gets a
 link to our allele set (so we don't end up with zillions of allele sets).  Same
 is true for the copy constructor.
   The array may have a single allele set or an array of allele sets, depending
-on which creator was called.  Either way, the allele set cannot be changed 
+on which creator was called.  Either way, the allele set cannot be changed
 once the array is created.
 ---------------------------------------------------------------------------- */
 template <class T> const char *
@@ -213,7 +213,7 @@ GA1DArrayAlleleGenome<T>::className() const {return "GA1DArrayAlleleGenome";}
 template <class T> int
 GA1DArrayAlleleGenome<T>::classID() const {return GAID::ArrayAlleleGenome;}
 
-template <class T> 
+template <class T>
 GA1DArrayAlleleGenome<T>::
 GA1DArrayAlleleGenome(unsigned int length, const GAAlleleSet<T> & s,
 		      GAGenome::Evaluator f, void * u) :
@@ -228,7 +228,7 @@ GA1DArrayGenome<T>(length, f, u){
   this->crossover(GA1DArrayAlleleGenome<T>::DEFAULT_1DARRAY_ALLELE_CROSSOVER);
 }
 
-template <class T> 
+template <class T>
 GA1DArrayAlleleGenome<T>::
 GA1DArrayAlleleGenome(const GAAlleleSetArray<T> & sa,
 		      GAGenome::Evaluator f, void * u) :
@@ -247,9 +247,9 @@ GA1DArrayGenome<T>(sa.size(), f, u) {
 
 // The copy constructor creates a new genome whose allele set refers to the
 // original's allele set.
-template <class T> 
+template <class T>
 GA1DArrayAlleleGenome<T>::
-GA1DArrayAlleleGenome(const GA1DArrayAlleleGenome<T>& orig) : 
+GA1DArrayAlleleGenome(const GA1DArrayAlleleGenome<T>& orig) :
 GA1DArrayGenome<T>(orig.sz) {
   naset = 0;
   aset = (GAAlleleSet<T>*)0;
@@ -265,7 +265,7 @@ GA1DArrayAlleleGenome<T>::~GA1DArrayAlleleGenome(){
 
 
 // This implementation of clone does not make use of the contents/attributes
-// capability because this whole interface isn't quite right yet...  Just 
+// capability because this whole interface isn't quite right yet...  Just
 // clone the entire thing, contents and all.
 template <class T> GAGenome *
 GA1DArrayAlleleGenome<T>::clone(GAGenome::CloneMethod) const {
@@ -273,10 +273,10 @@ GA1DArrayAlleleGenome<T>::clone(GAGenome::CloneMethod) const {
 }
 
 
-template <class T> void 
+template <class T> void
 GA1DArrayAlleleGenome<T>::copy(const GAGenome& orig){
   if(&orig == this) return;
-  const GA1DArrayAlleleGenome<T> * c = 
+  const GA1DArrayAlleleGenome<T> * c =
     DYN_CAST(const GA1DArrayAlleleGenome<T>*, &orig);
   if(c) {
     GA1DArrayGenome<T>::copy(*c);
@@ -339,7 +339,7 @@ GA1DArrayAlleleGenome<T>::equal(const GAGenome & c) const {
 ---------------------------------------------------------------------------- */
 // The random initializer sets the elements of the array based on the alleles
 // set.  We choose randomly the allele for each element.
-template <class ARRAY_TYPE> void 
+template <class ARRAY_TYPE> void
 GA1DArrayAlleleGenome<ARRAY_TYPE>::UniformInitializer(GAGenome & c)
 {
   GA1DArrayAlleleGenome<ARRAY_TYPE> &child=
@@ -354,7 +354,7 @@ GA1DArrayAlleleGenome<ARRAY_TYPE>::UniformInitializer(GAGenome & c)
 // and assign each element the next allele in the allele set.  Once each
 // element has been initialized, scramble the contents by swapping elements.
 // This assumes that there is only one allele set for the array.
-template <class ARRAY_TYPE> void 
+template <class ARRAY_TYPE> void
 GA1DArrayAlleleGenome<ARRAY_TYPE>::OrderedInitializer(GAGenome & c)
 {
   GA1DArrayAlleleGenome<ARRAY_TYPE> &child=
@@ -372,15 +372,15 @@ GA1DArrayAlleleGenome<ARRAY_TYPE>::OrderedInitializer(GAGenome & c)
 }
 
 
-// Randomly pick elements in the array then set the element to any of the 
+// Randomly pick elements in the array then set the element to any of the
 // alleles in the allele set for this genome.  This will work for any number
 // of allele sets for a given array.
-template <class ARRAY_TYPE> int 
+template <class ARRAY_TYPE> int
 GA1DArrayAlleleGenome<ARRAY_TYPE>::FlipMutator(GAGenome & c, float pmut)
 {
   GA1DArrayAlleleGenome<ARRAY_TYPE> &child=
     DYN_CAST(GA1DArrayAlleleGenome<ARRAY_TYPE> &, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.length());
@@ -404,11 +404,11 @@ GA1DArrayAlleleGenome<ARRAY_TYPE>::FlipMutator(GAGenome & c, float pmut)
 
 
 // Randomly swap elements in the array.
-template <class ARRAY_TYPE> int 
+template <class ARRAY_TYPE> int
 GA1DArrayGenome<ARRAY_TYPE>::SwapMutator(GAGenome & c, float pmut)
 {
   GA1DArrayGenome<ARRAY_TYPE> &child=DYN_CAST(GA1DArrayGenome<ARRAY_TYPE>&, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.length());
@@ -469,7 +469,7 @@ ElementComparator(const GAGenome& a, const GAGenome& b)
 #define SWAP(a,b) {unsigned int tmp=a; a=b; b=tmp;}
 
 // Randomly take bits from each parent.  For each bit we flip a coin to see if
-// that bit should come from the mother or the father.  If strings are 
+// that bit should come from the mother or the father.  If strings are
 // different lengths then we need to use the mask to get things right.
 template <class T> int
 GA1DArrayGenome<T>::
@@ -517,8 +517,8 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
     n = 2;
   }
   else if(c1 || c2){
-    GA1DArrayGenome<T> &sis = (c1 ? 
-			       DYN_CAST(GA1DArrayGenome<T> &, *c1) : 
+    GA1DArrayGenome<T> &sis = (c1 ?
+			       DYN_CAST(GA1DArrayGenome<T> &, *c1) :
 			       DYN_CAST(GA1DArrayGenome<T> &, *c2));
 
     if(mom.length() == dad.length() && sis.length() == mom.length()){
@@ -550,7 +550,7 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
 // we cannot handle that and post an error message.
 template <class T> int
 GA1DArrayGenome<T>::
-OnePointCrossover(const GAGenome& p1, const GAGenome& p2, 
+OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 		  GAGenome* c1, GAGenome* c2){
   const GA1DArrayGenome<T> &mom=DYN_CAST(const GA1DArrayGenome<T> &, p1);
   const GA1DArrayGenome<T> &dad=DYN_CAST(const GA1DArrayGenome<T> &, p2);
@@ -565,7 +565,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour() == GAGenome::FIXED_SIZE){
-      if(mom.length() != dad.length() || 
+      if(mom.length() != dad.length() ||
 	 sis.length() != bro.length() ||
 	 sis.length() != mom.length()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -587,17 +587,17 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sis.resize(momsite+dadlen);
       bro.resize(dadsite+momlen);
     }
-    
+
     sis.copy(mom, 0, 0, momsite);
     sis.copy(dad, momsite, dadsite, dadlen);
     bro.copy(dad, 0, 0, dadsite);
     bro.copy(mom, dadsite, momsite, momlen);
-  
+
     nc = 2;
   }
   else if(c1 || c2){
-    GA1DArrayGenome<T> &sis = (c1 ? 
-			       DYN_CAST(GA1DArrayGenome<T> &, *c1) : 
+    GA1DArrayGenome<T> &sis = (c1 ?
+			       DYN_CAST(GA1DArrayGenome<T> &, *c1) :
 			       DYN_CAST(GA1DArrayGenome<T> &, *c2));
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE){
@@ -615,7 +615,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       dadlen = dad.length() - dadsite;
       sis.resize(momsite+dadlen);
     }
-    
+
     if(GARandomBit()){
       sis.copy(mom, 0, 0, momsite);
       sis.copy(dad, momsite, dadsite, dadlen);
@@ -642,14 +642,14 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
 
 // Two point crossover for the 1D array genome.  Similar to the single point
-// crossover, but here we pick two points then grab the sections based upon 
+// crossover, but here we pick two points then grab the sections based upon
 // those two points.
 //   When we pick the points, it doesn't matter where they fall (one is not
 // dependent upon the other).  Make sure we get the lesser one into the first
 // position of our site array.
 template <class T> int
 GA1DArrayGenome<T>::
-TwoPointCrossover(const GAGenome& p1, const GAGenome& p2, 
+TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
 		  GAGenome* c1, GAGenome* c2){
   const GA1DArrayGenome<T> &mom=DYN_CAST(const GA1DArrayGenome<T> &, p1);
   const GA1DArrayGenome<T> &dad=DYN_CAST(const GA1DArrayGenome<T> &, p2);
@@ -664,7 +664,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour() == GAGenome::FIXED_SIZE){
-      if(mom.length() != dad.length() || 
+      if(mom.length() != dad.length() ||
 	 sis.length() != bro.length() ||
 	 sis.length() != mom.length()){
 	GAErr(GA_LOC, mom.className(), "two-point cross", gaErrSameLengthReqd);
@@ -675,7 +675,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
       if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
-      
+
       dadsite[0] = momsite[0];
       dadsite[1] = momsite[1];
       dadlen[0] = momlen[0];
@@ -691,13 +691,13 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
       if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
-      
+
       dadsite[0] = GARandomInt(0, dad.length());
       dadsite[1] = GARandomInt(0, dad.length());
       if(dadsite[0] > dadsite[1]) SWAP(dadsite[0], dadsite[1]);
       dadlen[0] = dadsite[1] - dadsite[0];
       dadlen[1] = dad.length() - dadsite[1];
-      
+
       sis.resize(momsite[0]+dadlen[0]+momlen[1]);
       bro.resize(dadsite[0]+momlen[0]+dadlen[1]);
     }
@@ -726,7 +726,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
       if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
-      
+
       dadsite[0] = momsite[0];
       dadsite[1] = momsite[1];
       dadlen[0] = momlen[0];
@@ -738,7 +738,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
       if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
-      
+
       dadsite[0] = GARandomInt(0, dad.length());
       dadsite[1] = GARandomInt(0, dad.length());
       if(dadsite[0] > dadsite[1]) SWAP(dadsite[0], dadsite[1]);
@@ -771,13 +771,13 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
 
 
 
-// Even and odd crossover for the array works just like it does for the 
+// Even and odd crossover for the array works just like it does for the
 // binary strings.  For even crossover we take the 0th element and every other
 // one after that from the mother.  The 1st and every other come from the
 // father.  For odd crossover, we do just the opposite.
 template <class T> int
 GA1DArrayGenome<T>::
-EvenOddCrossover(const GAGenome& p1, const GAGenome& p2, 
+EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
 		 GAGenome* c1, GAGenome* c2){
   const GA1DArrayGenome<T> &mom=DYN_CAST(const GA1DArrayGenome<T> &, p1);
   const GA1DArrayGenome<T> &dad=DYN_CAST(const GA1DArrayGenome<T> &, p2);
@@ -816,10 +816,10 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
     nc = 2;
   }
   else if(c1 || c2){
-    GA1DArrayGenome<T> &sis = (c1 ? 
-			       DYN_CAST(GA1DArrayGenome<T> &, *c1) : 
+    GA1DArrayGenome<T> &sis = (c1 ?
+			       DYN_CAST(GA1DArrayGenome<T> &, *c1) :
 			       DYN_CAST(GA1DArrayGenome<T> &, *c2));
-    
+
     if(mom.length() == dad.length() && sis.length() == mom.length()){
       for(i=sis.length()-1; i>=1; i-=2){
 	sis.gene(i, mom.gene(i));
@@ -853,7 +853,7 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
 //   We make sure that b will be greater than a.
 template <class T> int
 GA1DArrayGenome<T>::
-PartialMatchCrossover(const GAGenome& p1, const GAGenome& p2, 
+PartialMatchCrossover(const GAGenome& p1, const GAGenome& p2,
 		      GAGenome* c1, GAGenome* c2){
   const GA1DArrayGenome<T> &mom=DYN_CAST(const GA1DArrayGenome<T> &, p1);
   const GA1DArrayGenome<T> &dad=DYN_CAST(const GA1DArrayGenome<T> &, p2);
@@ -868,7 +868,7 @@ PartialMatchCrossover(const GAGenome& p1, const GAGenome& p2,
     GAErr(GA_LOC, mom.className(), "parial match cross", gaErrBadParentLength);
     return nc;
   }
-  
+
   if(c1 && c2){
     GA1DArrayGenome<T> &sis=DYN_CAST(GA1DArrayGenome<T> &, *c1);
     GA1DArrayGenome<T> &bro=DYN_CAST(GA1DArrayGenome<T> &, *c2);
@@ -887,8 +887,8 @@ PartialMatchCrossover(const GAGenome& p1, const GAGenome& p2,
     nc = 2;
   }
   else if(c1 || c2){
-    GA1DArrayGenome<T> &sis = (c1 ? 
-			       DYN_CAST(GA1DArrayGenome<T> &, *c1) : 
+    GA1DArrayGenome<T> &sis = (c1 ?
+			       DYN_CAST(GA1DArrayGenome<T> &, *c1) :
 			       DYN_CAST(GA1DArrayGenome<T> &, *c2));
 
     const GA1DArrayGenome<T> *parent1, *parent2;
@@ -929,7 +929,7 @@ GA1DArrayIsHole(const GA1DArrayGenome<T> &c, const GA1DArrayGenome<T> &dad,
 //   This implementation isn't terribly smart.  For example, I do a linear
 // search rather than caching and doing binary search or smarter hash tables.
 //   First we copy the mother into the sister.  Then move the 'holes' into the
-// crossover section and maintain the ordering of the non-hole elements.  
+// crossover section and maintain the ordering of the non-hole elements.
 // Finally, put the 'holes' in the proper order within the crossover section.
 // After we have done the sister, we do the brother.
 template <class T> int
@@ -949,7 +949,7 @@ OrderCrossover(const GAGenome& p1, const GAGenome& p2,
     GAErr(GA_LOC, mom.className(), "order cross", gaErrBadParentLength);
     return nc;
   }
-  
+
   if(c1 && c2){
     GA1DArrayGenome<T> &sis=DYN_CAST(GA1DArrayGenome<T> &, *c1);
     GA1DArrayGenome<T> &bro=DYN_CAST(GA1DArrayGenome<T> &, *c2);
@@ -962,7 +962,7 @@ OrderCrossover(const GAGenome& p1, const GAGenome& p2,
       if(index >= sis.size()) index=0;
       if(GA1DArrayIsHole(sis,dad,index,a,b)) break;
     }
-    
+
     for(; i<sis.size()-b+a; i++, index++){
       if(index >= sis.size()) index=0;
       j=index;
@@ -999,7 +999,7 @@ OrderCrossover(const GAGenome& p1, const GAGenome& p2,
       } while(GA1DArrayIsHole(bro,mom,j,a,b));
       bro.swap(index,j);
     }
-    
+
 // Now put the 'holes' in the proper order within the crossover section.
     for(i=a; i<b; i++){
       if(bro.gene(i) != mom.gene(i)){
@@ -1011,8 +1011,8 @@ OrderCrossover(const GAGenome& p1, const GAGenome& p2,
     nc = 2;
   }
   else if(c1 || c2){
-    GA1DArrayGenome<T> &sis = (c1 ? 
-			       DYN_CAST(GA1DArrayGenome<T> &, *c1) : 
+    GA1DArrayGenome<T> &sis = (c1 ?
+			       DYN_CAST(GA1DArrayGenome<T> &, *c1) :
 			       DYN_CAST(GA1DArrayGenome<T> &, *c2));
 
     const GA1DArrayGenome<T> *parent1, *parent2;
@@ -1053,7 +1053,7 @@ OrderCrossover(const GAGenome& p1, const GAGenome& p2,
 
 
 
-// Cycle crossover for the 1D array genome.  This is implemented as described 
+// Cycle crossover for the 1D array genome.  This is implemented as described
 // in goldberg's book.  The first is picked from mom, then cycle using dad.
 // Finally, fill in the gaps with the elements from dad.
 //   We allocate space for a temporary array in this routine.  It never frees
@@ -1063,8 +1063,8 @@ OrderCrossover(const GAGenome& p1, const GAGenome& p2,
 //  Allocate space for an array of flags.  We use this to keep track of whether
 // the child's contents came from the mother or the father.  We don't free the
 // space here, but it is not a memory leak.
-//   The first step is to cycle through mom & dad to get the cyclic part of 
-// the crossover.  Then fill in the rest of the sis with dad's contents that 
+//   The first step is to cycle through mom & dad to get the cyclic part of
+// the crossover.  Then fill in the rest of the sis with dad's contents that
 // we didn't use in the cycle.  Finally, do the same thing for the other child.
 //   Notice that this implementation makes serious use of the operator= for the
 // objects in the array.  It also requires the operator != and == comparators.
@@ -1139,7 +1139,7 @@ CycleCrossover(const GAGenome& p1, const GAGenome& p2,
     GAMask mask;
     mask.size(sis.length());
     mask.clear();
-    
+
     sis.gene(0, parent1->gene(0));
     mask[0] = 1;
     while(parent2->gene(current) != parent1->gene(0)){

--- a/Global_dynamic_MPFA/source/ga-mpi/GA1DBinStrGenome.C
+++ b/Global_dynamic_MPFA/source/ga-mpi/GA1DBinStrGenome.C
@@ -17,7 +17,12 @@
 #include <ga-mpi/GA1DBinStrGenome.h>
 #include <ga-mpi/GAMask.h>
 
-#define SWAP(a,b) {unsigned int tmp=a; a=b; b=tmp;}
+#define SWAP(a, b)        \
+  {                       \
+    unsigned int tmp = a; \
+    a = b;                \
+    b = tmp;              \
+  }
 
 /* ----------------------------------------------------------------------------
    Genome class definition
@@ -27,128 +32,136 @@
 // this point - initialization must be done explicitly by the user of the
 // genome (eg when the population is created or reset).  If we called the
 // initializer routine here then we could end up with multiple initializations
-// and/or calls to dummy initializers (for example when the genome is 
+// and/or calls to dummy initializers (for example when the genome is
 // created with a dummy initializer and the initializer is assigned later on).
 GA1DBinaryStringGenome::
-GA1DBinaryStringGenome(unsigned int len, 
-		       GAGenome::Evaluator f, void * u) :
-GABinaryString(len),
-GAGenome(DEFAULT_1DBINSTR_INITIALIZER, 
-	 DEFAULT_1DBINSTR_MUTATOR,
-	 DEFAULT_1DBINSTR_COMPARATOR) {
+    GA1DBinaryStringGenome(unsigned int len,
+                           GAGenome::Evaluator f, void *u) : GABinaryString(len),
+                                                             GAGenome(DEFAULT_1DBINSTR_INITIALIZER,
+                                                                      DEFAULT_1DBINSTR_MUTATOR,
+                                                                      DEFAULT_1DBINSTR_COMPARATOR)
+{
   evaluator(f);
   userData(u);
   crossover(DEFAULT_1DBINSTR_CROSSOVER); // assign the default sexual crossover
-  nx=minX=maxX=0;
+  nx = minX = maxX = 0;
   resize(len);
 }
-
 
 // This is the copy initializer.  We set everything to the default values, then
 // copy the original.  The BinaryStringGenome creator takes care of zeroing
 // the data and sz members.
 GA1DBinaryStringGenome::
-GA1DBinaryStringGenome(const GA1DBinaryStringGenome& orig) :
-GABinaryString(orig.GABinaryString::size()),
-GAGenome() {
-  nx=minX=maxX=0;
+    GA1DBinaryStringGenome(const GA1DBinaryStringGenome &orig) : GABinaryString(orig.GABinaryString::size()),
+                                                                 GAGenome()
+{
+  nx = minX = maxX = 0;
   GA1DBinaryStringGenome::copy(orig);
 }
 
-GA1DBinaryStringGenome::~GA1DBinaryStringGenome() {
+GA1DBinaryStringGenome::~GA1DBinaryStringGenome()
+{
 }
 
-
 // The clone member creates a duplicate (exact or just attributes, depending
-// on the flag).  The caller is responsible for freeing the memory that is 
+// on the flag).  The caller is responsible for freeing the memory that is
 // allocated by this method.
-GAGenome*
-GA1DBinaryStringGenome::clone(GAGenome::CloneMethod flag) const {
+GAGenome *
+GA1DBinaryStringGenome::clone(GAGenome::CloneMethod flag) const
+{
   GA1DBinaryStringGenome *cpy = new GA1DBinaryStringGenome(nx);
-  if(flag == CONTENTS){
+  if (flag == CONTENTS)
+  {
     cpy->copy(*this);
   }
-  else{
+  else
+  {
     cpy->GAGenome::copy(*this);
-    cpy->maxX = maxX; cpy->minX = minX;
+    cpy->maxX = maxX;
+    cpy->minX = minX;
   }
   return cpy;
 }
-
 
 // This is the class-specific copy method.  It will get called by the super
 // class since the superclass operator= is set up to call ccopy (and that is
 // what we define here - a virtual function).  We should check to be sure that
 // both genomes are the same class and same dimension.  This function tries
 // to be smart about they way it copies.  If we already have data, then we do
-// a memcpy of the one we're supposed to copy.  If we don't or we're not the 
+// a memcpy of the one we're supposed to copy.  If we don't or we're not the
 // same size as the one we're supposed to copy, then we adjust ourselves.
 //   The BinaryStringGenome takes care of the resize in its copy method.
 // It also copies the bitstring for us.
-void
-GA1DBinaryStringGenome::copy(const GAGenome & orig)
+void GA1DBinaryStringGenome::copy(const GAGenome &orig)
 {
-  if(&orig == this) return;
-  const GA1DBinaryStringGenome* c = 
-    DYN_CAST(const GA1DBinaryStringGenome*, &orig);
-  if(c) {
+  if (&orig == this)
+    return;
+  const GA1DBinaryStringGenome *c =
+      DYN_CAST(const GA1DBinaryStringGenome *, &orig);
+  if (c)
+  {
     GAGenome::copy(*c);
     GABinaryString::copy(*c);
-    nx = c->nx; minX = c->minX; maxX = c->maxX;
+    nx = c->nx;
+    minX = c->minX;
+    maxX = c->maxX;
   }
 }
-
 
 //   Resize the genome.  If someone specifies ANY_RESIZE then we pick a random
 // size within the behaviour limits that have been set.  If limits have been
 // set and someone passes us something outside the limits, we resize to the
 // closest bound.  If the genome is fixed size (ie min limit equals max limit)
 // then we resize to the specified value and move the min/max to match it.
-int
-GA1DBinaryStringGenome::resize(int l)
+int GA1DBinaryStringGenome::resize(int l)
 {
-  if(l == STA_CAST(int, nx)) return nx;
+  if (l == STA_CAST(int, nx))
+    return nx;
 
-  if(l == GAGenome::ANY_SIZE)
+  if (l == GAGenome::ANY_SIZE)
     l = GARandomInt(minX, maxX);
-  else if(l < 0)
-    return nx;			// do nothing
-  else if(minX == maxX)
-    minX=maxX=l;
-  else{
-    if(l < STA_CAST(int, minX)) l=minX;
-    if(l > STA_CAST(int, maxX)) l=maxX;
+  else if (l < 0)
+    return nx; // do nothing
+  else if (minX == maxX)
+    minX = maxX = l;
+  else
+  {
+    if (l < STA_CAST(int, minX))
+      l = minX;
+    if (l > STA_CAST(int, maxX))
+      l = maxX;
   }
 
   GABinaryString::resize(l);
-  if(l > STA_CAST(int, nx))
-    for(int i=nx; i<l; i++)
+  if (l > STA_CAST(int, nx))
+    for (int i = nx; i < l; i++)
       bit(i, GARandomBit());
   nx = l;
   _evaluated = gaFalse;
   return sz;
 }
 
-
 #ifdef GALIB_USE_STREAMS
 // We read data from a stream as a series of 1's and 0's.  We want a continuous
 // stream (ie no spaces) but if there are spaces then we can handle them.  We
 // ignore all whitespace.  We ignore anything that is not a digit.  If it is a
 // zero then we set to zero.  Anything else is a 1.
-int
-GA1DBinaryStringGenome::read(STD_ISTREAM & is)
+int GA1DBinaryStringGenome::read(STD_ISTREAM &is)
 {
   static char c;
-  unsigned int i=0;
+  unsigned int i = 0;
 
-  while(!is.fail() && !is.eof() && i<nx) {
+  while (!is.fail() && !is.eof() && i < nx)
+  {
     is >> c;
-    if(isdigit(c)) gene(i++, ((c == '0') ? 0 : 1));
+    if (isdigit(c))
+      gene(i++, ((c == '0') ? 0 : 1));
   }
 
   _evaluated = gaFalse;
 
-  if(is.eof() && i < nx){
+  if (is.eof() && i < nx)
+  {
     GAErr(GA_LOC, className(), "read", gaErrUnexpectedEOF);
     is.clear(STD_IOS_BADBIT | is.rdstate());
     return 1;
@@ -157,72 +170,66 @@ GA1DBinaryStringGenome::read(STD_ISTREAM & is)
   return 0;
 }
 
-
 // When we write the data to a stream we do it without any spaces.  Also, there
 // is no newline at the end of the stream of digits.
-int
-GA1DBinaryStringGenome::write(STD_OSTREAM & os) const
+int GA1DBinaryStringGenome::write(STD_OSTREAM &os) const
 {
-  for(unsigned int i=0; i<nx; i++)
+  for (unsigned int i = 0; i < nx; i++)
     os << gene(i);
   return 0;
 }
 #endif
 
-
 //   Set the resize behaviour of the genome.  A genome can be fixed
 // length, resizeable with a max and min limit, or resizeable with no limits
 // (other than an implicit one that we use internally).
-//   A value of 0 means no resize, a value less than zero mean unlimited 
+//   A value of 0 means no resize, a value less than zero mean unlimited
 // resize, and a positive value means resize with that value as the limit.
 //   We return the upper limit of the genome's size.
-int
-GA1DBinaryStringGenome::
-resizeBehaviour(unsigned int lower, unsigned int upper)
+int GA1DBinaryStringGenome::
+    resizeBehaviour(unsigned int lower, unsigned int upper)
 {
-  if(upper < lower){
+  if (upper < lower)
+  {
     GAErr(GA_LOC, className(), "resizeBehaviour", gaErrBadResizeBehaviour);
     return resizeBehaviour();
   }
-  minX = lower; maxX = upper;
-  if(nx > upper) resize(upper);
-  if(nx < lower) resize(lower);
+  minX = lower;
+  maxX = upper;
+  if (nx > upper)
+    resize(upper);
+  if (nx < lower)
+    resize(lower);
   return resizeBehaviour();
 }
 
-int 
-GA1DBinaryStringGenome::resizeBehaviour() const {
+int GA1DBinaryStringGenome::resizeBehaviour() const
+{
   int val = maxX;
-  if(maxX == minX) val = FIXED_SIZE;
+  if (maxX == minX)
+    val = FIXED_SIZE;
   return val;
 }
 
-int 
-GA1DBinaryStringGenome::
-equal(const GA1DBinaryStringGenome& c,
-      unsigned int dest, unsigned int src, unsigned int len) const {
-  return GABinaryString::equal(c,dest,src,len);
+int GA1DBinaryStringGenome::
+    equal(const GA1DBinaryStringGenome &c,
+          unsigned int dest, unsigned int src, unsigned int len) const
+{
+  return GABinaryString::equal(c, dest, src, len);
 }
 
-int 
-GA1DBinaryStringGenome::equal(const GAGenome & c) const {
-  if(this == &c) return 1;
-  const GA1DBinaryStringGenome* b = DYN_CAST(const GA1DBinaryStringGenome*,&c);
+int GA1DBinaryStringGenome::equal(const GAGenome &c) const
+{
+  if (this == &c)
+    return 1;
+  const GA1DBinaryStringGenome *b = DYN_CAST(const GA1DBinaryStringGenome *, &c);
   int eq = 0;
-  if(b) {
-    eq = ((nx != b->nx) ? 0 : GABinaryString::equal(*b,0,0,nx));
+  if (b)
+  {
+    eq = ((nx != b->nx) ? 0 : GABinaryString::equal(*b, 0, 0, nx));
   }
   return eq;
 }
-
-
-
-
-
-
-
-
-
 
 /* ----------------------------------------------------------------------------
    Operators
@@ -231,35 +238,29 @@ GA1DBinaryStringGenome::equal(const GAGenome & c) const {
 // random bit function so we don't have to worry about machine-specific stuff.
 //   We also do a resize so the genome can resize itself (randomly) if it
 // is a resizeable genome.
-void 
-GA1DBinaryStringGenome::UniformInitializer(GAGenome & c)
+void GA1DBinaryStringGenome::UniformInitializer(GAGenome &c)
 {
-  GA1DBinaryStringGenome &child=DYN_CAST(GA1DBinaryStringGenome &, c);
+  GA1DBinaryStringGenome &child = DYN_CAST(GA1DBinaryStringGenome &, c);
   child.resize(GAGenome::ANY_SIZE); // let chrom resize if it can
-  for(int i=child.length()-1; i>=0; i--)
+  for (int i = child.length() - 1; i >= 0; i--)
     child.gene(i, GARandomBit()); // initial values are all random
 }
 
-
 //   Unset all of the bits in the genome.
-void 
-GA1DBinaryStringGenome::UnsetInitializer(GAGenome & c)
+void GA1DBinaryStringGenome::UnsetInitializer(GAGenome &c)
 {
-  GA1DBinaryStringGenome &child=DYN_CAST(GA1DBinaryStringGenome &, c);
+  GA1DBinaryStringGenome &child = DYN_CAST(GA1DBinaryStringGenome &, c);
   child.resize(GAGenome::ANY_SIZE); // let chrom resize if it can
   child.unset(0, child.length());
 }
 
-
 //   Set all of the bits in the genome.
-void 
-GA1DBinaryStringGenome::SetInitializer(GAGenome & c)
+void GA1DBinaryStringGenome::SetInitializer(GAGenome &c)
 {
-  GA1DBinaryStringGenome &child=DYN_CAST(GA1DBinaryStringGenome &, c);
+  GA1DBinaryStringGenome &child = DYN_CAST(GA1DBinaryStringGenome &, c);
   child.resize(GAGenome::ANY_SIZE); // let chrom resize if it can
   child.set(0, child.length());
 }
-
 
 // This function gets called a lot (especially for the simple ga) so it must
 // be as streamlined as possible.  If the mutation probability is small, then
@@ -271,133 +272,133 @@ GA1DBinaryStringGenome::SetInitializer(GAGenome & c)
 // better the chance that it will match the desired mutation rate.
 //   If nMut is greater than 1, then we round up, so a mutation of 2.2 would
 // be 3 mutations, and 2.9 would be 3 as well.  nMut of 3 would be 3 mutations.
-int 
-GA1DBinaryStringGenome::FlipMutator(GAGenome & c, float pmut)
+int GA1DBinaryStringGenome::FlipMutator(GAGenome &c, float pmut)
 {
-  GA1DBinaryStringGenome &child=DYN_CAST(GA1DBinaryStringGenome &, c);
-  register int n, i;
-  if(pmut <= 0.0) return(0);
+  GA1DBinaryStringGenome &child = DYN_CAST(GA1DBinaryStringGenome &, c);
+  int n, i;
+  if (pmut <= 0.0)
+    return (0);
 
   float nMut = pmut * STA_CAST(float, child.length());
-  if(nMut < 1.0){		// we have to do a flip test on each bit
+  if (nMut < 1.0)
+  { // we have to do a flip test on each bit
     nMut = 0;
-    for(i=child.length()-1; i>=0; i--){
-      if(GAFlipCoin(pmut)){
-	child.gene(i, ((child.gene(i) == 0) ? 1 : 0));
-	nMut++;
+    for (i = child.length() - 1; i >= 0; i--)
+    {
+      if (GAFlipCoin(pmut))
+      {
+        child.gene(i, ((child.gene(i) == 0) ? 1 : 0));
+        nMut++;
       }
     }
   }
-  else{				// only flip the number of bits we need to flip
-    for(n=0; n<nMut; n++){
-      i = GARandomInt(0, child.length()-1); // the index of the bit to flip
+  else
+  { // only flip the number of bits we need to flip
+    for (n = 0; n < nMut; n++)
+    {
+      i = GARandomInt(0, child.length() - 1); // the index of the bit to flip
       child.gene(i, ((child.gene(i) == 0) ? 1 : 0));
     }
   }
-  return(STA_CAST(int, nMut));
+  return (STA_CAST(int, nMut));
 }
 
-
-// Return a number from 0 to 1 to indicate how similar two genomes are.  For 
+// Return a number from 0 to 1 to indicate how similar two genomes are.  For
 // the binary strings we compare bits.  We count the number of bits that are
 // the same then divide by the number of bits.  If the genomes are different
-// length then we return a -1 to indicate that we cannot calculate the 
+// length then we return a -1 to indicate that we cannot calculate the
 // similarity.
 //   Normal hamming distance makes use of population information - this is not
 // a hamming measure!  This is a similarity measure of two individuals, not
 // two individuals relative to the rest of the population.  This comparison is
 // independent of the population!  (you can do Hamming measure in the scaling
 // object)
-float
-GA1DBinaryStringGenome::BitComparator(const GAGenome& a, const GAGenome& b){
-  const GA1DBinaryStringGenome &sis=DYN_CAST(const GA1DBinaryStringGenome&, a);
-  const GA1DBinaryStringGenome &bro=DYN_CAST(const GA1DBinaryStringGenome&, b);
-  if(sis.length() != bro.length()) return -1;
-  if(sis.length() == 0) return 0;
+float GA1DBinaryStringGenome::BitComparator(const GAGenome &a, const GAGenome &b)
+{
+  const GA1DBinaryStringGenome &sis = DYN_CAST(const GA1DBinaryStringGenome &, a);
+  const GA1DBinaryStringGenome &bro = DYN_CAST(const GA1DBinaryStringGenome &, b);
+  if (sis.length() != bro.length())
+    return -1;
+  if (sis.length() == 0)
+    return 0;
   float count = 0.0;
-  for(int i=sis.length()-1; i>=0; i--)
+  for (int i = sis.length() - 1; i >= 0; i--)
     count += ((sis.gene(i) == bro.gene(i)) ? 0 : 1);
-  return count/sis.length();
+  return count / sis.length();
 }
 
-
-
-
-
-
-
-
-
-
-
-
-
-
 // Randomly take bits from each parent.  For each bit we flip a coin to see if
-// that bit should come from the mother or the father.  This operator can be 
+// that bit should come from the mother or the father.  This operator can be
 // used on genomes of different lengths, but the crossover is truncated to the
 // shorter of the parents and child.
-int
-GA1DBinaryStringGenome::
-UniformCrossover(const GAGenome& p1, const GAGenome& p2,
-		 GAGenome* c1, GAGenome* c2){
-  const GA1DBinaryStringGenome &mom=
-    DYN_CAST(const GA1DBinaryStringGenome &, p1);
-  const GA1DBinaryStringGenome &dad=
-    DYN_CAST(const GA1DBinaryStringGenome &, p2);
+int GA1DBinaryStringGenome::
+    UniformCrossover(const GAGenome &p1, const GAGenome &p2,
+                     GAGenome *c1, GAGenome *c2)
+{
+  const GA1DBinaryStringGenome &mom =
+      DYN_CAST(const GA1DBinaryStringGenome &, p1);
+  const GA1DBinaryStringGenome &dad =
+      DYN_CAST(const GA1DBinaryStringGenome &, p2);
 
-  int n=0;
+  int n = 0;
   int i;
 
-  if(c1 && c2){
-    GA1DBinaryStringGenome &sis=DYN_CAST(GA1DBinaryStringGenome &, *c1);
-    GA1DBinaryStringGenome &bro=DYN_CAST(GA1DBinaryStringGenome &, *c2);
+  if (c1 && c2)
+  {
+    GA1DBinaryStringGenome &sis = DYN_CAST(GA1DBinaryStringGenome &, *c1);
+    GA1DBinaryStringGenome &bro = DYN_CAST(GA1DBinaryStringGenome &, *c2);
 
-    if(sis.length() == bro.length() &&
-       mom.length() == dad.length() &&
-       sis.length() == mom.length()){
-      for(i=sis.length()-1; i>=0; i--){
-	if(GARandomBit()){
-	  sis.gene(i, mom.gene(i));
-	  bro.gene(i, dad.gene(i));
-	}
-	else{
-	  sis.gene(i, dad.gene(i));
-	  bro.gene(i, mom.gene(i));
-	}
+    if (sis.length() == bro.length() &&
+        mom.length() == dad.length() &&
+        sis.length() == mom.length())
+    {
+      for (i = sis.length() - 1; i >= 0; i--)
+      {
+        if (GARandomBit())
+        {
+          sis.gene(i, mom.gene(i));
+          bro.gene(i, dad.gene(i));
+        }
+        else
+        {
+          sis.gene(i, dad.gene(i));
+          bro.gene(i, mom.gene(i));
+        }
       }
     }
-    else{
+    else
+    {
       GAMask mask;
       int start;
       int max = (sis.length() > bro.length()) ? sis.length() : bro.length();
       int min = (mom.length() < dad.length()) ? mom.length() : dad.length();
       mask.size(max);
-      for(i=0; i<max; i++)
-	mask[i] = GARandomBit();
-      start = (sis.length() < min) ? sis.length()-1 : min-1;
-      for(i=start; i>=0; i--)
-	sis.gene(i, (mask[i] ? mom.gene(i) : dad.gene(i)));
-      start = (bro.length() < min) ? bro.length()-1 : min-1;
-      for(i=start; i>=0; i--)
-	bro.gene(i, (mask[i] ? dad.gene(i) : mom.gene(i)));
+      for (i = 0; i < max; i++)
+        mask[i] = GARandomBit();
+      start = (sis.length() < min) ? sis.length() - 1 : min - 1;
+      for (i = start; i >= 0; i--)
+        sis.gene(i, (mask[i] ? mom.gene(i) : dad.gene(i)));
+      start = (bro.length() < min) ? bro.length() - 1 : min - 1;
+      for (i = start; i >= 0; i--)
+        bro.gene(i, (mask[i] ? dad.gene(i) : mom.gene(i)));
     }
     n = 2;
   }
-  else if(c1 || c2){
-    GA1DBinaryStringGenome &sis = (c1 ? 
-				   DYN_CAST(GA1DBinaryStringGenome&, *c1) : 
-				   DYN_CAST(GA1DBinaryStringGenome&, *c2));
+  else if (c1 || c2)
+  {
+    GA1DBinaryStringGenome &sis = (c1 ? DYN_CAST(GA1DBinaryStringGenome &, *c1) : DYN_CAST(GA1DBinaryStringGenome &, *c2));
 
-    if(mom.length() == dad.length() && sis.length() == mom.length()){
-      for(i=sis.length()-1; i>=0; i--)
-	sis.gene(i, (GARandomBit() ? mom.gene(i) : dad.gene(i)));
+    if (mom.length() == dad.length() && sis.length() == mom.length())
+    {
+      for (i = sis.length() - 1; i >= 0; i--)
+        sis.gene(i, (GARandomBit() ? mom.gene(i) : dad.gene(i)));
     }
-    else{
+    else
+    {
       int min = (mom.length() < dad.length()) ? mom.length() : dad.length();
       min = (sis.length() < min) ? sis.length() : min;
-      for(i=min-1; i>=0; i--)
-	sis.gene(i, (GARandomBit() ? mom.gene(i) : dad.gene(i)));
+      for (i = min - 1; i >= 0; i--)
+        sis.gene(i, (GARandomBit() ? mom.gene(i) : dad.gene(i)));
     }
     n = 1;
   }
@@ -405,91 +406,96 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
   return n;
 }
 
-
-
-
-
 // Pick a point in the parents then grab alternating chunks for each child.
 //   A word about crossover site mapping.  If a genome has width 10, the
 // cross site can assume a value of 0 to 10, inclusive.  A site of 0 means
 // that all of the material comes from the father.  A site of 10 means that
 // all of the material comes from the mother.  A site of 3 means that bits
 // 0-2 come from the mother and bits 3-9 come from the father.
-int
-GA1DBinaryStringGenome::
-OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
-		  GAGenome* c1, GAGenome* c2){
-  const GA1DBinaryStringGenome &mom=
-    DYN_CAST(const GA1DBinaryStringGenome &, p1);
-  const GA1DBinaryStringGenome &dad=
-    DYN_CAST(const GA1DBinaryStringGenome &, p2);
+int GA1DBinaryStringGenome::
+    OnePointCrossover(const GAGenome &p1, const GAGenome &p2,
+                      GAGenome *c1, GAGenome *c2)
+{
+  const GA1DBinaryStringGenome &mom =
+      DYN_CAST(const GA1DBinaryStringGenome &, p1);
+  const GA1DBinaryStringGenome &dad =
+      DYN_CAST(const GA1DBinaryStringGenome &, p2);
 
-  int n=0;
+  int n = 0;
   unsigned int momsite, momlen;
   unsigned int dadsite, dadlen;
 
-  if(c1 && c2){
-    GA1DBinaryStringGenome &sis=DYN_CAST(GA1DBinaryStringGenome &, *c1);
-    GA1DBinaryStringGenome &bro=DYN_CAST(GA1DBinaryStringGenome &, *c2);
+  if (c1 && c2)
+  {
+    GA1DBinaryStringGenome &sis = DYN_CAST(GA1DBinaryStringGenome &, *c1);
+    GA1DBinaryStringGenome &bro = DYN_CAST(GA1DBinaryStringGenome &, *c2);
 
-    if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE &&
-       bro.resizeBehaviour() == GAGenome::FIXED_SIZE){
-      if(mom.length() != dad.length() || 
-	 sis.length() != bro.length() ||
-	 sis.length() != mom.length()){
-	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
-	return n;
+    if (sis.resizeBehaviour() == GAGenome::FIXED_SIZE &&
+        bro.resizeBehaviour() == GAGenome::FIXED_SIZE)
+    {
+      if (mom.length() != dad.length() ||
+          sis.length() != bro.length() ||
+          sis.length() != mom.length())
+      {
+        GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
+        return n;
       }
       momsite = dadsite = GARandomInt(0, mom.length());
       momlen = dadlen = mom.length() - momsite;
     }
-    else if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE ||
-	    bro.resizeBehaviour() == GAGenome::FIXED_SIZE){
+    else if (sis.resizeBehaviour() == GAGenome::FIXED_SIZE ||
+             bro.resizeBehaviour() == GAGenome::FIXED_SIZE)
+    {
       GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameBehavReqd);
       return n;
     }
-    else{
+    else
+    {
       momsite = GARandomInt(0, mom.length());
       dadsite = GARandomInt(0, dad.length());
       momlen = mom.length() - momsite;
       dadlen = dad.length() - dadsite;
-      sis.resize(momsite+dadlen);
-      bro.resize(dadsite+momlen);
+      sis.resize(momsite + dadlen);
+      bro.resize(dadsite + momlen);
     }
 
     sis.copy(mom, 0, 0, momsite);
     sis.copy(dad, momsite, dadsite, dadlen);
     bro.copy(dad, 0, 0, dadsite);
     bro.copy(mom, dadsite, momsite, momlen);
-  
+
     n = 2;
   }
-  else if(c1 || c2){
-    GA1DBinaryStringGenome &sis = (c1 ? 
-				   DYN_CAST(GA1DBinaryStringGenome&, *c1) : 
-				   DYN_CAST(GA1DBinaryStringGenome&, *c2));
+  else if (c1 || c2)
+  {
+    GA1DBinaryStringGenome &sis = (c1 ? DYN_CAST(GA1DBinaryStringGenome &, *c1) : DYN_CAST(GA1DBinaryStringGenome &, *c2));
 
-    if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE){
-      if(mom.length() != dad.length() || sis.length() != mom.length()){
-	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
-	return n;
+    if (sis.resizeBehaviour() == GAGenome::FIXED_SIZE)
+    {
+      if (mom.length() != dad.length() || sis.length() != mom.length())
+      {
+        GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
+        return n;
       }
       momsite = dadsite = GARandomInt(0, mom.length());
       momlen = dadlen = mom.length() - momsite;
     }
-    else{
+    else
+    {
       momsite = GARandomInt(0, mom.length());
       dadsite = GARandomInt(0, dad.length());
       momlen = mom.length() - momsite;
       dadlen = dad.length() - dadsite;
-      sis.resize(momsite+dadlen);
+      sis.resize(momsite + dadlen);
     }
 
-    if(GARandomBit()){
+    if (GARandomBit())
+    {
       sis.copy(mom, 0, 0, momsite);
       sis.copy(dad, momsite, dadsite, dadlen);
     }
-    else{
+    else
+    {
       sis.copy(dad, 0, 0, dadsite);
       sis.copy(mom, dadsite, momsite, momlen);
     }
@@ -500,45 +506,43 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
   return n;
 }
 
-
-
-
-
-
-
 // Two point crossover for one dimension binary strings.  The first part is
 // taken from the mother, the second from the father, and the third from the
 // mother.  If the child is resizable then we resize before copying the parts.
 //   The rules for doing resizable crossover apply here as well as for the
 // single point crossover (see comments for 1Pt for details).
-int
-GA1DBinaryStringGenome::
-TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
-		  GAGenome* c1, GAGenome* c2){
-  const GA1DBinaryStringGenome &mom=
-    DYN_CAST(const GA1DBinaryStringGenome &, p1);
-  const GA1DBinaryStringGenome &dad=
-    DYN_CAST(const GA1DBinaryStringGenome &, p2);
+int GA1DBinaryStringGenome::
+    TwoPointCrossover(const GAGenome &p1, const GAGenome &p2,
+                      GAGenome *c1, GAGenome *c2)
+{
+  const GA1DBinaryStringGenome &mom =
+      DYN_CAST(const GA1DBinaryStringGenome &, p1);
+  const GA1DBinaryStringGenome &dad =
+      DYN_CAST(const GA1DBinaryStringGenome &, p2);
 
-  int n=0;
+  int n = 0;
   unsigned int momsite[2], momlen[2];
   unsigned int dadsite[2], dadlen[2];
 
-  if(c1 && c2){
-    GA1DBinaryStringGenome &sis=DYN_CAST(GA1DBinaryStringGenome &, *c1);
-    GA1DBinaryStringGenome &bro=DYN_CAST(GA1DBinaryStringGenome &, *c2);
+  if (c1 && c2)
+  {
+    GA1DBinaryStringGenome &sis = DYN_CAST(GA1DBinaryStringGenome &, *c1);
+    GA1DBinaryStringGenome &bro = DYN_CAST(GA1DBinaryStringGenome &, *c2);
 
-    if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE &&
-       bro.resizeBehaviour() == GAGenome::FIXED_SIZE){
-      if(mom.length() != dad.length() || 
-	 sis.length() != bro.length() ||
-	 sis.length() != mom.length()){
-	GAErr(GA_LOC, mom.className(), "two-point cross", gaErrSameLengthReqd);
-	return n;
+    if (sis.resizeBehaviour() == GAGenome::FIXED_SIZE &&
+        bro.resizeBehaviour() == GAGenome::FIXED_SIZE)
+    {
+      if (mom.length() != dad.length() ||
+          sis.length() != bro.length() ||
+          sis.length() != mom.length())
+      {
+        GAErr(GA_LOC, mom.className(), "two-point cross", gaErrSameLengthReqd);
+        return n;
       }
       momsite[0] = GARandomInt(0, mom.length());
       momsite[1] = GARandomInt(0, mom.length());
-      if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
+      if (momsite[0] > momsite[1])
+        SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
 
@@ -547,50 +551,56 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
       dadlen[0] = momlen[0];
       dadlen[1] = momlen[1];
     }
-    else if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE ||
-	    bro.resizeBehaviour() == GAGenome::FIXED_SIZE){
+    else if (sis.resizeBehaviour() == GAGenome::FIXED_SIZE ||
+             bro.resizeBehaviour() == GAGenome::FIXED_SIZE)
+    {
       GAErr(GA_LOC, mom.className(), "two-point cross", gaErrSameBehavReqd);
       return n;
     }
-    else{
+    else
+    {
       momsite[0] = GARandomInt(0, mom.length());
       momsite[1] = GARandomInt(0, mom.length());
-      if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
+      if (momsite[0] > momsite[1])
+        SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
-      
+
       dadsite[0] = GARandomInt(0, dad.length());
       dadsite[1] = GARandomInt(0, dad.length());
-      if(dadsite[0] > dadsite[1]) SWAP(dadsite[0], dadsite[1]);
+      if (dadsite[0] > dadsite[1])
+        SWAP(dadsite[0], dadsite[1]);
       dadlen[0] = dadsite[1] - dadsite[0];
       dadlen[1] = dad.length() - dadsite[1];
 
-      sis.resize(momsite[0]+dadlen[0]+momlen[1]);
-      bro.resize(dadsite[0]+momlen[0]+dadlen[1]);
+      sis.resize(momsite[0] + dadlen[0] + momlen[1]);
+      bro.resize(dadsite[0] + momlen[0] + dadlen[1]);
     }
 
     sis.copy(mom, 0, 0, momsite[0]);
     sis.copy(dad, momsite[0], dadsite[0], dadlen[0]);
-    sis.copy(mom, momsite[0]+dadlen[0], momsite[1], momlen[1]);
+    sis.copy(mom, momsite[0] + dadlen[0], momsite[1], momlen[1]);
     bro.copy(dad, 0, 0, dadsite[0]);
     bro.copy(mom, dadsite[0], momsite[0], momlen[0]);
-    bro.copy(dad, dadsite[0]+momlen[0], dadsite[1], dadlen[1]);
+    bro.copy(dad, dadsite[0] + momlen[0], dadsite[1], dadlen[1]);
 
     n = 2;
   }
-  else if(c1 || c2){
-    GA1DBinaryStringGenome &sis = (c1 ? 
-				   DYN_CAST(GA1DBinaryStringGenome&, *c1) : 
-				   DYN_CAST(GA1DBinaryStringGenome&, *c2));
+  else if (c1 || c2)
+  {
+    GA1DBinaryStringGenome &sis = (c1 ? DYN_CAST(GA1DBinaryStringGenome &, *c1) : DYN_CAST(GA1DBinaryStringGenome &, *c2));
 
-    if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE){
-      if(mom.length() != dad.length() || sis.length() != mom.length()){
-	GAErr(GA_LOC, mom.className(), "two-point cross", gaErrSameLengthReqd);
-	return n;
+    if (sis.resizeBehaviour() == GAGenome::FIXED_SIZE)
+    {
+      if (mom.length() != dad.length() || sis.length() != mom.length())
+      {
+        GAErr(GA_LOC, mom.className(), "two-point cross", gaErrSameLengthReqd);
+        return n;
       }
       momsite[0] = GARandomInt(0, mom.length());
       momsite[1] = GARandomInt(0, mom.length());
-      if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
+      if (momsite[0] > momsite[1])
+        SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
 
@@ -599,31 +609,36 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
       dadlen[0] = momlen[0];
       dadlen[1] = momlen[1];
     }
-    else{
+    else
+    {
       momsite[0] = GARandomInt(0, mom.length());
       momsite[1] = GARandomInt(0, mom.length());
-      if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
+      if (momsite[0] > momsite[1])
+        SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
-      
+
       dadsite[0] = GARandomInt(0, dad.length());
       dadsite[1] = GARandomInt(0, dad.length());
-      if(dadsite[0] > dadsite[1]) SWAP(dadsite[0], dadsite[1]);
+      if (dadsite[0] > dadsite[1])
+        SWAP(dadsite[0], dadsite[1]);
       dadlen[0] = dadsite[1] - dadsite[0];
       dadlen[1] = dad.length() - dadsite[1];
 
-      sis.resize(momsite[0]+dadlen[0]+momlen[1]);
+      sis.resize(momsite[0] + dadlen[0] + momlen[1]);
     }
 
-    if(GARandomBit()){
+    if (GARandomBit())
+    {
       sis.copy(mom, 0, 0, momsite[0]);
       sis.copy(dad, momsite[0], dadsite[0], dadlen[0]);
-      sis.copy(mom, momsite[0]+dadlen[0], momsite[1], momlen[1]);
+      sis.copy(mom, momsite[0] + dadlen[0], momsite[1], momlen[1]);
     }
-    else{
+    else
+    {
       sis.copy(dad, 0, 0, dadsite[0]);
       sis.copy(mom, dadsite[0], momsite[0], momlen[0]);
-      sis.copy(dad, dadsite[0]+momlen[0], dadsite[1], dadlen[1]);
+      sis.copy(dad, dadsite[0] + momlen[0], dadsite[1], dadlen[1]);
     }
 
     n = 1;
@@ -632,76 +647,80 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
   return n;
 }
 
-
-
-
-
 //   Even and odd crossovers take alternating bits from the mother and father.
 // For even crossover, we take every even bit from the mother and every odd bit
 // from the father (the first bit is the 0th bit, so it is even).  Odd
-// crossover is just the opposite.  
-int
-GA1DBinaryStringGenome::
-EvenOddCrossover(const GAGenome& p1, const GAGenome& p2, 
-		 GAGenome* c1, GAGenome* c2){
-  const GA1DBinaryStringGenome &mom=
-    DYN_CAST(const GA1DBinaryStringGenome &, p1);
-  const GA1DBinaryStringGenome &dad=
-    DYN_CAST(const GA1DBinaryStringGenome &, p2);
+// crossover is just the opposite.
+int GA1DBinaryStringGenome::
+    EvenOddCrossover(const GAGenome &p1, const GAGenome &p2,
+                     GAGenome *c1, GAGenome *c2)
+{
+  const GA1DBinaryStringGenome &mom =
+      DYN_CAST(const GA1DBinaryStringGenome &, p1);
+  const GA1DBinaryStringGenome &dad =
+      DYN_CAST(const GA1DBinaryStringGenome &, p2);
 
-  int n=0;
+  int n = 0;
   int i;
 
-  if(c1 && c2){
-    GA1DBinaryStringGenome &sis=DYN_CAST(GA1DBinaryStringGenome &, *c1);
-    GA1DBinaryStringGenome &bro=DYN_CAST(GA1DBinaryStringGenome &, *c2);
+  if (c1 && c2)
+  {
+    GA1DBinaryStringGenome &sis = DYN_CAST(GA1DBinaryStringGenome &, *c1);
+    GA1DBinaryStringGenome &bro = DYN_CAST(GA1DBinaryStringGenome &, *c2);
 
-    if(sis.length() == bro.length() &&
-       mom.length() == dad.length() &&
-       sis.length() == mom.length()){
-      for(i=sis.length()-1; i>=1; i-=2){
-	sis.gene(i, mom.gene(i));
-	bro.gene(i, dad.gene(i));
-	sis.gene(i-1, dad.gene(i-1));
-	bro.gene(i-1, mom.gene(i-1));
+    if (sis.length() == bro.length() &&
+        mom.length() == dad.length() &&
+        sis.length() == mom.length())
+    {
+      for (i = sis.length() - 1; i >= 1; i -= 2)
+      {
+        sis.gene(i, mom.gene(i));
+        bro.gene(i, dad.gene(i));
+        sis.gene(i - 1, dad.gene(i - 1));
+        bro.gene(i - 1, mom.gene(i - 1));
       }
-      if(i==0){
-	sis.gene(0, mom.gene(0));
-	bro.gene(0, dad.gene(0));
+      if (i == 0)
+      {
+        sis.gene(0, mom.gene(0));
+        bro.gene(0, dad.gene(0));
       }
     }
-    else{
+    else
+    {
       int start;
       int min = (mom.length() < dad.length()) ? mom.length() : dad.length();
-      start = (sis.length() < min) ? sis.length()-1 : min-1;
-      for(i=start; i>=0; i--)
-	sis.gene(i, ((i%2 == 0) ? mom.gene(i) : dad.gene(i)));
-      start = (bro.length() < min) ? bro.length()-1 : min-1;
-      for(i=start; i>=0; i--)
-	bro.gene(i, ((i%2 == 0) ? dad.gene(i) : mom.gene(i)));
+      start = (sis.length() < min) ? sis.length() - 1 : min - 1;
+      for (i = start; i >= 0; i--)
+        sis.gene(i, ((i % 2 == 0) ? mom.gene(i) : dad.gene(i)));
+      start = (bro.length() < min) ? bro.length() - 1 : min - 1;
+      for (i = start; i >= 0; i--)
+        bro.gene(i, ((i % 2 == 0) ? dad.gene(i) : mom.gene(i)));
     }
 
     n = 2;
   }
-  else if(c1 || c2){
-    GA1DBinaryStringGenome &sis = (c1 ?
-				   DYN_CAST(GA1DBinaryStringGenome&, *c1) : 
-				   DYN_CAST(GA1DBinaryStringGenome&, *c2));
+  else if (c1 || c2)
+  {
+    GA1DBinaryStringGenome &sis = (c1 ? DYN_CAST(GA1DBinaryStringGenome &, *c1) : DYN_CAST(GA1DBinaryStringGenome &, *c2));
 
-    if(mom.length() == dad.length() && sis.length() == mom.length()){
-      for(i=sis.length()-1; i>=1; i-=2){
-	sis.gene(i, mom.gene(i));
-	sis.gene(i-1, dad.gene(i-1));
+    if (mom.length() == dad.length() && sis.length() == mom.length())
+    {
+      for (i = sis.length() - 1; i >= 1; i -= 2)
+      {
+        sis.gene(i, mom.gene(i));
+        sis.gene(i - 1, dad.gene(i - 1));
       }
-      if(i==0){
-	sis.gene(0, mom.gene(0));
+      if (i == 0)
+      {
+        sis.gene(0, mom.gene(0));
       }
     }
-    else{
+    else
+    {
       int min = (mom.length() < dad.length()) ? mom.length() : dad.length();
-      min = (sis.length() < min) ? sis.length()-1 : min-1;
-      for(i=min; i>=0; i--)
-	sis.gene(i, ((i%2 == 0) ? mom.gene(i) : dad.gene(i)));
+      min = (sis.length() < min) ? sis.length() - 1 : min - 1;
+      for (i = min; i >= 0; i--)
+        sis.gene(i, ((i % 2 == 0) ? mom.gene(i) : dad.gene(i)));
     }
 
     n = 1;

--- a/Global_dynamic_MPFA/source/ga-mpi/GA2DArrayGenome.C
+++ b/Global_dynamic_MPFA/source/ga-mpi/GA2DArrayGenome.C
@@ -27,13 +27,13 @@ GA2DArrayGenome<T>::className() const {return "GA2DArrayGenome";}
 template <class T> int
 GA2DArrayGenome<T>::classID() const {return GAID::ArrayGenome2D;}
 
-template <class T> 
+template <class T>
 GA2DArrayGenome<T>::
-GA2DArrayGenome(unsigned int width, unsigned int height, 
+GA2DArrayGenome(unsigned int width, unsigned int height,
 		GAGenome::Evaluator f,
 		void * u) :
 GAArray<T>(width*height),
-GAGenome(DEFAULT_2DARRAY_INITIALIZER, 
+GAGenome(DEFAULT_2DARRAY_INITIALIZER,
 	 DEFAULT_2DARRAY_MUTATOR,
 	 DEFAULT_2DARRAY_COMPARATOR)
 {
@@ -44,7 +44,7 @@ GAGenome(DEFAULT_2DARRAY_INITIALIZER,
 }
 
 
-template <class T> 
+template <class T>
 GA2DArrayGenome<T>::
 GA2DArrayGenome(const GA2DArrayGenome<T> & orig) : GAArray<T>(orig.sz){
   GA2DArrayGenome<T>::copy(orig);
@@ -62,10 +62,10 @@ GA2DArrayGenome<T>::copy(const GAGenome & orig){
   if(c) {
     GAGenome::copy(*c);
     GAArray<T>::copy(*c);
-    nx = c->nx; ny = c->ny; 
-    minX = c->minX; minY = c->minY; 
+    nx = c->nx; ny = c->ny;
+    minX = c->minX; minY = c->minY;
     maxX = c->maxX; maxY = c->maxY;
-  } 
+  }
 }
 
 
@@ -77,8 +77,8 @@ GA2DArrayGenome<T>::clone(GAGenome::CloneMethod flag) const {
   }
   else{
     cpy->GAGenome::copy(*this);
-    cpy->minX = minX; cpy->minY = minY; 
-    cpy->maxX = maxX; cpy->maxY = maxY; 
+    cpy->minX = minX; cpy->minY = minY;
+    cpy->maxX = maxX; cpy->maxY = maxY;
   }
   return cpy;
 }
@@ -137,7 +137,7 @@ GA2DArrayGenome<T>::read(STD_ISTREAM &) {
 
 
 template <class T> int
-GA2DArrayGenome<T>::write(STD_OSTREAM & os) const 
+GA2DArrayGenome<T>::write(STD_OSTREAM & os) const
 {
   for(unsigned int j=0; j<ny; j++){
     for(unsigned int i=0; i<nx; i++){
@@ -167,7 +167,7 @@ GA2DArrayGenome<T>::resizeBehaviour(GAGenome::Dimension which) const {
 
 template <class T> int
 GA2DArrayGenome<T>::
-resizeBehaviour(GAGenome::Dimension which, 
+resizeBehaviour(GAGenome::Dimension which,
 		unsigned int lower, unsigned int upper)
 {
   if(upper < lower){
@@ -212,12 +212,12 @@ GA2DArrayGenome<T>::copy(const GA2DArrayGenome<T> & orig,
   for(unsigned int j=0; j<h; j++)
     GAArray<T>::copy(orig, (s+j)*nx+r, (y+j)*orig.nx+x, w);
 
-  _evaluated = gaFalse; 
+  _evaluated = gaFalse;
 }
 
 
 
-template <class T> int 
+template <class T> int
 GA2DArrayGenome<T>::equal(const GAGenome & c) const
 {
   if(this == &c) return 1;
@@ -259,9 +259,9 @@ GA2DArrayAlleleGenome<T>::className() const {return "GA2DArrayAlleleGenome";}
 template <class T> int
 GA2DArrayAlleleGenome<T>::classID() const {return GAID::ArrayAlleleGenome2D;}
 
-template <class T> 
+template <class T>
 GA2DArrayAlleleGenome<T>::
-GA2DArrayAlleleGenome(unsigned int width, unsigned int height, 
+GA2DArrayAlleleGenome(unsigned int width, unsigned int height,
 		      const GAAlleleSet<T> & s,
 		      GAGenome::Evaluator f, void * u) :
 GA2DArrayGenome<T>(width,height,f,u){
@@ -275,9 +275,9 @@ GA2DArrayGenome<T>(width,height,f,u){
   this->crossover(GA2DArrayAlleleGenome<T>::DEFAULT_2DARRAY_ALLELE_CROSSOVER);
 }
 
-template <class T> 
+template <class T>
 GA2DArrayAlleleGenome<T>::
-GA2DArrayAlleleGenome(unsigned int width, unsigned int height, 
+GA2DArrayAlleleGenome(unsigned int width, unsigned int height,
 		      const GAAlleleSetArray<T> & sa,
 		      GAGenome::Evaluator f, void * u) :
 GA2DArrayGenome<T>(width,height, f, u) {
@@ -293,9 +293,9 @@ GA2DArrayGenome<T>(width,height, f, u) {
 }
 
 
-template <class T> 
+template <class T>
 GA2DArrayAlleleGenome<T>::
-GA2DArrayAlleleGenome(const GA2DArrayAlleleGenome<T> & orig) : 
+GA2DArrayAlleleGenome(const GA2DArrayAlleleGenome<T> & orig) :
 GA2DArrayGenome<T>(orig.nx, orig.ny) {
   naset = 0;
   aset = (GAAlleleSet<T>*)0;
@@ -315,10 +315,10 @@ GA2DArrayAlleleGenome<T>::clone(GAGenome::CloneMethod) const {
 }
 
 
-template <class T> void 
+template <class T> void
 GA2DArrayAlleleGenome<T>::copy(const GAGenome& orig){
   if(&orig == this) return;
-  const GA2DArrayAlleleGenome<T>* c = 
+  const GA2DArrayAlleleGenome<T>* c =
     DYN_CAST(const GA2DArrayAlleleGenome<T>*, &orig);
   if(c) {
     GA2DArrayGenome<T>::copy(*c);
@@ -386,24 +386,24 @@ GA2DArrayAlleleGenome<T>::equal(const GAGenome & c) const {
    Operator definitions
 ---------------------------------------------------------------------------- */
 // this does not handle genomes with multiple allele sets!
-template <class ARRAY_TYPE> void 
+template <class ARRAY_TYPE> void
 GA2DArrayAlleleGenome<ARRAY_TYPE>::UniformInitializer(GAGenome & c)
 {
   GA2DArrayAlleleGenome<ARRAY_TYPE> &child=
     DYN_CAST(GA2DArrayAlleleGenome<ARRAY_TYPE> &, c);
-  child.resize(GAGenome::ANY_SIZE,GAGenome::ANY_SIZE); 
+  child.resize(GAGenome::ANY_SIZE,GAGenome::ANY_SIZE);
   for(int i=child.width()-1; i>=0; i--)
     for(int j=child.height()-1; j>=0; j--)
       child.gene(i, j, child.alleleset().allele());
 }
 
 
-template <class ARRAY_TYPE> int 
+template <class ARRAY_TYPE> int
 GA2DArrayAlleleGenome<ARRAY_TYPE>::FlipMutator(GAGenome & c, float pmut)
 {
   GA2DArrayAlleleGenome<ARRAY_TYPE> &child=
     DYN_CAST(GA2DArrayAlleleGenome<ARRAY_TYPE> &, c);
-  register int n, m, i, j;
+  int n, m, i, j;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.size());
@@ -430,11 +430,11 @@ GA2DArrayAlleleGenome<ARRAY_TYPE>::FlipMutator(GAGenome & c, float pmut)
 }
 
 
-template <class ARRAY_TYPE> int 
+template <class ARRAY_TYPE> int
 GA2DArrayGenome<ARRAY_TYPE>::SwapMutator(GAGenome & c, float pmut)
 {
   GA2DArrayGenome<ARRAY_TYPE> &child=DYN_CAST(GA2DArrayGenome<ARRAY_TYPE>&, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.size());
@@ -496,7 +496,7 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
   if(c1 && c2){
     GA2DArrayGenome<T> &sis=DYN_CAST(GA2DArrayGenome<T> &, *c1);
     GA2DArrayGenome<T> &bro=DYN_CAST(GA2DArrayGenome<T> &, *c2);
-    
+
     if(sis.width() == bro.width() && sis.height() == bro.height() &&
        mom.width() == dad.width() && mom.height() == dad.height() &&
        sis.width() == mom.width() && sis.height() == mom.height()){
@@ -567,7 +567,7 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
 
 
 // This crossover does clipping (no padding) for resizables.  Notice that this
-// means that any resizable children of two parents will have identical 
+// means that any resizable children of two parents will have identical
 // dimensions no matter what.
 template <class T> int
 GA2DArrayGenome<T>::
@@ -587,8 +587,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE){
-      if(mom.width() != dad.width() || 
-	 sis.width() != bro.width() || 
+      if(mom.width() != dad.width() ||
+	 sis.width() != bro.width() ||
 	 sis.width() != mom.width()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -612,8 +612,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
-      if(mom.height() != dad.height() || 
-	 sis.height() != bro.height() || 
+      if(mom.height() != dad.height() ||
+	 sis.height() != bro.height() ||
 	 sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -637,12 +637,12 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     sis.resize(sitex+lenx, sitey+leny);
     bro.resize(sitex+lenx, sitey+leny);
-    
+
     sis.copy(mom, 0, 0, momsitex-sitex, momsitey-sitey, sitex, sitey);
     sis.copy(dad, sitex, 0, dadsitex, dadsitey-sitey, lenx, sitey);
     sis.copy(dad, 0, sitey, dadsitex-sitex, dadsitey, sitex, leny);
     sis.copy(mom, sitex, sitey, momsitex, momsitey, lenx, leny);
-    
+
     bro.copy(dad, 0, 0, dadsitex-sitex, dadsitey-sitey, sitex, sitey);
     bro.copy(mom, sitex, 0, momsitex, momsitey-sitey, lenx, sitey);
     bro.copy(mom, 0, sitey, momsitex-sitex, momsitey, sitex, leny);
@@ -652,7 +652,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
   }
   else if(c1){
     GA2DArrayGenome<T> &sis=DYN_CAST(GA2DArrayGenome<T> &, *c1);
-    
+
     if(sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE){
       if(mom.width() != dad.width() || sis.width() != mom.width()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -669,7 +669,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitex = GAMin(momsitex, dadsitex);
       lenx = GAMin(momlenx, dadlenx);
     }
-    
+
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
       if(mom.height() != dad.height() || sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -686,9 +686,9 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitey = GAMin(momsitey, dadsitey);
       leny = GAMin(momleny, dadleny);
     }
-    
+
     sis.resize(sitex+lenx, sitey+leny);
-    
+
     if(GARandomBit()){
       sis.copy(mom, 0, 0, momsitex-sitex, momsitey-sitey, sitex, sitey);
       sis.copy(dad, sitex, 0, dadsitex, dadsitey-sitey, lenx, sitey);
@@ -759,7 +759,7 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
   }
   else if(c1){
     GA2DArrayGenome<T> &sis=DYN_CAST(GA2DArrayGenome<T> &, *c1);
-    
+
     if(mom.width() == dad.width() && mom.height() == dad.height() &&
        sis.width() == mom.width() && sis.height() == mom.height()){
       int count=0;

--- a/Global_dynamic_MPFA/source/ga-mpi/GA2DBinStrGenome.C
+++ b/Global_dynamic_MPFA/source/ga-mpi/GA2DBinStrGenome.C
@@ -21,141 +21,164 @@
    Genome class definition
 ---------------------------------------------------------------------------- */
 GA2DBinaryStringGenome::
-GA2DBinaryStringGenome(unsigned int width, unsigned int height, 
-		       GAGenome::Evaluator f, void * u) :
-GABinaryString(width*height),
-GAGenome(DEFAULT_2DBINSTR_INITIALIZER,
-	 DEFAULT_2DBINSTR_MUTATOR,
-	 DEFAULT_2DBINSTR_COMPARATOR) {
+    GA2DBinaryStringGenome(unsigned int width, unsigned int height,
+                           GAGenome::Evaluator f, void *u) : GABinaryString(width * height),
+                                                             GAGenome(DEFAULT_2DBINSTR_INITIALIZER,
+                                                                      DEFAULT_2DBINSTR_MUTATOR,
+                                                                      DEFAULT_2DBINSTR_COMPARATOR)
+{
   evaluator(f);
   userData(u);
   crossover(DEFAULT_2DBINSTR_CROSSOVER);
-  nx=minX=maxX=0; ny=minY=maxY=0;
+  nx = minX = maxX = 0;
+  ny = minY = maxY = 0;
   resize(width, height);
 }
 
-
 GA2DBinaryStringGenome::
-GA2DBinaryStringGenome(const GA2DBinaryStringGenome & orig) :
-GABinaryString(orig.GABinaryString::size()),
-GAGenome() {
-  nx=minX=maxX=0; ny=minY=maxY=0;
+    GA2DBinaryStringGenome(const GA2DBinaryStringGenome &orig) : GABinaryString(orig.GABinaryString::size()),
+                                                                 GAGenome()
+{
+  nx = minX = maxX = 0;
+  ny = minY = maxY = 0;
   GA2DBinaryStringGenome::copy(orig);
 }
 
-GA2DBinaryStringGenome::~GA2DBinaryStringGenome() {
+GA2DBinaryStringGenome::~GA2DBinaryStringGenome()
+{
 }
 
 GAGenome *
-GA2DBinaryStringGenome::clone(GAGenome::CloneMethod flag) const {
-  GA2DBinaryStringGenome *cpy = new GA2DBinaryStringGenome(nx,ny);
-  if(flag == CONTENTS){
+GA2DBinaryStringGenome::clone(GAGenome::CloneMethod flag) const
+{
+  GA2DBinaryStringGenome *cpy = new GA2DBinaryStringGenome(nx, ny);
+  if (flag == CONTENTS)
+  {
     cpy->copy(*this);
   }
-  else{
+  else
+  {
     cpy->GAGenome::copy(*this);
-    cpy->minX = minX; cpy->minY = minY; 
-    cpy->maxX = maxX; cpy->maxY = maxY; 
+    cpy->minX = minX;
+    cpy->minY = minY;
+    cpy->maxX = maxX;
+    cpy->maxY = maxY;
   }
   return cpy;
 }
 
-void
-GA2DBinaryStringGenome::copy(const GAGenome & orig)
+void GA2DBinaryStringGenome::copy(const GAGenome &orig)
 {
-  if(&orig == this) return;
-  const GA2DBinaryStringGenome* c =
-    DYN_CAST(const GA2DBinaryStringGenome*, &orig);
-  if(c) {
+  if (&orig == this)
+    return;
+  const GA2DBinaryStringGenome *c =
+      DYN_CAST(const GA2DBinaryStringGenome *, &orig);
+  if (c)
+  {
     GAGenome::copy(*c);
     GABinaryString::copy(*c);
-    nx = c->nx; ny = c->ny; 
-    minX = c->minX; minY = c->minY; 
-    maxX = c->maxX; maxY = c->maxY;
-  } 
+    nx = c->nx;
+    ny = c->ny;
+    minX = c->minX;
+    minY = c->minY;
+    maxX = c->maxX;
+    maxY = c->maxY;
+  }
 }
 
-
-int
-GA2DBinaryStringGenome::resize(int w, int h)
+int GA2DBinaryStringGenome::resize(int w, int h)
 {
-  if((unsigned int)w == nx && (unsigned int)h == ny) return sz;
+  if ((unsigned int)w == nx && (unsigned int)h == ny)
+    return sz;
 
-  if(w == GAGenome::ANY_SIZE)
+  if (w == GAGenome::ANY_SIZE)
     w = GARandomInt(minX, maxX);
-  else if(w < 0)
-    w = nx;		// do nothing
-  else if(minX == maxX)
-    minX=maxX = w;
-  else{
-    if(w < STA_CAST(int, minX)) w=minX;
-    if(w > STA_CAST(int, maxX)) w=maxX;
+  else if (w < 0)
+    w = nx; // do nothing
+  else if (minX == maxX)
+    minX = maxX = w;
+  else
+  {
+    if (w < STA_CAST(int, minX))
+      w = minX;
+    if (w > STA_CAST(int, maxX))
+      w = maxX;
   }
 
-  if(h == GAGenome::ANY_SIZE)
+  if (h == GAGenome::ANY_SIZE)
     h = GARandomInt(minY, maxY);
-  else if(h < 0)
-    h = ny;		// do nothing
-  else if(minY == maxY)
-    minY=maxY = h;
-  else{
-    if(h < STA_CAST(int, minY)) h=minY;
-    if(h > STA_CAST(int, maxY)) h=maxY;
+  else if (h < 0)
+    h = ny; // do nothing
+  else if (minY == maxY)
+    minY = maxY = h;
+  else
+  {
+    if (h < STA_CAST(int, minY))
+      h = minY;
+    if (h > STA_CAST(int, maxY))
+      h = maxY;
   }
 
-// Move the bits into the right position.  If we're smaller, then shift to
-// the smaller size before we do the resize (the resize method maintains bit
-// integrety).  If we're larger, do the move after the resize.  If we're the 
-// same size the we don't do anything.  When we're adding more bits, the new
-// bits get set randomly to 0 or 1.
+  // Move the bits into the right position.  If we're smaller, then shift to
+  // the smaller size before we do the resize (the resize method maintains bit
+  // integrety).  If we're larger, do the move after the resize.  If we're the
+  // same size the we don't do anything.  When we're adding more bits, the new
+  // bits get set randomly to 0 or 1.
 
-  if(w < STA_CAST(int,nx)){
-    int y=GAMin(STA_CAST(int,ny),h);
-    for(int j=0; j<y; j++)
-      GABinaryString::move(j*w,j*nx,w);
+  if (w < STA_CAST(int, nx))
+  {
+    int y = GAMin(STA_CAST(int, ny), h);
+    for (int j = 0; j < y; j++)
+      GABinaryString::move(j * w, j * nx, w);
   }
-  GABinaryString::resize(w*h);
-  if(w > STA_CAST(int,nx)){		// adjust the existing chunks of bits
-    int y=GAMin(STA_CAST(int,ny),h);
-    for(int j=y-1; j>=0; j--){
-      GABinaryString::move(j*w,j*nx,nx);
-      for(int i=nx; i<w; i++)
-	bit(j*w+i, GARandomBit());
+  GABinaryString::resize(w * h);
+  if (w > STA_CAST(int, nx))
+  { // adjust the existing chunks of bits
+    int y = GAMin(STA_CAST(int, ny), h);
+    for (int j = y - 1; j >= 0; j--)
+    {
+      GABinaryString::move(j * w, j * nx, nx);
+      for (int i = nx; i < w; i++)
+        bit(j * w + i, GARandomBit());
     }
   }
-  if(h > STA_CAST(int,ny)){		// change in height is always new bits
-    for(int i=w*ny; i<w*h; i++)
+  if (h > STA_CAST(int, ny))
+  { // change in height is always new bits
+    for (int i = w * ny; i < w * h; i++)
       bit(i, GARandomBit());
   }
 
-  nx = w; ny = h;
+  nx = w;
+  ny = h;
   _evaluated = gaFalse;
   return sz;
 }
 
-
 #ifdef GALIB_USE_STREAMS
-int
-GA2DBinaryStringGenome::read(STD_ISTREAM & is)
+int GA2DBinaryStringGenome::read(STD_ISTREAM &is)
 {
   static char c;
-  unsigned int i=0, j=0;
-  while(!is.fail() && !is.eof() && j < ny) {
+  unsigned int i = 0, j = 0;
+  while (!is.fail() && !is.eof() && j < ny)
+  {
     is >> c;
-    if(isdigit(c)){
+    if (isdigit(c))
+    {
       gene(i, j, ((c == '0') ? 0 : 1));
-      if(++i >= nx){		// ready for next row
-	i=0;
-	j++;
+      if (++i >= nx)
+      { // ready for next row
+        i = 0;
+        j++;
       }
     }
   }
 
   _evaluated = gaFalse;
 
-  if(is.eof() && 
-     ((j < ny) ||	     // didn't get some lines
-      (i < nx && i != 0))){   // stopped early on a row
+  if (is.eof() &&
+      ((j < ny) || // didn't get some lines
+       (i < nx && i != 0)))
+  { // stopped early on a row
     GAErr(GA_LOC, className(), "read", gaErrUnexpectedEOF);
     is.clear(STD_IOS_BADBIT | is.rdstate());
     return 1;
@@ -164,57 +187,67 @@ GA2DBinaryStringGenome::read(STD_ISTREAM & is)
   return 0;
 }
 
-
 // Dump the digits to the stream with a newline between each row.  No newline
 // at the end of the whole thing.
-int
-GA2DBinaryStringGenome::write(STD_OSTREAM & os) const 
+int GA2DBinaryStringGenome::write(STD_OSTREAM &os) const
 {
-  for(unsigned int j=0; j<ny; j++){
-    for(unsigned int i=0; i<nx; i++)
-      os << gene(i,j);
+  for (unsigned int j = 0; j < ny; j++)
+  {
+    for (unsigned int i = 0; i < nx; i++)
+      os << gene(i, j);
     os << "\n";
   }
   return 0;
 }
 #endif
 
-
-int 
-GA2DBinaryStringGenome::resizeBehaviour(GAGenome::Dimension which) const {
+int GA2DBinaryStringGenome::resizeBehaviour(GAGenome::Dimension which) const
+{
   int val = 0;
-  if(which == WIDTH) {
-    if(maxX == minX) val = FIXED_SIZE;
-    else val = maxX;
+  if (which == WIDTH)
+  {
+    if (maxX == minX)
+      val = FIXED_SIZE;
+    else
+      val = maxX;
   }
-  else if(which == HEIGHT) {
-    if(maxY == minY) val = FIXED_SIZE;
-    else val = maxY;
+  else if (which == HEIGHT)
+  {
+    if (maxY == minY)
+      val = FIXED_SIZE;
+    else
+      val = maxY;
   }
   return val;
 }
 
-
-int
-GA2DBinaryStringGenome::
-resizeBehaviour(Dimension which, unsigned int lower, unsigned int upper)
+int GA2DBinaryStringGenome::
+    resizeBehaviour(Dimension which, unsigned int lower, unsigned int upper)
 {
-  if(upper < lower){
+  if (upper < lower)
+  {
     GAErr(GA_LOC, className(), "resizeBehaviour", gaErrBadResizeBehaviour);
     return resizeBehaviour(which);
   }
 
-  switch(which){
+  switch (which)
+  {
   case WIDTH:
-    minX = lower; maxX = upper;
-    if(nx > upper) resize(upper,ny);
-    if(nx < lower) resize(lower,ny);
+    minX = lower;
+    maxX = upper;
+    if (nx > upper)
+      resize(upper, ny);
+    if (nx < lower)
+      resize(lower, ny);
     break;
 
   case HEIGHT:
-    minY = lower; maxY = upper;
-    if(ny > upper) resize(nx,upper);
-    if(ny < lower) resize(nx,lower);
+    minY = lower;
+    maxY = upper;
+    if (ny > upper)
+      resize(nx, upper);
+    if (ny < lower)
+      resize(nx, lower);
     break;
 
   default:
@@ -224,117 +257,116 @@ resizeBehaviour(Dimension which, unsigned int lower, unsigned int upper)
   return resizeBehaviour(which);
 }
 
-
-void
-GA2DBinaryStringGenome::copy(const GA2DBinaryStringGenome & orig,
-			     unsigned int r, unsigned int s,
-			     unsigned int x, unsigned int y,
-			     unsigned int w, unsigned int h)
+void GA2DBinaryStringGenome::copy(const GA2DBinaryStringGenome &orig,
+                                  unsigned int r, unsigned int s,
+                                  unsigned int x, unsigned int y,
+                                  unsigned int w, unsigned int h)
 {
-  if(w == 0 || x >= orig.nx || r >= nx ||
-     h == 0 || y >= orig.ny || s >= ny) return;
-  if(x + w > orig.nx) w = orig.nx - x;
-  if(y + h > orig.ny) h = orig.ny - y;
-  if(r + w > nx) w = nx - r;
-  if(s + h > ny) h = ny - s;
+  if (w == 0 || x >= orig.nx || r >= nx ||
+      h == 0 || y >= orig.ny || s >= ny)
+    return;
+  if (x + w > orig.nx)
+    w = orig.nx - x;
+  if (y + h > orig.ny)
+    h = orig.ny - y;
+  if (r + w > nx)
+    w = nx - r;
+  if (s + h > ny)
+    h = ny - s;
 
-  for(unsigned int j=0; j<h; j++)
-    GABinaryString::copy(orig, (s+j)*nx+r, (y+j)*orig.nx+x, w);
+  for (unsigned int j = 0; j < h; j++)
+    GABinaryString::copy(orig, (s + j) * nx + r, (y + j) * orig.nx + x, w);
   _evaluated = gaFalse;
 }
 
-
-void
-GA2DBinaryStringGenome::set(unsigned int x, unsigned int y,
-			    unsigned int w, unsigned int h)
+void GA2DBinaryStringGenome::set(unsigned int x, unsigned int y,
+                                 unsigned int w, unsigned int h)
 {
-  if(x + w > nx) w = nx - x;
-  if(y + h > ny) h = ny - y;
+  if (x + w > nx)
+    w = nx - x;
+  if (y + h > ny)
+    h = ny - y;
 
-  for(unsigned int j=0; j<h; j++)
-    GABinaryString::set((y+j)*nx+x, w);
+  for (unsigned int j = 0; j < h; j++)
+    GABinaryString::set((y + j) * nx + x, w);
   _evaluated = gaFalse;
 }
 
-
-void
-GA2DBinaryStringGenome::unset(unsigned int x, unsigned int y,
-			      unsigned int w, unsigned int h)
+void GA2DBinaryStringGenome::unset(unsigned int x, unsigned int y,
+                                   unsigned int w, unsigned int h)
 {
-  if(x + w > nx) w = nx - x;
-  if(y + h > ny) h = ny - y;
+  if (x + w > nx)
+    w = nx - x;
+  if (y + h > ny)
+    h = ny - y;
 
-  for(unsigned int j=0; j<h; j++)
-    GABinaryString::unset((y+j)*nx+x, w);
+  for (unsigned int j = 0; j < h; j++)
+    GABinaryString::unset((y + j) * nx + x, w);
   _evaluated = gaFalse;
 }
 
-
-void
-GA2DBinaryStringGenome::randomize(unsigned int x, unsigned int y,
-				  unsigned int w, unsigned int h)
+void GA2DBinaryStringGenome::randomize(unsigned int x, unsigned int y,
+                                       unsigned int w, unsigned int h)
 {
-  if(x + w > nx) w = nx - x;
-  if(y + h > ny) h = ny - y;
+  if (x + w > nx)
+    w = nx - x;
+  if (y + h > ny)
+    h = ny - y;
 
-  for(unsigned int j=0; j<h; j++)
-    GABinaryString::randomize((y+j)*nx+x, w);
+  for (unsigned int j = 0; j < h; j++)
+    GABinaryString::randomize((y + j) * nx + x, w);
   _evaluated = gaFalse;
 }
 
-
-void
-GA2DBinaryStringGenome::move(unsigned int x, unsigned int y,
-			     unsigned int srcx, unsigned int srcy,
-			     unsigned int w, unsigned int h)
+void GA2DBinaryStringGenome::move(unsigned int x, unsigned int y,
+                                  unsigned int srcx, unsigned int srcy,
+                                  unsigned int w, unsigned int h)
 {
-  if(srcx + w > nx) w = nx - srcx;
-  if(x + w > nx) w = nx - x;
-  if(srcy + h > ny) h = ny - srcy;
-  if(y + h > ny) h = ny - y;
+  if (srcx + w > nx)
+    w = nx - srcx;
+  if (x + w > nx)
+    w = nx - x;
+  if (srcy + h > ny)
+    h = ny - srcy;
+  if (y + h > ny)
+    h = ny - y;
 
-  if(srcy<y){
-    for(int j=h-1; j>=0; j--)
-      GABinaryString::move((y+j)*nx+x, (srcy+j)*nx+srcx, w);
+  if (srcy < y)
+  {
+    for (int j = h - 1; j >= 0; j--)
+      GABinaryString::move((y + j) * nx + x, (srcy + j) * nx + srcx, w);
   }
-  else{
-    for(unsigned int j=0; j<h; j++)
-      GABinaryString::move((y+j)*nx+x, (srcy+j)*nx+srcx, w);
+  else
+  {
+    for (unsigned int j = 0; j < h; j++)
+      GABinaryString::move((y + j) * nx + x, (srcy + j) * nx + srcx, w);
   }
   _evaluated = gaFalse;
 }
 
-
-int
-GA2DBinaryStringGenome::equal(const GA2DBinaryStringGenome& orig,
-			      unsigned int x, unsigned int y,
-			      unsigned int srcx, unsigned int srcy,
-			      unsigned int w, unsigned int h) const
+int GA2DBinaryStringGenome::equal(const GA2DBinaryStringGenome &orig,
+                                  unsigned int x, unsigned int y,
+                                  unsigned int srcx, unsigned int srcy,
+                                  unsigned int w, unsigned int h) const
 {
   unsigned int eq = 0;
-  for(unsigned int j=0; j<h; j++)
-    eq += GABinaryString::equal(orig, (y+j)*nx+x, (srcy+j)*nx+srcx, w);
-  return eq==h ? 1 : 0;
+  for (unsigned int j = 0; j < h; j++)
+    eq += GABinaryString::equal(orig, (y + j) * nx + x, (srcy + j) * nx + srcx, w);
+  return eq == h ? 1 : 0;
 }
 
-
-int 
-GA2DBinaryStringGenome::equal(const GAGenome & c) const
+int GA2DBinaryStringGenome::equal(const GAGenome &c) const
 {
-  if(this == &c) return 1;
-  GA2DBinaryStringGenome & b = (GA2DBinaryStringGenome &)c;
-  if(nx != b.nx || ny != b.ny) return 0;
-  int val=0;
-  for(unsigned int j=0; j<ny && val==0; j++)
-    val = GABinaryString::equal(b,j*nx,j*nx,nx) ? 0 : 1;
-  return(val ? 0 : 1);
+  if (this == &c)
+    return 1;
+  GA2DBinaryStringGenome &b = (GA2DBinaryStringGenome &)c;
+  if (nx != b.nx || ny != b.ny)
+    return 0;
+  int val = 0;
+  for (unsigned int j = 0; j < ny && val == 0; j++)
+    val = GABinaryString::equal(b, j * nx, j * nx, nx) ? 0 : 1;
+  return (val ? 0 : 1);
 }
-
-
-
-
-
-
 
 /* ----------------------------------------------------------------------------
    Operators
@@ -344,166 +376,165 @@ GA2DBinaryStringGenome::equal(const GAGenome & c) const
   The order for looping through indices is height-then-width (ie height loops
 before a single width increment)
 ---------------------------------------------------------------------------- */
-void 
-GA2DBinaryStringGenome::UniformInitializer(GAGenome & c)
+void GA2DBinaryStringGenome::UniformInitializer(GAGenome &c)
 {
-  GA2DBinaryStringGenome &child=DYN_CAST(GA2DBinaryStringGenome &, c);
+  GA2DBinaryStringGenome &child = DYN_CAST(GA2DBinaryStringGenome &, c);
   child.resize(GAGenome::ANY_SIZE, GAGenome::ANY_SIZE);
-  for(int i=child.width()-1; i>=0; i--)
-    for(int j=child.height()-1; j>=0; j--)
+  for (int i = child.width() - 1; i >= 0; i--)
+    for (int j = child.height() - 1; j >= 0; j--)
       child.gene(i, j, GARandomBit());
 }
 
-
-void 
-GA2DBinaryStringGenome::UnsetInitializer(GAGenome & c)
+void GA2DBinaryStringGenome::UnsetInitializer(GAGenome &c)
 {
-  GA2DBinaryStringGenome &child=DYN_CAST(GA2DBinaryStringGenome &, c);
+  GA2DBinaryStringGenome &child = DYN_CAST(GA2DBinaryStringGenome &, c);
   child.resize(GAGenome::ANY_SIZE, GAGenome::ANY_SIZE);
   child.unset(0, 0, child.width(), child.height());
 }
 
-
-void 
-GA2DBinaryStringGenome::SetInitializer(GAGenome & c)
+void GA2DBinaryStringGenome::SetInitializer(GAGenome &c)
 {
-  GA2DBinaryStringGenome &child=DYN_CAST(GA2DBinaryStringGenome &, c);
-  child.resize(GAGenome::ANY_SIZE, GAGenome::ANY_SIZE);	
+  GA2DBinaryStringGenome &child = DYN_CAST(GA2DBinaryStringGenome &, c);
+  child.resize(GAGenome::ANY_SIZE, GAGenome::ANY_SIZE);
   child.set(0, 0, child.width(), child.height());
 }
 
-
-int 
-GA2DBinaryStringGenome::FlipMutator(GAGenome & c, float pmut)
+int GA2DBinaryStringGenome::FlipMutator(GAGenome &c, float pmut)
 {
-  GA2DBinaryStringGenome &child=DYN_CAST(GA2DBinaryStringGenome &, c);
-  register int n, m, i, j;
-  if(pmut <= 0.0) return(0);
+  GA2DBinaryStringGenome &child = DYN_CAST(GA2DBinaryStringGenome &, c);
+  int n, m, i, j;
+  if (pmut <= 0.0)
+    return (0);
 
   float nMut = pmut * STA_CAST(float, child.size());
-  if(nMut < 1.0){		// we have to do a flip test on each bit
+  if (nMut < 1.0)
+  { // we have to do a flip test on each bit
     nMut = 0;
-    for(i=child.width()-1; i>=0; i--){
-      for(j=child.height()-1; j>=0; j--){
-	if(GAFlipCoin(pmut)){
-	  child.gene(i, j, ((child.gene(i,j) == 0) ? 1 : 0));
-	  nMut++;
-	}
+    for (i = child.width() - 1; i >= 0; i--)
+    {
+      for (j = child.height() - 1; j >= 0; j--)
+      {
+        if (GAFlipCoin(pmut))
+        {
+          child.gene(i, j, ((child.gene(i, j) == 0) ? 1 : 0));
+          nMut++;
+        }
       }
     }
   }
-  else{				// only flip the number of bits we need to flip
-    for(n=0; n<nMut; n++){
-      m = GARandomInt(0, child.size()-1);
+  else
+  { // only flip the number of bits we need to flip
+    for (n = 0; n < nMut; n++)
+    {
+      m = GARandomInt(0, child.size() - 1);
       i = m % child.width();
       j = m / child.width();
-      child.gene(i, j, ((child.gene(i,j) == 0) ? 1 : 0));
+      child.gene(i, j, ((child.gene(i, j) == 0) ? 1 : 0));
     }
   }
-  return(STA_CAST(int,nMut));
+  return (STA_CAST(int, nMut));
 }
 
-
-float
-GA2DBinaryStringGenome::BitComparator(const GAGenome& a, const GAGenome& b){
-  const GA2DBinaryStringGenome &sis=
-    DYN_CAST(const GA2DBinaryStringGenome &, a);
-  const GA2DBinaryStringGenome &bro=
-    DYN_CAST(const GA2DBinaryStringGenome &, b);
-  if(sis.size() != bro.size()) return -1;
-  if(sis.size() == 0) return 0;
+float GA2DBinaryStringGenome::BitComparator(const GAGenome &a, const GAGenome &b)
+{
+  const GA2DBinaryStringGenome &sis =
+      DYN_CAST(const GA2DBinaryStringGenome &, a);
+  const GA2DBinaryStringGenome &bro =
+      DYN_CAST(const GA2DBinaryStringGenome &, b);
+  if (sis.size() != bro.size())
+    return -1;
+  if (sis.size() == 0)
+    return 0;
   float count = 0.0;
-  for(int i=sis.width()-1; i>=0; i--)
-    for(int j=sis.height()-1; j>=0; j--)
-      count += ((sis.gene(i,j) == bro.gene(i,j)) ? 0 : 1);
-  return count/sis.size();
+  for (int i = sis.width() - 1; i >= 0; i--)
+    for (int j = sis.height() - 1; j >= 0; j--)
+      count += ((sis.gene(i, j) == bro.gene(i, j)) ? 0 : 1);
+  return count / sis.size();
 }
 
+int GA2DBinaryStringGenome::
+    UniformCrossover(const GAGenome &p1, const GAGenome &p2,
+                     GAGenome *c1, GAGenome *c2)
+{
+  const GA2DBinaryStringGenome &mom =
+      DYN_CAST(const GA2DBinaryStringGenome &, p1);
+  const GA2DBinaryStringGenome &dad =
+      DYN_CAST(const GA2DBinaryStringGenome &, p2);
 
+  int nc = 0;
+  int i, j;
 
+  if (c1 && c2)
+  {
+    GA2DBinaryStringGenome &sis = DYN_CAST(GA2DBinaryStringGenome &, *c1);
+    GA2DBinaryStringGenome &bro = DYN_CAST(GA2DBinaryStringGenome &, *c2);
 
-
-
-
-
-
-
-
-int
-GA2DBinaryStringGenome::
-UniformCrossover(const GAGenome& p1, const GAGenome& p2, 
-		 GAGenome* c1, GAGenome* c2){
-  const GA2DBinaryStringGenome &mom=
-    DYN_CAST(const GA2DBinaryStringGenome &, p1);
-  const GA2DBinaryStringGenome &dad=
-    DYN_CAST(const GA2DBinaryStringGenome &, p2);
-
-  int nc=0;
-  int i,j;
-
-  if(c1 && c2){
-    GA2DBinaryStringGenome &sis=DYN_CAST(GA2DBinaryStringGenome &, *c1);
-    GA2DBinaryStringGenome &bro=DYN_CAST(GA2DBinaryStringGenome &, *c2);
-
-    if(sis.width() == bro.width() && sis.height() == bro.height() &&
-       mom.width() == dad.width() && mom.height() == dad.height() &&
-       sis.width() == mom.width() && sis.height() == mom.height()){
-      for(i=sis.width()-1; i>=0; i--){
-	for(j=sis.height()-1; j>=0; j--){
-	  if(GARandomBit()){
-	    sis.gene(i,j, mom.gene(i,j));
-	    bro.gene(i,j, dad.gene(i,j));
-	  }
-	  else{
-	    sis.gene(i,j, dad.gene(i,j));
-	    bro.gene(i,j, mom.gene(i,j));
-	  }
-	}
+    if (sis.width() == bro.width() && sis.height() == bro.height() &&
+        mom.width() == dad.width() && mom.height() == dad.height() &&
+        sis.width() == mom.width() && sis.height() == mom.height())
+    {
+      for (i = sis.width() - 1; i >= 0; i--)
+      {
+        for (j = sis.height() - 1; j >= 0; j--)
+        {
+          if (GARandomBit())
+          {
+            sis.gene(i, j, mom.gene(i, j));
+            bro.gene(i, j, dad.gene(i, j));
+          }
+          else
+          {
+            sis.gene(i, j, dad.gene(i, j));
+            bro.gene(i, j, mom.gene(i, j));
+          }
+        }
       }
     }
-    else{
+    else
+    {
       GAMask mask;
       int maxx = GAMax(sis.width(), bro.width());
       int minx = GAMin(mom.width(), dad.width());
       int maxy = GAMax(sis.height(), bro.height());
       int miny = GAMin(mom.height(), dad.height());
-      mask.size(maxx*maxy);
-      for(i=0; i<maxx; i++)
-	for(j=0; j<maxy; j++)
-	  mask[i*maxy+j] = GARandomBit();
+      mask.size(maxx * maxy);
+      for (i = 0; i < maxx; i++)
+        for (j = 0; j < maxy; j++)
+          mask[i * maxy + j] = GARandomBit();
       minx = GAMin(sis.width(), minx);
       miny = GAMin(sis.height(), miny);
-      for(i=0; i<minx; i++)
-	for(j=0; j<miny; j++)
-	  sis.gene(i,j, (mask[i*miny+j] ? mom.gene(i,j) : dad.gene(i,j)));
+      for (i = 0; i < minx; i++)
+        for (j = 0; j < miny; j++)
+          sis.gene(i, j, (mask[i * miny + j] ? mom.gene(i, j) : dad.gene(i, j)));
       minx = GAMin(bro.width(), minx);
       miny = GAMin(bro.height(), miny);
-      for(i=0; i<minx; i++)
-	for(j=0; j<miny; j++)
-	  bro.gene(i,j, (mask[i*miny+j] ? dad.gene(i,j) : mom.gene(i,j)));
+      for (i = 0; i < minx; i++)
+        for (j = 0; j < miny; j++)
+          bro.gene(i, j, (mask[i * miny + j] ? dad.gene(i, j) : mom.gene(i, j)));
     }
 
     nc = 2;
   }
-  else if(c1 || c2){
-    GA2DBinaryStringGenome &sis = (c1 ? 
-				   DYN_CAST(GA2DBinaryStringGenome&, *c1) : 
-				   DYN_CAST(GA2DBinaryStringGenome&, *c2));
+  else if (c1 || c2)
+  {
+    GA2DBinaryStringGenome &sis = (c1 ? DYN_CAST(GA2DBinaryStringGenome &, *c1) : DYN_CAST(GA2DBinaryStringGenome &, *c2));
 
-    if(mom.width() == dad.width() && mom.height() == dad.height() &&
-       sis.width() == mom.width() && sis.height() == mom.height()){
-      for(i=sis.width()-1; i>=0; i--)
-	for(j=sis.height()-1; j>=0; j--)
-	  sis.gene(i,j, (GARandomBit() ? mom.gene(i,j) : dad.gene(i,j)));
+    if (mom.width() == dad.width() && mom.height() == dad.height() &&
+        sis.width() == mom.width() && sis.height() == mom.height())
+    {
+      for (i = sis.width() - 1; i >= 0; i--)
+        for (j = sis.height() - 1; j >= 0; j--)
+          sis.gene(i, j, (GARandomBit() ? mom.gene(i, j) : dad.gene(i, j)));
     }
-    else{
+    else
+    {
       int minx = GAMin(mom.width(), dad.width());
       int miny = GAMin(mom.height(), dad.height());
       minx = GAMin(sis.width(), minx);
       miny = GAMin(sis.height(), miny);
-      for(i=0; i<minx; i++)
-	for(j=0; j<miny; j++)
-	  sis.gene(i,j, (GARandomBit() ? mom.gene(i,j) : dad.gene(i,j)));
+      for (i = 0; i < minx; i++)
+        for (j = 0; j < miny; j++)
+          sis.gene(i, j, (GARandomBit() ? mom.gene(i, j) : dad.gene(i, j)));
     }
 
     nc = 1;
@@ -512,48 +543,52 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
   return nc;
 }
 
-
 //   When we do single point crossover on resizable 2D genomes we can either
 // clip or pad to make the mismatching geometries work out.  Either way, both
-// children end up with the same dimensions (the children have the same 
+// children end up with the same dimensions (the children have the same
 // dimensions as each other, not the same as if they were clipped/padded).
 //   When we pad, the extra space is filled with random bits.  This
 // implementation does only clipping, no padding!
-int
-GA2DBinaryStringGenome::
-OnePointCrossover(const GAGenome& p1, const GAGenome& p2, 
-		  GAGenome* c1, GAGenome* c2){
-  const GA2DBinaryStringGenome &mom=
-    DYN_CAST(const GA2DBinaryStringGenome &, p1);
-  const GA2DBinaryStringGenome &dad=
-    DYN_CAST(const GA2DBinaryStringGenome &, p2);
+int GA2DBinaryStringGenome::
+    OnePointCrossover(const GAGenome &p1, const GAGenome &p2,
+                      GAGenome *c1, GAGenome *c2)
+{
+  const GA2DBinaryStringGenome &mom =
+      DYN_CAST(const GA2DBinaryStringGenome &, p1);
+  const GA2DBinaryStringGenome &dad =
+      DYN_CAST(const GA2DBinaryStringGenome &, p2);
 
-  int nc=0;
+  int nc = 0;
   unsigned int momsitex, momlenx, momsitey, momleny;
   unsigned int dadsitex, dadlenx, dadsitey, dadleny;
   unsigned int sitex, lenx, sitey, leny;
 
-  if(c1 && c2){
-    GA2DBinaryStringGenome &sis=DYN_CAST(GA2DBinaryStringGenome &, *c1);
-    GA2DBinaryStringGenome &bro=DYN_CAST(GA2DBinaryStringGenome &, *c2);
+  if (c1 && c2)
+  {
+    GA2DBinaryStringGenome &sis = DYN_CAST(GA2DBinaryStringGenome &, *c1);
+    GA2DBinaryStringGenome &bro = DYN_CAST(GA2DBinaryStringGenome &, *c2);
 
-    if(sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE &&
-       bro.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE){
-      if(mom.width() != dad.width() || 
-	 sis.width() != bro.width() || 
-	 sis.width() != mom.width()){
-	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
-	return nc;
+    if (sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE &&
+        bro.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE)
+    {
+      if (mom.width() != dad.width() ||
+          sis.width() != bro.width() ||
+          sis.width() != mom.width())
+      {
+        GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
+        return nc;
       }
       sitex = momsitex = dadsitex = GARandomInt(0, mom.width());
       lenx = momlenx = dadlenx = mom.width() - momsitex;
     }
-    else if(sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE ||
-	    bro.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE){
+    else if (sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE ||
+             bro.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE)
+    {
       GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameBehavReqd);
       return nc;
     }
-    else{
+    else
+    {
       momsitex = GARandomInt(0, mom.width());
       dadsitex = GARandomInt(0, dad.width());
       momlenx = mom.width() - momsitex;
@@ -562,23 +597,27 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       lenx = GAMin(momlenx, dadlenx);
     }
 
-    if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE &&
-       bro.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
-      if(mom.height() != dad.height() || 
-	 sis.height() != bro.height() || 
-	 sis.height() != mom.height()){
-	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
-	return nc;
+    if (sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE &&
+        bro.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE)
+    {
+      if (mom.height() != dad.height() ||
+          sis.height() != bro.height() ||
+          sis.height() != mom.height())
+      {
+        GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
+        return nc;
       }
       sitey = momsitey = dadsitey = GARandomInt(0, mom.height());
       leny = momleny = dadleny = mom.height() - momsitey;
     }
-    else if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE ||
-	    bro.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
+    else if (sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE ||
+             bro.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE)
+    {
       GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameBehavReqd);
       return nc;
     }
-    else{
+    else
+    {
       momsitey = GARandomInt(0, mom.height());
       dadsitey = GARandomInt(0, dad.height());
       momleny = mom.height() - momsitey;
@@ -587,35 +626,37 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       leny = GAMin(momleny, dadleny);
     }
 
-    sis.resize(sitex+lenx, sitey+leny);
-    bro.resize(sitex+lenx, sitey+leny);
+    sis.resize(sitex + lenx, sitey + leny);
+    bro.resize(sitex + lenx, sitey + leny);
 
-    sis.copy(mom, 0, 0, momsitex-sitex, momsitey-sitey, sitex, sitey);
-    sis.copy(dad, sitex, 0, dadsitex, dadsitey-sitey, lenx, sitey);
-    sis.copy(dad, 0, sitey, dadsitex-sitex, dadsitey, sitex, leny);
+    sis.copy(mom, 0, 0, momsitex - sitex, momsitey - sitey, sitex, sitey);
+    sis.copy(dad, sitex, 0, dadsitex, dadsitey - sitey, lenx, sitey);
+    sis.copy(dad, 0, sitey, dadsitex - sitex, dadsitey, sitex, leny);
     sis.copy(mom, sitex, sitey, momsitex, momsitey, lenx, leny);
 
-    bro.copy(dad, 0, 0, dadsitex-sitex, dadsitey-sitey, sitex, sitey);
-    bro.copy(mom, sitex, 0, momsitex, momsitey-sitey, lenx, sitey);
-    bro.copy(mom, 0, sitey, momsitex-sitex, momsitey, sitex, leny);
+    bro.copy(dad, 0, 0, dadsitex - sitex, dadsitey - sitey, sitex, sitey);
+    bro.copy(mom, sitex, 0, momsitex, momsitey - sitey, lenx, sitey);
+    bro.copy(mom, 0, sitey, momsitex - sitex, momsitey, sitex, leny);
     bro.copy(dad, sitex, sitey, dadsitex, dadsitey, lenx, leny);
 
     nc = 2;
   }
-  else if(c1 || c2){
-    GA2DBinaryStringGenome &sis = (c1 ?
-				   DYN_CAST(GA2DBinaryStringGenome&, *c1) :
-				   DYN_CAST(GA2DBinaryStringGenome&, *c2));
+  else if (c1 || c2)
+  {
+    GA2DBinaryStringGenome &sis = (c1 ? DYN_CAST(GA2DBinaryStringGenome &, *c1) : DYN_CAST(GA2DBinaryStringGenome &, *c2));
 
-    if(sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE){
-      if(mom.width() != dad.width() || sis.width() != mom.width()){
-	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
-	return nc;
+    if (sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE)
+    {
+      if (mom.width() != dad.width() || sis.width() != mom.width())
+      {
+        GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
+        return nc;
       }
       sitex = momsitex = dadsitex = GARandomInt(0, mom.width());
       lenx = momlenx = dadlenx = mom.width() - momsitex;
     }
-    else{
+    else
+    {
       momsitex = GARandomInt(0, mom.width());
       dadsitex = GARandomInt(0, dad.width());
       momlenx = mom.width() - momsitex;
@@ -624,15 +665,18 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       lenx = GAMin(momlenx, dadlenx);
     }
 
-    if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
-      if(mom.height() != dad.height() || sis.height() != mom.height()){
-	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
-	return nc;
+    if (sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE)
+    {
+      if (mom.height() != dad.height() || sis.height() != mom.height())
+      {
+        GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
+        return nc;
       }
       sitey = momsitey = dadsitey = GARandomInt(0, mom.height());
       leny = momleny = dadleny = mom.height() - momsitey;
     }
-    else{
+    else
+    {
       momsitey = GARandomInt(0, mom.height());
       dadsitey = GARandomInt(0, dad.height());
       momleny = mom.height() - momsitey;
@@ -640,19 +684,21 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitey = GAMin(momsitey, dadsitey);
       leny = GAMin(momleny, dadleny);
     }
-    
-    sis.resize(sitex+lenx, sitey+leny);
-    
-    if(GARandomBit()){
-      sis.copy(mom, 0, 0, momsitex-sitex, momsitey-sitey, sitex, sitey);
-      sis.copy(dad, sitex, 0, dadsitex, dadsitey-sitey, lenx, sitey);
-      sis.copy(dad, 0, sitey, dadsitex-sitex, dadsitey, sitex, leny);
+
+    sis.resize(sitex + lenx, sitey + leny);
+
+    if (GARandomBit())
+    {
+      sis.copy(mom, 0, 0, momsitex - sitex, momsitey - sitey, sitex, sitey);
+      sis.copy(dad, sitex, 0, dadsitex, dadsitey - sitey, lenx, sitey);
+      sis.copy(dad, 0, sitey, dadsitex - sitex, dadsitey, sitex, leny);
       sis.copy(mom, sitex, sitey, momsitex, momsitey, lenx, leny);
     }
-    else{
-      sis.copy(dad, 0, 0, dadsitex-sitex, dadsitey-sitey, sitex, sitey);
-      sis.copy(mom, sitex, 0, momsitex, momsitey-sitey, lenx, sitey);
-      sis.copy(mom, 0, sitey, momsitex-sitex, momsitey, sitex, leny);
+    else
+    {
+      sis.copy(dad, 0, 0, dadsitex - sitex, dadsitey - sitey, sitex, sitey);
+      sis.copy(mom, sitex, 0, momsitex, momsitey - sitey, lenx, sitey);
+      sis.copy(mom, 0, sitey, momsitex - sitex, momsitey, sitex, leny);
       sis.copy(dad, sitex, sitey, dadsitex, dadsitey, lenx, leny);
     }
 
@@ -662,85 +708,93 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
   return nc;
 }
 
+int GA2DBinaryStringGenome::
+    EvenOddCrossover(const GAGenome &p1, const GAGenome &p2,
+                     GAGenome *c1, GAGenome *c2)
+{
+  const GA2DBinaryStringGenome &mom =
+      DYN_CAST(const GA2DBinaryStringGenome &, p1);
+  const GA2DBinaryStringGenome &dad =
+      DYN_CAST(const GA2DBinaryStringGenome &, p2);
 
+  int nc = 0;
+  int i, j;
 
-int
-GA2DBinaryStringGenome::
-EvenOddCrossover(const GAGenome& p1, const GAGenome& p2, 
-		 GAGenome* c1, GAGenome* c2){
-  const GA2DBinaryStringGenome &mom=
-    DYN_CAST(const GA2DBinaryStringGenome &, p1);
-  const GA2DBinaryStringGenome &dad=
-    DYN_CAST(const GA2DBinaryStringGenome &, p2);
+  if (c1 && c2)
+  {
+    GA2DBinaryStringGenome &sis = DYN_CAST(GA2DBinaryStringGenome &, *c1);
+    GA2DBinaryStringGenome &bro = DYN_CAST(GA2DBinaryStringGenome &, *c2);
 
-  int nc=0;
-  int i,j;
-
-  if(c1 && c2){
-    GA2DBinaryStringGenome &sis=DYN_CAST(GA2DBinaryStringGenome &, *c1);
-    GA2DBinaryStringGenome &bro=DYN_CAST(GA2DBinaryStringGenome &, *c2);
-    
-    if(sis.width() == bro.width() && sis.height() == bro.height() &&
-       mom.width() == dad.width() && mom.height() == dad.height() &&
-       sis.width() == mom.width() && sis.height() == mom.height()){
-      int count=0;
-      for(i=sis.width()-1; i>=0; i--){
-	for(j=sis.height()-1; j>=0; j--){
-	  if(count%2 == 0){
-	    sis.gene(i,j, mom.gene(i,j));
-	    bro.gene(i,j, dad.gene(i,j));
-	  }
-	  else{
-	    sis.gene(i,j, dad.gene(i,j));
-	    bro.gene(i,j, mom.gene(i,j));
-	  }
-	  count++;
-	}
+    if (sis.width() == bro.width() && sis.height() == bro.height() &&
+        mom.width() == dad.width() && mom.height() == dad.height() &&
+        sis.width() == mom.width() && sis.height() == mom.height())
+    {
+      int count = 0;
+      for (i = sis.width() - 1; i >= 0; i--)
+      {
+        for (j = sis.height() - 1; j >= 0; j--)
+        {
+          if (count % 2 == 0)
+          {
+            sis.gene(i, j, mom.gene(i, j));
+            bro.gene(i, j, dad.gene(i, j));
+          }
+          else
+          {
+            sis.gene(i, j, dad.gene(i, j));
+            bro.gene(i, j, mom.gene(i, j));
+          }
+          count++;
+        }
       }
     }
-    else{
+    else
+    {
       int count;
       int minx = GAMin(mom.width(), dad.width());
       int miny = GAMin(mom.height(), dad.height());
       count = 0;
       minx = GAMin(sis.width(), minx);
       miny = GAMin(sis.height(), miny);
-      for(i=0; i<minx; i++)
-	for(j=0; j<miny; j++)
-	  sis.gene(i,j, (((count++)%2 == 0) ? mom.gene(i,j):dad.gene(i,j)));
+      for (i = 0; i < minx; i++)
+        for (j = 0; j < miny; j++)
+          sis.gene(i, j, (((count++) % 2 == 0) ? mom.gene(i, j) : dad.gene(i, j)));
       count = 0;
       minx = GAMin(bro.width(), minx);
       miny = GAMin(bro.height(), miny);
-      for(i=0; i<minx; i++)
-	for(j=0; j<miny; j++)
-	  bro.gene(i,j, (((count++)%2 == 0) ? dad.gene(i,j):mom.gene(i,j)));
+      for (i = 0; i < minx; i++)
+        for (j = 0; j < miny; j++)
+          bro.gene(i, j, (((count++) % 2 == 0) ? dad.gene(i, j) : mom.gene(i, j)));
     }
 
     nc = 2;
   }
-  else if(c1 || c2){
-    GA2DBinaryStringGenome &sis = (c1 ? 
-				   DYN_CAST(GA2DBinaryStringGenome&, *c1) :
-				   DYN_CAST(GA2DBinaryStringGenome&, *c2));
-    
-    if(mom.width() == dad.width() && mom.height() == dad.height() &&
-       sis.width() == mom.width() && sis.height() == mom.height()){
-      int count=0;
-      for(i=sis.width()-1; i>=0; i--){
-	for(j=sis.height()-1; j>=0; j--){
-	  sis.gene(i,j, ((count%2 == 0) ? mom.gene(i,j) : dad.gene(i,j)));
-	  count++;
-	}
+  else if (c1 || c2)
+  {
+    GA2DBinaryStringGenome &sis = (c1 ? DYN_CAST(GA2DBinaryStringGenome &, *c1) : DYN_CAST(GA2DBinaryStringGenome &, *c2));
+
+    if (mom.width() == dad.width() && mom.height() == dad.height() &&
+        sis.width() == mom.width() && sis.height() == mom.height())
+    {
+      int count = 0;
+      for (i = sis.width() - 1; i >= 0; i--)
+      {
+        for (j = sis.height() - 1; j >= 0; j--)
+        {
+          sis.gene(i, j, ((count % 2 == 0) ? mom.gene(i, j) : dad.gene(i, j)));
+          count++;
+        }
       }
     }
-    else{
+    else
+    {
       int minx = GAMin(mom.width(), dad.width());
       int miny = GAMin(mom.height(), dad.height());
       minx = GAMin(sis.width(), minx);
       miny = GAMin(sis.height(), miny);
-      for(i=minx-1; i>=0; i--)
-	for(j=miny-1; j>=0; j--)
-	  sis.gene(i,j, (((i*miny+j)%2 == 0) ? mom.gene(i,j) : dad.gene(i,j)));
+      for (i = minx - 1; i >= 0; i--)
+        for (j = miny - 1; j >= 0; j--)
+          sis.gene(i, j, (((i * miny + j) % 2 == 0) ? mom.gene(i, j) : dad.gene(i, j)));
     }
 
     nc = 1;

--- a/Global_dynamic_MPFA/source/ga-mpi/GA3DArrayGenome.C
+++ b/Global_dynamic_MPFA/source/ga-mpi/GA3DArrayGenome.C
@@ -27,13 +27,13 @@ GA3DArrayGenome<T>::className() const {return "GA3DArrayGenome";}
 template <class T> int
 GA3DArrayGenome<T>::classID() const {return GAID::ArrayGenome3D;}
 
-template <class T> 
+template <class T>
 GA3DArrayGenome<T>::
 GA3DArrayGenome(unsigned int w, unsigned int h, unsigned int d,
 		GAGenome::Evaluator f,
 		void * u) :
 GAArray<T>(w*h*d),
-GAGenome(DEFAULT_3DARRAY_INITIALIZER, 
+GAGenome(DEFAULT_3DARRAY_INITIALIZER,
 	 DEFAULT_3DARRAY_MUTATOR,
 	 DEFAULT_3DARRAY_COMPARATOR)
 {
@@ -44,7 +44,7 @@ GAGenome(DEFAULT_3DARRAY_INITIALIZER,
 }
 
 
-template <class T> 
+template <class T>
 GA3DArrayGenome<T>::
 GA3DArrayGenome(const GA3DArrayGenome<T> & orig) :
 GAArray<T>(orig.sz), GAGenome(){
@@ -78,7 +78,7 @@ GA3DArrayGenome<T>::clone(GAGenome::CloneMethod flag) const {
   }
   else{
     cpy->GAGenome::copy(*this);
-    cpy->minX = minX; cpy->minY = minY; cpy->minZ = minZ; 
+    cpy->minX = minX; cpy->minY = minY; cpy->minZ = minZ;
     cpy->maxX = maxX; cpy->maxY = maxY; cpy->maxZ = maxZ;
   }
   return cpy;
@@ -145,7 +145,7 @@ GA3DArrayGenome<T>::resize(int w, int h, int d)
 
   GAArray<T>::size(w*h*d);
 
-  if(w > STA_CAST(int,nx) && h > STA_CAST(int,ny)){ 
+  if(w > STA_CAST(int,nx) && h > STA_CAST(int,ny)){
     int z=GAMin(STA_CAST(int,nz),d);
     for(int k=z-1; k>=0; k--)
       for(int j=ny-1; j>=0; j--)
@@ -179,7 +179,7 @@ GA3DArrayGenome<T>::read(STD_ISTREAM &) {
 
 
 template <class T> int
-GA3DArrayGenome<T>::write(STD_OSTREAM & os) const 
+GA3DArrayGenome<T>::write(STD_OSTREAM & os) const
 {
   for(unsigned int k=0; k<nz; k++){
     for(unsigned int j=0; j<ny; j++){
@@ -216,7 +216,7 @@ GA3DArrayGenome<T>::resizeBehaviour(GAGenome::Dimension which) const {
 
 template <class T> int
 GA3DArrayGenome<T>::
-resizeBehaviour(GAGenome::Dimension which, 
+resizeBehaviour(GAGenome::Dimension which,
 		unsigned int lower, unsigned int upper)
 {
   if(upper < lower){
@@ -278,7 +278,7 @@ copy(const GA3DArrayGenome<T> & orig,
 }
 
 
-template <class T> int 
+template <class T> int
 GA3DArrayGenome<T>::equal(const GAGenome & c) const
 {
   if(this == &c) return 1;
@@ -312,7 +312,7 @@ GA3DArrayAlleleGenome<T>::className() const {return "GA3DArrayAlleleGenome";}
 template <class T> int
 GA3DArrayAlleleGenome<T>::classID() const {return GAID::ArrayAlleleGenome3D;}
 
-template <class T> 
+template <class T>
 GA3DArrayAlleleGenome<T>::
 GA3DArrayAlleleGenome(unsigned int w, unsigned int h, unsigned int d,
 		      const GAAlleleSet<T> & s,
@@ -328,7 +328,7 @@ GA3DArrayGenome<T>(w,h,d,f,u) {
   this->crossover(GA3DArrayAlleleGenome<T>::DEFAULT_3DARRAY_ALLELE_CROSSOVER);
 }
 
-template <class T> 
+template <class T>
 GA3DArrayAlleleGenome<T>::
 GA3DArrayAlleleGenome(unsigned int w, unsigned int h, unsigned int d,
 		      const GAAlleleSetArray<T> & sa,
@@ -346,9 +346,9 @@ GA3DArrayGenome<T>(w,h,d, f, u) {
 }
 
 
-template <class T> 
+template <class T>
 GA3DArrayAlleleGenome<T>::
-GA3DArrayAlleleGenome(const GA3DArrayAlleleGenome<T> & orig) : 
+GA3DArrayAlleleGenome(const GA3DArrayAlleleGenome<T> & orig) :
 GA3DArrayGenome<T>(orig.nx, orig.ny, orig.nz) {
   naset = 0;
   aset = (GAAlleleSet<T>*)0;
@@ -368,10 +368,10 @@ GA3DArrayAlleleGenome<T>::clone(GAGenome::CloneMethod) const {
 }
 
 
-template <class T> void 
+template <class T> void
 GA3DArrayAlleleGenome<T>::copy(const GAGenome& orig){
   if(&orig == this) return;
-  const GA3DArrayAlleleGenome<T>* c = 
+  const GA3DArrayAlleleGenome<T>* c =
     DYN_CAST(const GA3DArrayAlleleGenome<T>*, &orig);
   if(c) {
     GA3DArrayGenome<T>::copy(*c);
@@ -414,7 +414,7 @@ GA3DArrayAlleleGenome<T>::resize(int w, int h, int d){
     for(int k=z-1; k>=0; k--)
       for(int j=this->ny-1; j>=0; j--)
 	for(unsigned int i=oldx; i<this->nx; i++)
-	  this->a[k*this->ny*this->nx+j*this->nx+i] = 
+	  this->a[k*this->ny*this->nx+j*this->nx+i] =
 	    aset[(k*this->ny*this->nx+j*this->nx+i) % naset].allele();
   }
   else if(this->ny > oldy){
@@ -463,7 +463,7 @@ GA3DArrayAlleleGenome<T>::equal(const GAGenome & c) const {
    Operator definitions
 ---------------------------------------------------------------------------- */
 // this does not handle genomes with multiple allele sets!
-template <class ARRAY_TYPE> void 
+template <class ARRAY_TYPE> void
 GA3DArrayAlleleGenome<ARRAY_TYPE>::UniformInitializer(GAGenome & c)
 {
   GA3DArrayAlleleGenome<ARRAY_TYPE> &child=
@@ -476,12 +476,12 @@ GA3DArrayAlleleGenome<ARRAY_TYPE>::UniformInitializer(GAGenome & c)
 }
 
 
-template <class ARRAY_TYPE> int 
+template <class ARRAY_TYPE> int
 GA3DArrayAlleleGenome<ARRAY_TYPE>::FlipMutator(GAGenome & c, float pmut)
 {
   GA3DArrayAlleleGenome<ARRAY_TYPE> &child=
     DYN_CAST(GA3DArrayAlleleGenome<ARRAY_TYPE> &, c);
-  register int n, m, d, i, j, k;
+  int n, m, d, i, j, k;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.size());
@@ -512,11 +512,11 @@ GA3DArrayAlleleGenome<ARRAY_TYPE>::FlipMutator(GAGenome & c, float pmut)
 }
 
 
-template <class ARRAY_TYPE> int 
+template <class ARRAY_TYPE> int
 GA3DArrayGenome<ARRAY_TYPE>::SwapMutator(GAGenome & c, float pmut)
 {
   GA3DArrayGenome<ARRAY_TYPE> &child=DYN_CAST(GA3DArrayGenome<ARRAY_TYPE>&, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.size());
@@ -568,7 +568,7 @@ ElementComparator(const GAGenome& a, const GAGenome& b)
 
 
 
-// Make sure our bitmask is big enough, generate a mask, then use it to 
+// Make sure our bitmask is big enough, generate a mask, then use it to
 // extract the information from each parent to stuff the two children.
 // We don't deallocate any space for the masks under the assumption that we'll
 // have to use them again in the future.
@@ -680,12 +680,12 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
 //   This is designed only for genomes that are the same length.  If the child
 // is not the same length as the parent, or if the children are not the same
 // size, we don't do the crossover.
-//   In the interest of speed we do not do any checks for size.  Do not use 
+//   In the interest of speed we do not do any checks for size.  Do not use
 // this crossover method when the parents and children may be different sizes.
 // It might break!
 template <class T> int
 GA3DArrayGenome<T>::
-EvenOddCrossover(const GAGenome& p1, const GAGenome& p2, 
+EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
 GAGenome* c1, GAGenome* c2){
   const GA3DArrayGenome<T> &mom=DYN_CAST(const GA3DArrayGenome<T> &, p1);
   const GA3DArrayGenome<T> &dad=DYN_CAST(const GA3DArrayGenome<T> &, p2);
@@ -696,7 +696,7 @@ GAGenome* c1, GAGenome* c2){
   if(c1 && c2){
     GA3DArrayGenome<T> &sis=DYN_CAST(GA3DArrayGenome<T> &, *c1);
     GA3DArrayGenome<T> &bro=DYN_CAST(GA3DArrayGenome<T> &, *c2);
-    
+
     if(sis.width() == bro.width() && sis.height() == bro.height() &&
        sis.depth() == bro.depth() &&
        mom.width() == dad.width() && mom.height() == dad.height() &&
@@ -806,8 +806,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE){
-      if(mom.width() != dad.width() || 
-	 sis.width() != bro.width() || 
+      if(mom.width() != dad.width() ||
+	 sis.width() != bro.width() ||
 	 sis.width() != mom.width()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -828,11 +828,11 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitex = GAMin(momsitex, dadsitex);
       lenx = GAMin(momlenx, dadlenx);
     }
-    
+
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
-      if(mom.height() != dad.height() || 
-	 sis.height() != bro.height() || 
+      if(mom.height() != dad.height() ||
+	 sis.height() != bro.height() ||
 	 sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -856,8 +856,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE){
-      if(mom.depth() != dad.depth() || 
-	 sis.depth() != bro.depth() || 
+      if(mom.depth() != dad.depth() ||
+	 sis.depth() != bro.depth() ||
 	 sis.depth() != mom.depth()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -882,8 +882,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
     sis.resize(sitex+lenx, sitey+leny, sitez+lenz);
     bro.resize(sitex+lenx, sitey+leny, sitez+lenz);
 
-    sis.copy(mom, 
-	     0, 0, 0, 
+    sis.copy(mom,
+	     0, 0, 0,
 	     momsitex-sitex, momsitey-sitey, momsitez-sitez,
 	     sitex, sitey, sitez);
     sis.copy(dad,
@@ -898,8 +898,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	     sitex, sitey, 0,
 	     momsitex, momsitey, momsitez-sitez,
 	     lenx, leny, sitez);
-    sis.copy(dad, 
-	     0, 0, sitez, 
+    sis.copy(dad,
+	     0, 0, sitez,
 	     dadsitex-sitex, dadsitey-sitey, dadsitez,
 	     sitex, sitey, lenz);
     sis.copy(mom,
@@ -914,9 +914,9 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	     sitex, sitey, sitez,
 	     dadsitex, dadsitey, dadsitez,
 	     lenx, leny, lenz);
-    
-    bro.copy(dad, 
-	     0, 0, 0, 
+
+    bro.copy(dad,
+	     0, 0, 0,
 	     dadsitex-sitex, dadsitey-sitey, dadsitez-sitez,
 	     sitex, sitey, sitez);
     bro.copy(mom,
@@ -931,8 +931,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	     sitex, sitey, 0,
 	     dadsitex, dadsitey, dadsitez-sitez,
 	     lenx, leny, sitez);
-    bro.copy(mom, 
-	     0, 0, sitez, 
+    bro.copy(mom,
+	     0, 0, sitez,
 	     momsitex-sitex, momsitey-sitey, momsitez,
 	     sitex, sitey, lenz);
     bro.copy(dad,
@@ -969,7 +969,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitex = GAMin(momsitex, dadsitex);
       lenx = GAMin(momlenx, dadlenx);
     }
-    
+
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
       if(mom.height() != dad.height() || sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -1003,12 +1003,12 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitez = GAMin(momsitez, dadsitez);
       lenz = GAMin(momlenz, dadlenz);
     }
-    
+
     sis.resize(sitex+lenx, sitey+leny, sitez+lenz);
-    
+
     if(GARandomBit()){
-      sis.copy(mom, 
-	       0, 0, 0, 
+      sis.copy(mom,
+	       0, 0, 0,
 	       momsitex-sitex, momsitey-sitey, momsitez-sitez,
 	       sitex, sitey, sitez);
       sis.copy(dad,
@@ -1023,8 +1023,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	       sitex, sitey, 0,
 	       momsitex, momsitey, momsitez-sitez,
 	       lenx, leny, sitez);
-      sis.copy(dad, 
-	       0, 0, sitez, 
+      sis.copy(dad,
+	       0, 0, sitez,
 	       dadsitex-sitex, dadsitey-sitey, dadsitez,
 	       sitex, sitey, lenz);
       sis.copy(mom,
@@ -1041,8 +1041,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	       lenx, leny, lenz);
     }
     else{
-      sis.copy(dad, 
-	       0, 0, 0, 
+      sis.copy(dad,
+	       0, 0, 0,
 	       dadsitex-sitex, dadsitey-sitey, dadsitez-sitez,
 	       sitex, sitey, sitez);
       sis.copy(mom,
@@ -1057,8 +1057,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	       sitex, sitey, 0,
 	       dadsitex, dadsitey, dadsitez-sitez,
 	       lenx, leny, sitez);
-      sis.copy(mom, 
-	       0, 0, sitez, 
+      sis.copy(mom,
+	       0, 0, sitez,
 	       momsitex-sitex, momsitey-sitey, momsitez,
 	       sitex, sitey, lenz);
       sis.copy(dad,

--- a/Global_dynamic_MPFA/source/ga-mpi/GA3DBinStrGenome.C
+++ b/Global_dynamic_MPFA/source/ga-mpi/GA3DBinStrGenome.C
@@ -17,199 +17,240 @@
 #include <ga-mpi/GA3DBinStrGenome.h>
 #include <ga-mpi/GAMask.h>
 
-
 /* ----------------------------------------------------------------------------
    Genome class definition
 ---------------------------------------------------------------------------- */
 GA3DBinaryStringGenome::
-GA3DBinaryStringGenome(unsigned int width,
-		       unsigned int height,
-		       unsigned int depth,
-		       GAGenome::Evaluator f, void * u) :
-GABinaryString(width*height*depth),
-GAGenome(DEFAULT_3DBINSTR_INITIALIZER,
-	 DEFAULT_3DBINSTR_MUTATOR,
-	 DEFAULT_3DBINSTR_COMPARATOR) {
+    GA3DBinaryStringGenome(unsigned int width,
+                           unsigned int height,
+                           unsigned int depth,
+                           GAGenome::Evaluator f, void *u) : GABinaryString(width * height * depth),
+                                                             GAGenome(DEFAULT_3DBINSTR_INITIALIZER,
+                                                                      DEFAULT_3DBINSTR_MUTATOR,
+                                                                      DEFAULT_3DBINSTR_COMPARATOR)
+{
   evaluator(f);
   userData(u);
   crossover(DEFAULT_3DBINSTR_CROSSOVER);
-  nx=minX=maxX=0; ny=minY=maxY=0; nz=minZ=maxZ=0;
+  nx = minX = maxX = 0;
+  ny = minY = maxY = 0;
+  nz = minZ = maxZ = 0;
   resize(width, height, depth);
 }
 
-
 GA3DBinaryStringGenome::
-GA3DBinaryStringGenome(const GA3DBinaryStringGenome & orig) :
-GABinaryString(orig.GABinaryString::size()),
-GAGenome() {
-  nx=minX=maxX=0; ny=minY=maxY=0; nz=minZ=maxZ=0;
+    GA3DBinaryStringGenome(const GA3DBinaryStringGenome &orig) : GABinaryString(orig.GABinaryString::size()),
+                                                                 GAGenome()
+{
+  nx = minX = maxX = 0;
+  ny = minY = maxY = 0;
+  nz = minZ = maxZ = 0;
   GA3DBinaryStringGenome::copy(orig);
 }
 
-GA3DBinaryStringGenome::~GA3DBinaryStringGenome() { }
+GA3DBinaryStringGenome::~GA3DBinaryStringGenome() {}
 
 GAGenome *
-GA3DBinaryStringGenome::clone(GAGenome::CloneMethod flag) const {
-  GA3DBinaryStringGenome *cpy = new GA3DBinaryStringGenome(nx,ny,nz);
-  if(flag == CONTENTS){
+GA3DBinaryStringGenome::clone(GAGenome::CloneMethod flag) const
+{
+  GA3DBinaryStringGenome *cpy = new GA3DBinaryStringGenome(nx, ny, nz);
+  if (flag == CONTENTS)
+  {
     cpy->copy(*this);
   }
-  else{
+  else
+  {
     cpy->GAGenome::copy(*this);
-    cpy->minX = minX; cpy->minY = minY; cpy->minZ = minZ; 
-    cpy->maxX = maxX; cpy->maxY = maxY; cpy->maxZ = maxZ;
+    cpy->minX = minX;
+    cpy->minY = minY;
+    cpy->minZ = minZ;
+    cpy->maxX = maxX;
+    cpy->maxY = maxY;
+    cpy->maxZ = maxZ;
   }
   return cpy;
 }
 
-void
-GA3DBinaryStringGenome::copy(const GAGenome & orig)
+void GA3DBinaryStringGenome::copy(const GAGenome &orig)
 {
-  if(&orig == this) return;
-  const GA3DBinaryStringGenome* c = 
-    DYN_CAST(const GA3DBinaryStringGenome*, &orig);
-  if(c) {
+  if (&orig == this)
+    return;
+  const GA3DBinaryStringGenome *c =
+      DYN_CAST(const GA3DBinaryStringGenome *, &orig);
+  if (c)
+  {
     GAGenome::copy(*c);
     GABinaryString::copy(*c);
-    nx = c->nx; ny = c->ny; nz = c->nz;
-    minX = c->minX; minY = c->minY; minZ = c->minZ;
-    maxX = c->maxX; maxY = c->maxY; maxZ = c->maxZ;
+    nx = c->nx;
+    ny = c->ny;
+    nz = c->nz;
+    minX = c->minX;
+    minY = c->minY;
+    minZ = c->minZ;
+    maxX = c->maxX;
+    maxY = c->maxY;
+    maxZ = c->maxZ;
   }
 }
 
-
-int
-GA3DBinaryStringGenome::resize(int w, int h, int d)
+int GA3DBinaryStringGenome::resize(int w, int h, int d)
 {
-  if(w == STA_CAST(int,nx) && h == STA_CAST(int,ny) && d == STA_CAST(int,nz))
+  if (w == STA_CAST(int, nx) && h == STA_CAST(int, ny) && d == STA_CAST(int, nz))
     return sz;
 
-  if(w == GAGenome::ANY_SIZE)
+  if (w == GAGenome::ANY_SIZE)
     w = GARandomInt(minX, maxX);
-  else if(w < 0)
-    w = nx;		// do nothing
-  else if(minX == maxX)
-    minX=maxX = w;
-  else{
-    if(w < STA_CAST(int,minX)) w=minX;
-    if(w > STA_CAST(int,maxX)) w=maxX;
+  else if (w < 0)
+    w = nx; // do nothing
+  else if (minX == maxX)
+    minX = maxX = w;
+  else
+  {
+    if (w < STA_CAST(int, minX))
+      w = minX;
+    if (w > STA_CAST(int, maxX))
+      w = maxX;
   }
 
-  if(h == GAGenome::ANY_SIZE)
+  if (h == GAGenome::ANY_SIZE)
     h = GARandomInt(minY, maxY);
-  else if(h < 0)
-    h = ny;		// do nothing
-  else if(minY == maxY)
-    minY=maxY = h;
-  else{
-    if(h < STA_CAST(int,minY)) h=minY;
-    if(h > STA_CAST(int,maxY)) h=maxY;
+  else if (h < 0)
+    h = ny; // do nothing
+  else if (minY == maxY)
+    minY = maxY = h;
+  else
+  {
+    if (h < STA_CAST(int, minY))
+      h = minY;
+    if (h > STA_CAST(int, maxY))
+      h = maxY;
   }
 
-  if(d == GAGenome::ANY_SIZE)
+  if (d == GAGenome::ANY_SIZE)
     d = GARandomInt(minZ, maxZ);
-  else if(d < 0)
-    d = nz;		// do nothing
-  else if(minZ == maxZ)
-    minZ=maxZ = d;
-  else{
-    if(d < STA_CAST(int,minZ)) d=minZ;
-    if(d > STA_CAST(int,maxZ)) d=maxZ;
+  else if (d < 0)
+    d = nz; // do nothing
+  else if (minZ == maxZ)
+    minZ = maxZ = d;
+  else
+  {
+    if (d < STA_CAST(int, minZ))
+      d = minZ;
+    if (d > STA_CAST(int, maxZ))
+      d = maxZ;
   }
 
-  if(w < STA_CAST(int,nx) && h < STA_CAST(int,ny)){
-    int z=GAMin(STA_CAST(int,nz),d);
-    for(int k=0; k<z; k++)
-      for(int j=0; j<h; j++)
-	GABinaryString::move(k*h*w+j*w,k*ny*nx+j*nx,w);
+  if (w < STA_CAST(int, nx) && h < STA_CAST(int, ny))
+  {
+    int z = GAMin(STA_CAST(int, nz), d);
+    for (int k = 0; k < z; k++)
+      for (int j = 0; j < h; j++)
+        GABinaryString::move(k * h * w + j * w, k * ny * nx + j * nx, w);
   }
-  else if(w < STA_CAST(int,nx)){
-    int z=GAMin(STA_CAST(int,nz),d);
-    for(int k=0; k<z; k++)
-      for(int j=0; j<STA_CAST(int,ny); j++)
-	GABinaryString::move(k*ny*w+j*w,k*ny*nx+j*nx,w);
+  else if (w < STA_CAST(int, nx))
+  {
+    int z = GAMin(STA_CAST(int, nz), d);
+    for (int k = 0; k < z; k++)
+      for (int j = 0; j < STA_CAST(int, ny); j++)
+        GABinaryString::move(k * ny * w + j * w, k * ny * nx + j * nx, w);
   }
-  else if(h < STA_CAST(int,ny)){
-    int z=GAMin(STA_CAST(int,nz),d);
-    for(int k=0; k<z; k++)
-      for(int j=0; j<h; j++)
-	GABinaryString::move(k*h*nx+j*nx,k*ny*nx+j*nx,nx);
+  else if (h < STA_CAST(int, ny))
+  {
+    int z = GAMin(STA_CAST(int, nz), d);
+    for (int k = 0; k < z; k++)
+      for (int j = 0; j < h; j++)
+        GABinaryString::move(k * h * nx + j * nx, k * ny * nx + j * nx, nx);
   }
 
-  GABinaryString::resize(w*h*d);
+  GABinaryString::resize(w * h * d);
 
-  if(w > STA_CAST(int,nx) && h > STA_CAST(int,ny)){ // adjust the existing bits
-    int z=GAMin(STA_CAST(int,nz),d);
-    for(int k=z-1; k>=0; k--){
+  if (w > STA_CAST(int, nx) && h > STA_CAST(int, ny))
+  { // adjust the existing bits
+    int z = GAMin(STA_CAST(int, nz), d);
+    for (int k = z - 1; k >= 0; k--)
+    {
       int j;
-      for(j=ny-1; j>=0; j--){
-	GABinaryString::move(k*h*w+j*w,k*ny*nx+j*nx,nx);
-	for(int i=nx; i<w; i++)
-	  bit(k*h*w+j*w+i, GARandomBit());
+      for (j = ny - 1; j >= 0; j--)
+      {
+        GABinaryString::move(k * h * w + j * w, k * ny * nx + j * nx, nx);
+        for (int i = nx; i < w; i++)
+          bit(k * h * w + j * w + i, GARandomBit());
       }
-      for(j=ny; j<h; j++)
-	for(int i=0; i<w; i++)
-	  bit(k*h*w+j*w+i, GARandomBit());
+      for (j = ny; j < h; j++)
+        for (int i = 0; i < w; i++)
+          bit(k * h * w + j * w + i, GARandomBit());
     }
   }
-  else if(w > STA_CAST(int,nx)){
-    int z=GAMin(STA_CAST(int,nz),d);
-    for(int k=z-1; k>=0; k--){
-      for(int j=h-1; j>=0; j--){
-	GABinaryString::move(k*h*w+j*w,k*h*nx+j*nx,nx);
-	for(int i=nx; i<w; i++)
-	  bit(k*h*w+j*w+i, GARandomBit());
+  else if (w > STA_CAST(int, nx))
+  {
+    int z = GAMin(STA_CAST(int, nz), d);
+    for (int k = z - 1; k >= 0; k--)
+    {
+      for (int j = h - 1; j >= 0; j--)
+      {
+        GABinaryString::move(k * h * w + j * w, k * h * nx + j * nx, nx);
+        for (int i = nx; i < w; i++)
+          bit(k * h * w + j * w + i, GARandomBit());
       }
     }
   }
-  else if(h > STA_CAST(int,ny)){
-    int z=GAMin(STA_CAST(int,nz),d);
-    for(int k=z-1; k>=0; k--){
+  else if (h > STA_CAST(int, ny))
+  {
+    int z = GAMin(STA_CAST(int, nz), d);
+    for (int k = z - 1; k >= 0; k--)
+    {
       int j;
-      for(j=ny-1; j>=0; j--)
-	GABinaryString::move(k*h*w+j*w,k*ny*w+j*w,w);
-      for(j=ny; j<h; j++)
-	for(int i=0; i<w; i++)
-	  bit(k*h*w+j*w+i, GARandomBit());
+      for (j = ny - 1; j >= 0; j--)
+        GABinaryString::move(k * h * w + j * w, k * ny * w + j * w, w);
+      for (j = ny; j < h; j++)
+        for (int i = 0; i < w; i++)
+          bit(k * h * w + j * w + i, GARandomBit());
     }
   }
-  if(d > STA_CAST(int,nz)){		// change in depth is always new bits
-    for(int i=w*h*nz; i<w*h*d; i++)
+  if (d > STA_CAST(int, nz))
+  { // change in depth is always new bits
+    for (int i = w * h * nz; i < w * h * d; i++)
       bit(i, GARandomBit());
   }
 
-  nx = w; ny = h; nz = d;
+  nx = w;
+  ny = h;
+  nz = d;
   _evaluated = gaFalse;
   return sz;
 }
 
 #ifdef GALIB_USE_STREAMS
-int
-GA3DBinaryStringGenome::read(STD_ISTREAM & is)
+int GA3DBinaryStringGenome::read(STD_ISTREAM &is)
 {
   static char c;
-  unsigned int i=0, j=0, k=0;
-  while(!is.fail() && !is.eof() && k < nz) {
+  unsigned int i = 0, j = 0, k = 0;
+  while (!is.fail() && !is.eof() && k < nz)
+  {
     is >> c;
-    if(isdigit(c)){
+    if (isdigit(c))
+    {
       gene(i++, j, k, ((c == '0') ? 0 : 1));
-      if(i >= nx){
-	i=0;
-	j++;
+      if (i >= nx)
+      {
+        i = 0;
+        j++;
       }
-      if(j >= ny){
-	j=0;
-	k++;
+      if (j >= ny)
+      {
+        j = 0;
+        k++;
       }
     }
   }
 
   _evaluated = gaFalse;
 
-  if(is.eof() && 
-     ((k < nz) ||		// didn't get some lines
-      (j < ny && j != 0) ||	// didn't get some lines
-      (i < nx && i != 0))){	// didn't get some lines
+  if (is.eof() &&
+      ((k < nz) ||           // didn't get some lines
+       (j < ny && j != 0) || // didn't get some lines
+       (i < nx && i != 0)))
+  { // didn't get some lines
     GAErr(GA_LOC, className(), "read", gaErrUnexpectedEOF);
     is.clear(STD_IOS_BADBIT | is.rdstate());
     return 1;
@@ -218,16 +259,17 @@ GA3DBinaryStringGenome::read(STD_ISTREAM & is)
   return 0;
 }
 
-
-// Dump the bits to the stream with a newline at the end of each row and 
+// Dump the bits to the stream with a newline at the end of each row and
 // another at the end of each layer.  No newline at the end of the block.
-int
-GA3DBinaryStringGenome::write(STD_OSTREAM & os) const 
+int GA3DBinaryStringGenome::write(STD_OSTREAM &os) const
 {
-  for(unsigned int k=0; k<nz; k++){
-    for(unsigned int j=0; j<ny; j++){
-      for(unsigned int i=0; i<nx; i++){
-	os << gene(i,j,k);
+  for (unsigned int k = 0; k < nz; k++)
+  {
+    for (unsigned int j = 0; j < ny; j++)
+    {
+      for (unsigned int i = 0; i < nx; i++)
+      {
+        os << gene(i, j, k);
       }
       os << "\n";
     }
@@ -237,52 +279,69 @@ GA3DBinaryStringGenome::write(STD_OSTREAM & os) const
 }
 #endif
 
-
-int
-GA3DBinaryStringGenome::resizeBehaviour(GAGenome::Dimension which) const {
+int GA3DBinaryStringGenome::resizeBehaviour(GAGenome::Dimension which) const
+{
   int val = 0;
-  if(which == WIDTH) {
-    if(maxX == minX) val = FIXED_SIZE;
-    else val = maxX;
+  if (which == WIDTH)
+  {
+    if (maxX == minX)
+      val = FIXED_SIZE;
+    else
+      val = maxX;
   }
-  else if(which == HEIGHT) {
-    if(maxY == minY) val = FIXED_SIZE;
-    else val = maxY;
+  else if (which == HEIGHT)
+  {
+    if (maxY == minY)
+      val = FIXED_SIZE;
+    else
+      val = maxY;
   }
-  else if(which == DEPTH) {
-    if(maxZ == minZ) val = FIXED_SIZE;
-    else val = maxZ;
+  else if (which == DEPTH)
+  {
+    if (maxZ == minZ)
+      val = FIXED_SIZE;
+    else
+      val = maxZ;
   }
   return val;
 }
 
-
-int
-GA3DBinaryStringGenome::
-resizeBehaviour(Dimension which, unsigned int lower, unsigned int upper)
+int GA3DBinaryStringGenome::
+    resizeBehaviour(Dimension which, unsigned int lower, unsigned int upper)
 {
-  if(upper < lower){
+  if (upper < lower)
+  {
     GAErr(GA_LOC, className(), "resizeBehaviour", gaErrBadResizeBehaviour);
     return resizeBehaviour(which);
   }
 
-  switch(which){
+  switch (which)
+  {
   case WIDTH:
-    minX = lower; maxX = upper;
-    if(nx > upper) resize(upper,ny,nz);
-    if(nx < lower) resize(lower,ny,nz);
+    minX = lower;
+    maxX = upper;
+    if (nx > upper)
+      resize(upper, ny, nz);
+    if (nx < lower)
+      resize(lower, ny, nz);
     break;
 
   case HEIGHT:
-    minY = lower; maxY = upper;
-    if(ny > upper) resize(nx,upper,nz);
-    if(ny < lower) resize(nx,lower,nz);
+    minY = lower;
+    maxY = upper;
+    if (ny > upper)
+      resize(nx, upper, nz);
+    if (ny < lower)
+      resize(nx, lower, nz);
     break;
 
   case DEPTH:
-    minZ = lower; maxZ = upper;
-    if(nz > upper) resize(nx,ny,upper);
-    if(nz < lower) resize(nx,ny,lower);
+    minZ = lower;
+    maxZ = upper;
+    if (nz > upper)
+      resize(nx, ny, upper);
+    if (nz < lower)
+      resize(nx, ny, lower);
     break;
 
   default:
@@ -292,163 +351,172 @@ resizeBehaviour(Dimension which, unsigned int lower, unsigned int upper)
   return resizeBehaviour(which);
 }
 
-
-void
-GA3DBinaryStringGenome::
-copy(const GA3DBinaryStringGenome & orig,
-     unsigned int r, unsigned int s, unsigned int t,
-     unsigned int x, unsigned int y, unsigned int z,
-     unsigned int w, unsigned int h, unsigned int d)
+void GA3DBinaryStringGenome::
+    copy(const GA3DBinaryStringGenome &orig,
+         unsigned int r, unsigned int s, unsigned int t,
+         unsigned int x, unsigned int y, unsigned int z,
+         unsigned int w, unsigned int h, unsigned int d)
 {
-  if(w == 0 || x >= orig.nx || r >= nx ||
-     h == 0 || y >= orig.ny || s >= ny ||
-     d == 0 || z >= orig.nz || t >= nz) return;
-  if(x + w > orig.nx) w = orig.nx - x;
-  if(y + h > orig.ny) h = orig.ny - y;
-  if(z + d > orig.nz) d = orig.nz - z;
-  if(r + w > nx) w = nx - r;
-  if(s + h > ny) h = ny - s;
-  if(t + d > nz) d = nz - t;
+  if (w == 0 || x >= orig.nx || r >= nx ||
+      h == 0 || y >= orig.ny || s >= ny ||
+      d == 0 || z >= orig.nz || t >= nz)
+    return;
+  if (x + w > orig.nx)
+    w = orig.nx - x;
+  if (y + h > orig.ny)
+    h = orig.ny - y;
+  if (z + d > orig.nz)
+    d = orig.nz - z;
+  if (r + w > nx)
+    w = nx - r;
+  if (s + h > ny)
+    h = ny - s;
+  if (t + d > nz)
+    d = nz - t;
 
-  for(unsigned int k=0; k<d; k++)
-    for(unsigned int j=0; j<h; j++)
+  for (unsigned int k = 0; k < d; k++)
+    for (unsigned int j = 0; j < h; j++)
       GABinaryString::copy(orig,
-			   (t+k)*ny*nx + (s+j)*nx + r,
-			   (z+k)*orig.ny*orig.nx + (y+j)*orig.nx + x, w);
+                           (t + k) * ny * nx + (s + j) * nx + r,
+                           (z + k) * orig.ny * orig.nx + (y + j) * orig.nx + x, w);
   _evaluated = gaFalse;
 }
 
-
-void
-GA3DBinaryStringGenome::
-set(unsigned int x, unsigned int y, unsigned int z,
-    unsigned int w, unsigned int h, unsigned int d)
+void GA3DBinaryStringGenome::
+    set(unsigned int x, unsigned int y, unsigned int z,
+        unsigned int w, unsigned int h, unsigned int d)
 {
-  if(x + w > nx) w = nx - x;
-  if(y + h > ny) h = ny - y;
-  if(z + d > nz) d = nz - z;
+  if (x + w > nx)
+    w = nx - x;
+  if (y + h > ny)
+    h = ny - y;
+  if (z + d > nz)
+    d = nz - z;
 
-  for(unsigned int k=0; k<d; k++)
-    for(unsigned int j=0; j<h; j++)
-      GABinaryString::set((z+k)*ny*nx + (y+j)*nx + x, w);
+  for (unsigned int k = 0; k < d; k++)
+    for (unsigned int j = 0; j < h; j++)
+      GABinaryString::set((z + k) * ny * nx + (y + j) * nx + x, w);
   _evaluated = gaFalse;
 }
 
-
-void
-GA3DBinaryStringGenome::
-unset(unsigned int x, unsigned int y, unsigned int z,
-      unsigned int w, unsigned int h, unsigned int d)
+void GA3DBinaryStringGenome::
+    unset(unsigned int x, unsigned int y, unsigned int z,
+          unsigned int w, unsigned int h, unsigned int d)
 {
-  if(x + w > nx) w = nx - x;
-  if(y + h > ny) h = ny - y;
-  if(z + d > nz) d = nz - z;
+  if (x + w > nx)
+    w = nx - x;
+  if (y + h > ny)
+    h = ny - y;
+  if (z + d > nz)
+    d = nz - z;
 
-  for(unsigned int k=0; k<d; k++)
-    for(unsigned int j=0; j<h; j++)
-      GABinaryString::unset((z+k)*ny*nx + (y+j)*nx + x, w);
+  for (unsigned int k = 0; k < d; k++)
+    for (unsigned int j = 0; j < h; j++)
+      GABinaryString::unset((z + k) * ny * nx + (y + j) * nx + x, w);
   _evaluated = gaFalse;
 }
 
-
-void
-GA3DBinaryStringGenome::
-randomize(unsigned int x, unsigned int y, unsigned int z,
-	  unsigned int w, unsigned int h, unsigned int d)
+void GA3DBinaryStringGenome::
+    randomize(unsigned int x, unsigned int y, unsigned int z,
+              unsigned int w, unsigned int h, unsigned int d)
 {
-  if(x + w > nx) w = nx - x;
-  if(y + h > ny) h = ny - y;
-  if(z + d > nz) d = nz - z;
+  if (x + w > nx)
+    w = nx - x;
+  if (y + h > ny)
+    h = ny - y;
+  if (z + d > nz)
+    d = nz - z;
 
-  for(unsigned int k=0; k<d; k++)
-    for(unsigned int j=0; j<h; j++)
-      GABinaryString::randomize((z+k)*ny*nx + (y+j)*nx + x, w);
+  for (unsigned int k = 0; k < d; k++)
+    for (unsigned int j = 0; j < h; j++)
+      GABinaryString::randomize((z + k) * ny * nx + (y + j) * nx + x, w);
   _evaluated = gaFalse;
 }
 
-
-void
-GA3DBinaryStringGenome::
-move(unsigned int x, unsigned int y, unsigned int z,
-     unsigned int srcx, unsigned int srcy, unsigned int srcz,
-     unsigned int w, unsigned int h, unsigned int d)
+void GA3DBinaryStringGenome::
+    move(unsigned int x, unsigned int y, unsigned int z,
+         unsigned int srcx, unsigned int srcy, unsigned int srcz,
+         unsigned int w, unsigned int h, unsigned int d)
 {
-  if(srcx + w > nx) w = nx - srcx;
-  if(x + w > nx) w = nx - x;
-  if(srcy + h > ny) h = ny - srcy;
-  if(y + h > ny) h = ny - y;
-  if(srcz + d > nz) d = nz - srcz;
-  if(z + d > nz) d = nz - z;
+  if (srcx + w > nx)
+    w = nx - srcx;
+  if (x + w > nx)
+    w = nx - x;
+  if (srcy + h > ny)
+    h = ny - srcy;
+  if (y + h > ny)
+    h = ny - y;
+  if (srcz + d > nz)
+    d = nz - srcz;
+  if (z + d > nz)
+    d = nz - z;
 
-  if(srcz<z){
-    if(srcy<y){
-      for(int k=d-1; k>=0; k--)
-	for(int j=h-1; j>=0; j--)
-	  GABinaryString::move((z+k)*ny*nx + (y+j)*nx + x,
-			       (srcz+k)*ny*nx + (srcy+j)*nx + srcx, w);
+  if (srcz < z)
+  {
+    if (srcy < y)
+    {
+      for (int k = d - 1; k >= 0; k--)
+        for (int j = h - 1; j >= 0; j--)
+          GABinaryString::move((z + k) * ny * nx + (y + j) * nx + x,
+                               (srcz + k) * ny * nx + (srcy + j) * nx + srcx, w);
     }
-    else{
-      for(int k=d-1; k>=0; k--)
-	for(unsigned int j=0; j<h; j++)
-	  GABinaryString::move((z+k)*ny*nx + (y+j)*nx + x,
-			       (srcz+k)*ny*nx + (srcy+j)*nx + srcx, w);
-    }
-  }
-  else{
-    if(srcy<y){
-      for(unsigned int k=0; k<d; k++)
-	for(int j=h-1; j>=0; j--)
-	  GABinaryString::move((z+k)*ny*nx + (y+j)*nx + x,
-			       (srcz+k)*ny*nx + (srcy+j)*nx + srcx, w);
-    }
-    else{
-      for(unsigned int k=0; k<d; k++)
-	for(unsigned int j=0; j<h; j++)
-	  GABinaryString::move((z+k)*ny*nx + (y+j)*nx + x,
-			       (srcz+k)*ny*nx + (srcy+j)*nx + srcx, w);
+    else
+    {
+      for (int k = d - 1; k >= 0; k--)
+        for (unsigned int j = 0; j < h; j++)
+          GABinaryString::move((z + k) * ny * nx + (y + j) * nx + x,
+                               (srcz + k) * ny * nx + (srcy + j) * nx + srcx, w);
     }
   }
+  else
+  {
+    if (srcy < y)
+    {
+      for (unsigned int k = 0; k < d; k++)
+        for (int j = h - 1; j >= 0; j--)
+          GABinaryString::move((z + k) * ny * nx + (y + j) * nx + x,
+                               (srcz + k) * ny * nx + (srcy + j) * nx + srcx, w);
+    }
+    else
+    {
+      for (unsigned int k = 0; k < d; k++)
+        for (unsigned int j = 0; j < h; j++)
+          GABinaryString::move((z + k) * ny * nx + (y + j) * nx + x,
+                               (srcz + k) * ny * nx + (srcy + j) * nx + srcx, w);
+    }
+  }
   _evaluated = gaFalse;
 }
 
-
-int
-GA3DBinaryStringGenome::
-equal(const GA3DBinaryStringGenome& orig,
-      unsigned int x, unsigned int y, unsigned int z,
-      unsigned int srcx, unsigned int srcy, unsigned int srcz,
-      unsigned int w, unsigned int h, unsigned int d) const
+int GA3DBinaryStringGenome::
+    equal(const GA3DBinaryStringGenome &orig,
+          unsigned int x, unsigned int y, unsigned int z,
+          unsigned int srcx, unsigned int srcy, unsigned int srcz,
+          unsigned int w, unsigned int h, unsigned int d) const
 {
   unsigned int eq = 0;
-  for(unsigned int k=0; k<d; k++)
-    for(unsigned int j=0; j<h; j++)
+  for (unsigned int k = 0; k < d; k++)
+    for (unsigned int j = 0; j < h; j++)
       eq += GABinaryString::equal(orig,
-				  (z+k)*ny*nx + (y+j)*nx + x,
-				  (srcz+k)*ny*nx + (srcy+j)*nx + srcx, 
-				  w);
-  return eq==d*h ? 1 : 0;
+                                  (z + k) * ny * nx + (y + j) * nx + x,
+                                  (srcz + k) * ny * nx + (srcy + j) * nx + srcx,
+                                  w);
+  return eq == d * h ? 1 : 0;
 }
 
-
-int 
-GA3DBinaryStringGenome::equal(const GAGenome & c) const
+int GA3DBinaryStringGenome::equal(const GAGenome &c) const
 {
-  if(this == &c) return 1;
-  const GA3DBinaryStringGenome& b = DYN_CAST(const GA3DBinaryStringGenome&, c);
-  if(nx != b.nx || ny != b.ny || nz != b.nz) return 0;
-  int val=0;
-  for(unsigned int k=0; k<nz && val==0; k++)
-    for(unsigned int j=0; j<ny && val==0; j++)
-      val = GABinaryString::equal(b,k*ny*nx,k*ny*nx,nx) ? 0 : 1;
-  return(val ? 0 : 1);
+  if (this == &c)
+    return 1;
+  const GA3DBinaryStringGenome &b = DYN_CAST(const GA3DBinaryStringGenome &, c);
+  if (nx != b.nx || ny != b.ny || nz != b.nz)
+    return 0;
+  int val = 0;
+  for (unsigned int k = 0; k < nz && val == 0; k++)
+    for (unsigned int j = 0; j < ny && val == 0; j++)
+      val = GABinaryString::equal(b, k * ny * nx, k * ny * nx, nx) ? 0 : 1;
+  return (val ? 0 : 1);
 }
-
-
-
-
-
-
-
 
 /* ----------------------------------------------------------------------------
    Operators
@@ -459,140 +527,139 @@ GA3DBinaryStringGenome::equal(const GAGenome & c) const
 (ie depth loops before a single height increment, height loops before a single
 width increment)
 ---------------------------------------------------------------------------- */
-void 
-GA3DBinaryStringGenome::UniformInitializer(GAGenome & c)
+void GA3DBinaryStringGenome::UniformInitializer(GAGenome &c)
 {
-  GA3DBinaryStringGenome &child=DYN_CAST(GA3DBinaryStringGenome &, c);
-  child.resize(GAGenome::ANY_SIZE,GAGenome::ANY_SIZE,GAGenome::ANY_SIZE);
-  for(int i=child.width()-1; i>=0; i--)
-    for(int j=child.height()-1; j>=0; j--)
-      for(int k=child.depth()-1; k>=0; k--)
-	child.gene(i,j,k, GARandomBit());
+  GA3DBinaryStringGenome &child = DYN_CAST(GA3DBinaryStringGenome &, c);
+  child.resize(GAGenome::ANY_SIZE, GAGenome::ANY_SIZE, GAGenome::ANY_SIZE);
+  for (int i = child.width() - 1; i >= 0; i--)
+    for (int j = child.height() - 1; j >= 0; j--)
+      for (int k = child.depth() - 1; k >= 0; k--)
+        child.gene(i, j, k, GARandomBit());
 }
 
-
-void 
-GA3DBinaryStringGenome::UnsetInitializer(GAGenome & c)
+void GA3DBinaryStringGenome::UnsetInitializer(GAGenome &c)
 {
-  GA3DBinaryStringGenome &child=DYN_CAST(GA3DBinaryStringGenome &, c);
-  child.resize(GAGenome::ANY_SIZE,GAGenome::ANY_SIZE,GAGenome::ANY_SIZE);
+  GA3DBinaryStringGenome &child = DYN_CAST(GA3DBinaryStringGenome &, c);
+  child.resize(GAGenome::ANY_SIZE, GAGenome::ANY_SIZE, GAGenome::ANY_SIZE);
   child.unset(0, 0, 0, child.width(), child.height(), child.depth());
 }
 
-
-void 
-GA3DBinaryStringGenome::SetInitializer(GAGenome & c)
+void GA3DBinaryStringGenome::SetInitializer(GAGenome &c)
 {
-  GA3DBinaryStringGenome &child=DYN_CAST(GA3DBinaryStringGenome &, c);
-  child.resize(GAGenome::ANY_SIZE,GAGenome::ANY_SIZE,GAGenome::ANY_SIZE);
+  GA3DBinaryStringGenome &child = DYN_CAST(GA3DBinaryStringGenome &, c);
+  child.resize(GAGenome::ANY_SIZE, GAGenome::ANY_SIZE, GAGenome::ANY_SIZE);
   child.set(0, 0, 0, child.width(), child.height(), child.depth());
 }
 
-
-int 
-GA3DBinaryStringGenome::FlipMutator(GAGenome & c, float pmut)
+int GA3DBinaryStringGenome::FlipMutator(GAGenome &c, float pmut)
 {
-  GA3DBinaryStringGenome &child=DYN_CAST(GA3DBinaryStringGenome &, c);
-  register int n, m, i, j, k, d;
-  if(pmut <= 0.0) return(0);
+  GA3DBinaryStringGenome &child = DYN_CAST(GA3DBinaryStringGenome &, c);
+  int n, m, i, j, k, d;
+  if (pmut <= 0.0)
+    return (0);
 
-  float nMut = pmut * STA_CAST(float,child.size());
-  if(nMut < 1.0){		// we have to do a flip test on each bit
+  float nMut = pmut * STA_CAST(float, child.size());
+  if (nMut < 1.0)
+  { // we have to do a flip test on each bit
     nMut = 0;
-    for(i=child.width()-1; i>=0; i--){
-      for(j=child.height()-1; j>=0; j--){
-	for(k=child.depth()-1; k>=0; k--){
-	  if(GAFlipCoin(pmut)){
-	    child.gene(i, j, k, ((child.gene(i,j,k) == 0) ? 1 : 0));
-	    nMut++;
-	  }
-	}
+    for (i = child.width() - 1; i >= 0; i--)
+    {
+      for (j = child.height() - 1; j >= 0; j--)
+      {
+        for (k = child.depth() - 1; k >= 0; k--)
+        {
+          if (GAFlipCoin(pmut))
+          {
+            child.gene(i, j, k, ((child.gene(i, j, k) == 0) ? 1 : 0));
+            nMut++;
+          }
+        }
       }
     }
   }
-  else{				// only flip the number of bits we need to flip
-    for(n=0; n<nMut; n++){
-      m = GARandomInt(0, child.size()-1);
+  else
+  { // only flip the number of bits we need to flip
+    for (n = 0; n < nMut; n++)
+    {
+      m = GARandomInt(0, child.size() - 1);
       d = child.height() * child.depth();
       i = m / d;
       j = (m % d) / child.depth();
       k = (m % d) % child.depth();
-      child.gene(i, j, k, ((child.gene(i,j,k) == 0) ? 1 : 0));
+      child.gene(i, j, k, ((child.gene(i, j, k) == 0) ? 1 : 0));
     }
   }
-  return(STA_CAST(int,nMut));
+  return (STA_CAST(int, nMut));
 }
 
-
-float
-GA3DBinaryStringGenome::BitComparator(const GAGenome& a, const GAGenome& b){
-  const GA3DBinaryStringGenome &sis=DYN_CAST(const GA3DBinaryStringGenome&, a);
-  const GA3DBinaryStringGenome &bro=DYN_CAST(const GA3DBinaryStringGenome&, b);
-  if(sis.size() != bro.size()) return -1;
-  if(sis.size() == 0) return 0;
+float GA3DBinaryStringGenome::BitComparator(const GAGenome &a, const GAGenome &b)
+{
+  const GA3DBinaryStringGenome &sis = DYN_CAST(const GA3DBinaryStringGenome &, a);
+  const GA3DBinaryStringGenome &bro = DYN_CAST(const GA3DBinaryStringGenome &, b);
+  if (sis.size() != bro.size())
+    return -1;
+  if (sis.size() == 0)
+    return 0;
   float count = 0.0;
-  for(int i=sis.width()-1; i>=0; i--)
-    for(int j=sis.height()-1; j>=0; j--)
-      for(int k=sis.depth()-1; k>=0; k--)
-	count += ((sis.gene(i,j,k) == bro.gene(i,j,k)) ? 0 : 1);
-  return count/sis.size();
+  for (int i = sis.width() - 1; i >= 0; i--)
+    for (int j = sis.height() - 1; j >= 0; j--)
+      for (int k = sis.depth() - 1; k >= 0; k--)
+        count += ((sis.gene(i, j, k) == bro.gene(i, j, k)) ? 0 : 1);
+  return count / sis.size();
 }
 
-
-
-
-
-
-
-
-
-
-
-
-
-// Make sure our bitmask is big enough, generate a mask, then use it to 
+// Make sure our bitmask is big enough, generate a mask, then use it to
 // extract the information from each parent to stuff the two children.
 // We don't deallocate any space for the masks under the assumption that we'll
 // have to use them again in the future.
 //   For now we'll implement this only for fixed length genomes.  If you use
 // this crossover method on genomes of different sizes it might break!
-int
-GA3DBinaryStringGenome::
-UniformCrossover(const GAGenome& p1, const GAGenome& p2,
-		 GAGenome* c1, GAGenome* c2){
-  const GA3DBinaryStringGenome &mom=
-    DYN_CAST(const GA3DBinaryStringGenome &, p1);
-  const GA3DBinaryStringGenome &dad=
-    DYN_CAST(const GA3DBinaryStringGenome &, p2);
+int GA3DBinaryStringGenome::
+    UniformCrossover(const GAGenome &p1, const GAGenome &p2,
+                     GAGenome *c1, GAGenome *c2)
+{
+  const GA3DBinaryStringGenome &mom =
+      DYN_CAST(const GA3DBinaryStringGenome &, p1);
+  const GA3DBinaryStringGenome &dad =
+      DYN_CAST(const GA3DBinaryStringGenome &, p2);
 
-  int i,j,k, nc=0;;
+  int i, j, k, nc = 0;
+  ;
 
-  if(c1 && c2){
-    GA3DBinaryStringGenome &sis=DYN_CAST(GA3DBinaryStringGenome &, *c1);
-    GA3DBinaryStringGenome &bro=DYN_CAST(GA3DBinaryStringGenome &, *c2);
+  if (c1 && c2)
+  {
+    GA3DBinaryStringGenome &sis = DYN_CAST(GA3DBinaryStringGenome &, *c1);
+    GA3DBinaryStringGenome &bro = DYN_CAST(GA3DBinaryStringGenome &, *c2);
 
-    if(sis.width() == bro.width() && sis.height() == bro.height() &&
-       sis.depth() == bro.depth() &&
-       mom.width() == dad.width() && mom.height() == dad.height() &&
-       mom.depth() == dad.depth() &&
-       sis.width() == mom.width() && sis.height() == mom.height() &&
-       sis.depth() == mom.depth()){
-      for(i=sis.width()-1; i>=0; i--){
-	for(j=sis.height()-1; j>=0; j--){
-	  for(k=sis.depth()-1; k>=0; k--){
-	    if(GARandomBit()){
-	      sis.gene(i,j,k, mom.gene(i,j,k));
-	      bro.gene(i,j,k, dad.gene(i,j,k));
-	    }
-	    else{
-	      sis.gene(i,j,k, dad.gene(i,j,k));
-	      bro.gene(i,j,k, mom.gene(i,j,k));
-	    }
-	  }
-	}
+    if (sis.width() == bro.width() && sis.height() == bro.height() &&
+        sis.depth() == bro.depth() &&
+        mom.width() == dad.width() && mom.height() == dad.height() &&
+        mom.depth() == dad.depth() &&
+        sis.width() == mom.width() && sis.height() == mom.height() &&
+        sis.depth() == mom.depth())
+    {
+      for (i = sis.width() - 1; i >= 0; i--)
+      {
+        for (j = sis.height() - 1; j >= 0; j--)
+        {
+          for (k = sis.depth() - 1; k >= 0; k--)
+          {
+            if (GARandomBit())
+            {
+              sis.gene(i, j, k, mom.gene(i, j, k));
+              bro.gene(i, j, k, dad.gene(i, j, k));
+            }
+            else
+            {
+              sis.gene(i, j, k, dad.gene(i, j, k));
+              bro.gene(i, j, k, mom.gene(i, j, k));
+            }
+          }
+        }
       }
     }
-    else{
+    else
+    {
       GAMask mask;
       int maxx = GAMax(sis.width(), bro.width());
       int minx = GAMin(mom.width(), dad.width());
@@ -600,56 +667,55 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
       int miny = GAMin(mom.height(), dad.height());
       int maxz = GAMax(sis.depth(), bro.depth());
       int minz = GAMin(mom.depth(), dad.depth());
-      mask.size(maxx*maxy*maxz);
-      for(i=0; i<maxx; i++)
-	for(j=0; j<maxy; j++)
-	  for(k=0; k<maxz; k++)
-	    mask[i*maxy*maxz+j*maxz+k] = GARandomBit();
+      mask.size(maxx * maxy * maxz);
+      for (i = 0; i < maxx; i++)
+        for (j = 0; j < maxy; j++)
+          for (k = 0; k < maxz; k++)
+            mask[i * maxy * maxz + j * maxz + k] = GARandomBit();
       minx = GAMin(sis.width(), minx);
       miny = GAMin(sis.height(), miny);
       minz = GAMin(sis.depth(), minz);
-      for(i=minx-1; i>=0; i--)
-	for(j=miny-1; j>=0; j--)
-	  for(k=minz-1; k>=0; k--)
-	    sis.gene(i,j,k, (mask[i*miny*minz+j*minz+k] ?
-			     mom.gene(i,j,k) : dad.gene(i,j,k)));
+      for (i = minx - 1; i >= 0; i--)
+        for (j = miny - 1; j >= 0; j--)
+          for (k = minz - 1; k >= 0; k--)
+            sis.gene(i, j, k, (mask[i * miny * minz + j * minz + k] ? mom.gene(i, j, k) : dad.gene(i, j, k)));
       minx = GAMin(bro.width(), minx);
       miny = GAMin(bro.height(), miny);
       minz = GAMin(bro.depth(), minz);
-      for(i=minx-1; i>=0; i--)
-	for(j=miny-1; j>=0; j--)
-	  for(k=minz-1; k>=0; k--)
-	    bro.gene(i,j,k, (mask[i*miny*minz+j*minz+k] ?
-			     dad.gene(i,j,k) : mom.gene(i,j,k)));
+      for (i = minx - 1; i >= 0; i--)
+        for (j = miny - 1; j >= 0; j--)
+          for (k = minz - 1; k >= 0; k--)
+            bro.gene(i, j, k, (mask[i * miny * minz + j * minz + k] ? dad.gene(i, j, k) : mom.gene(i, j, k)));
     }
 
     nc = 2;
   }
-  else if(c1 || c2){
-    GA3DBinaryStringGenome &sis = (c1 ? 
-				   DYN_CAST(GA3DBinaryStringGenome&, *c1) : 
-				   DYN_CAST(GA3DBinaryStringGenome&, *c2));
-    
-    if(mom.width() == dad.width() && mom.height() == dad.height() &&
-       mom.depth() == dad.depth() &&
-       sis.width() == mom.width() && sis.height() == mom.height() &&
-       sis.depth() == mom.depth()){
-      for(i=sis.width()-1; i>=0; i--)
-	for(j=sis.height()-1; j>=0; j--)
-	  for(k=sis.depth()-1; k>=0; k--)
-	    sis.gene(i,j,k, (GARandomBit() ? mom.gene(i,j,k):dad.gene(i,j,k)));
+  else if (c1 || c2)
+  {
+    GA3DBinaryStringGenome &sis = (c1 ? DYN_CAST(GA3DBinaryStringGenome &, *c1) : DYN_CAST(GA3DBinaryStringGenome &, *c2));
+
+    if (mom.width() == dad.width() && mom.height() == dad.height() &&
+        mom.depth() == dad.depth() &&
+        sis.width() == mom.width() && sis.height() == mom.height() &&
+        sis.depth() == mom.depth())
+    {
+      for (i = sis.width() - 1; i >= 0; i--)
+        for (j = sis.height() - 1; j >= 0; j--)
+          for (k = sis.depth() - 1; k >= 0; k--)
+            sis.gene(i, j, k, (GARandomBit() ? mom.gene(i, j, k) : dad.gene(i, j, k)));
     }
-    else{
+    else
+    {
       int minx = GAMin(mom.width(), dad.width());
       int miny = GAMin(mom.height(), dad.height());
       int minz = GAMin(mom.depth(), dad.depth());
       minx = GAMin(sis.width(), minx);
       miny = GAMin(sis.height(), miny);
       minz = GAMin(sis.depth(), minz);
-      for(i=minx-1; i>=0; i--)
-	for(j=miny-1; j>=0; j--)
-	  for(k=minz-1; k>=0; k--)
-	    sis.gene(i,j,k, (GARandomBit() ? mom.gene(i,j,k):dad.gene(i,j,k)));
+      for (i = minx - 1; i >= 0; i--)
+        for (j = miny - 1; j >= 0; j--)
+          for (k = minz - 1; k >= 0; k--)
+            sis.gene(i, j, k, (GARandomBit() ? mom.gene(i, j, k) : dad.gene(i, j, k)));
     }
 
     nc = 1;
@@ -657,111 +723,118 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
 
   return nc;
 }
-
-
 
 // For even crossover we take the even bits from the mother (for the daughter)
 // and the odd bits from the father.  Just the opposite for the son.
 //   This is designed only for genomes that are the same length.  If the child
 // is not the same length as the parent, or if the children are not the same
 // size, we don't do the crossover.
-//   In the interest of speed we do not do any checks for size.  Do not use 
+//   In the interest of speed we do not do any checks for size.  Do not use
 // this crossover method when the parents and children may be different sizes.
 // It might break!
-int
-GA3DBinaryStringGenome::
-EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
-		 GAGenome* c1, GAGenome* c2){
-  const GA3DBinaryStringGenome &mom=
-    DYN_CAST(const GA3DBinaryStringGenome &, p1);
-  const GA3DBinaryStringGenome &dad=
-    DYN_CAST(const GA3DBinaryStringGenome &, p2);
+int GA3DBinaryStringGenome::
+    EvenOddCrossover(const GAGenome &p1, const GAGenome &p2,
+                     GAGenome *c1, GAGenome *c2)
+{
+  const GA3DBinaryStringGenome &mom =
+      DYN_CAST(const GA3DBinaryStringGenome &, p1);
+  const GA3DBinaryStringGenome &dad =
+      DYN_CAST(const GA3DBinaryStringGenome &, p2);
 
-  int nc=0;
-  int i,j,k;
+  int nc = 0;
+  int i, j, k;
 
-  if(c1 && c2){
-    GA3DBinaryStringGenome &sis=DYN_CAST(GA3DBinaryStringGenome &, *c1);
-    GA3DBinaryStringGenome &bro=DYN_CAST(GA3DBinaryStringGenome &, *c2);
+  if (c1 && c2)
+  {
+    GA3DBinaryStringGenome &sis = DYN_CAST(GA3DBinaryStringGenome &, *c1);
+    GA3DBinaryStringGenome &bro = DYN_CAST(GA3DBinaryStringGenome &, *c2);
 
-    if(sis.width() == bro.width() && sis.height() == bro.height() &&
-       sis.depth() == bro.depth() &&
-       mom.width() == dad.width() && mom.height() == dad.height() &&
-       mom.depth() == dad.depth() &&
-       sis.width() == mom.width() && sis.height() == mom.height() &&
-       sis.depth() == mom.depth()){
-      int count=0;
-      for(i=sis.width()-1; i>=0; i--){
-	for(j=sis.height()-1; j>=0; j--){
-	  for(k=sis.depth()-1; k>=0; k--){
-	    if(count%2 == 0){
-	      sis.gene(i,j,k, mom.gene(i,j,k));
-	      bro.gene(i,j,k, dad.gene(i,j,k));
-	    }
-	    else{
-	      sis.gene(i,j,k, dad.gene(i,j,k));
-	      bro.gene(i,j,k, mom.gene(i,j,k));
-	    }
-	    count++;
-	  }
-	}
+    if (sis.width() == bro.width() && sis.height() == bro.height() &&
+        sis.depth() == bro.depth() &&
+        mom.width() == dad.width() && mom.height() == dad.height() &&
+        mom.depth() == dad.depth() &&
+        sis.width() == mom.width() && sis.height() == mom.height() &&
+        sis.depth() == mom.depth())
+    {
+      int count = 0;
+      for (i = sis.width() - 1; i >= 0; i--)
+      {
+        for (j = sis.height() - 1; j >= 0; j--)
+        {
+          for (k = sis.depth() - 1; k >= 0; k--)
+          {
+            if (count % 2 == 0)
+            {
+              sis.gene(i, j, k, mom.gene(i, j, k));
+              bro.gene(i, j, k, dad.gene(i, j, k));
+            }
+            else
+            {
+              sis.gene(i, j, k, dad.gene(i, j, k));
+              bro.gene(i, j, k, mom.gene(i, j, k));
+            }
+            count++;
+          }
+        }
       }
     }
-    else{
+    else
+    {
       int minx = GAMin(mom.width(), dad.width());
       int miny = GAMin(mom.height(), dad.height());
       int minz = GAMin(mom.depth(), dad.depth());
       minx = GAMin(sis.width(), minx);
       miny = GAMin(sis.height(), miny);
       minz = GAMin(sis.depth(), minz);
-      for(i=minx-1; i>=0; i--)
-	for(j=miny-1; j>=0; j--)
-	  for(k=minz-1; k>=0; k--)
-	    sis.gene(i,j,k, (((i*miny*minz+j*minz+k)%2 == 0) ?
-			     mom.gene(i,j,k) : dad.gene(i,j,k)));
+      for (i = minx - 1; i >= 0; i--)
+        for (j = miny - 1; j >= 0; j--)
+          for (k = minz - 1; k >= 0; k--)
+            sis.gene(i, j, k, (((i * miny * minz + j * minz + k) % 2 == 0) ? mom.gene(i, j, k) : dad.gene(i, j, k)));
       minx = (bro.width() < minx) ? bro.width() : minx;
       miny = (bro.height() < miny) ? bro.height() : miny;
       minz = (bro.depth() < minz) ? bro.depth() : minz;
-      for(i=minx-1; i>=0; i--)
-	for(j=miny-1; j>=0; j--)
-	  for(k=minz-1; k>=0; k--)
-	    bro.gene(i,j,k, (((i*miny*minz+j*minz+k)%2 == 0) ?
-			     dad.gene(i,j,k) : mom.gene(i,j,k)));
+      for (i = minx - 1; i >= 0; i--)
+        for (j = miny - 1; j >= 0; j--)
+          for (k = minz - 1; k >= 0; k--)
+            bro.gene(i, j, k, (((i * miny * minz + j * minz + k) % 2 == 0) ? dad.gene(i, j, k) : mom.gene(i, j, k)));
     }
 
     nc = 2;
   }
-  else if(c1 || c2){
-    GA3DBinaryStringGenome &sis = (c1 ?
-				   DYN_CAST(GA3DBinaryStringGenome &, *c1) : 
-				   DYN_CAST(GA3DBinaryStringGenome &, *c2));
+  else if (c1 || c2)
+  {
+    GA3DBinaryStringGenome &sis = (c1 ? DYN_CAST(GA3DBinaryStringGenome &, *c1) : DYN_CAST(GA3DBinaryStringGenome &, *c2));
 
-    if(mom.width() == dad.width() && mom.height() == dad.height() &&
-       mom.depth() == dad.depth() &&
-       sis.width() == mom.width() && sis.height() == mom.height() &&
-       sis.depth() == mom.depth()){
-      int count=0;
-      for(i=sis.width()-1; i>=0; i--){
-	for(j=sis.height()-1; j>=0; j--){
-	  for(k=sis.depth()-1; k>=0; k--){
-	    sis.gene(i,j,k,((count%2 == 0) ? mom.gene(i,j,k):dad.gene(i,j,k)));
-	    count++;
-	  }
-	}
+    if (mom.width() == dad.width() && mom.height() == dad.height() &&
+        mom.depth() == dad.depth() &&
+        sis.width() == mom.width() && sis.height() == mom.height() &&
+        sis.depth() == mom.depth())
+    {
+      int count = 0;
+      for (i = sis.width() - 1; i >= 0; i--)
+      {
+        for (j = sis.height() - 1; j >= 0; j--)
+        {
+          for (k = sis.depth() - 1; k >= 0; k--)
+          {
+            sis.gene(i, j, k, ((count % 2 == 0) ? mom.gene(i, j, k) : dad.gene(i, j, k)));
+            count++;
+          }
+        }
       }
     }
-    else{
+    else
+    {
       int minx = GAMin(mom.width(), dad.width());
       int miny = GAMin(mom.height(), dad.height());
       int minz = GAMin(mom.depth(), dad.depth());
       minx = GAMin(sis.width(), minx);
       miny = GAMin(sis.height(), miny);
       minz = GAMin(sis.depth(), minz);
-      for(i=minx-1; i>=0; i--)
-	for(j=miny-1; j>=0; j--)
-	  for(k=minz-1; k>=0; k--)
-	    sis.gene(i,j, (((i*miny*minz+j*minz+k)%2 == 0) ?
-			   mom.gene(i,j,k) : dad.gene(i,j,k)));
+      for (i = minx - 1; i >= 0; i--)
+        for (j = miny - 1; j >= 0; j--)
+          for (k = minz - 1; k >= 0; k--)
+            sis.gene(i, j, (((i * miny * minz + j * minz + k) % 2 == 0) ? mom.gene(i, j, k) : dad.gene(i, j, k)));
     }
 
     nc = 1;
@@ -770,46 +843,50 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
   return nc;
 }
 
-
 // Pick a single point in the 3D block and grab alternating quadrants for each
-// child.  If the children are resizable, this crossover does clipping or 
+// child.  If the children are resizable, this crossover does clipping or
 // padding depending on the setting of the clip flag.  If we pad, we fill the
 // additional bits with random contents.
-int
-GA3DBinaryStringGenome::
-OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
-		  GAGenome* c1, GAGenome* c2){
-  const GA3DBinaryStringGenome &mom=
-    DYN_CAST(const GA3DBinaryStringGenome &, p1);
-  const GA3DBinaryStringGenome &dad=
-    DYN_CAST(const GA3DBinaryStringGenome &, p2);
+int GA3DBinaryStringGenome::
+    OnePointCrossover(const GAGenome &p1, const GAGenome &p2,
+                      GAGenome *c1, GAGenome *c2)
+{
+  const GA3DBinaryStringGenome &mom =
+      DYN_CAST(const GA3DBinaryStringGenome &, p1);
+  const GA3DBinaryStringGenome &dad =
+      DYN_CAST(const GA3DBinaryStringGenome &, p2);
 
-  int nc=0;
+  int nc = 0;
   unsigned int momsitex, momlenx, momsitey, momleny, momsitez, momlenz;
   unsigned int dadsitex, dadlenx, dadsitey, dadleny, dadsitez, dadlenz;
   unsigned int sitex, lenx, sitey, leny, sitez, lenz;
 
-  if(c1 && c2){
-    GA3DBinaryStringGenome &sis=DYN_CAST(GA3DBinaryStringGenome &, *c1);
-    GA3DBinaryStringGenome &bro=DYN_CAST(GA3DBinaryStringGenome &, *c2);
+  if (c1 && c2)
+  {
+    GA3DBinaryStringGenome &sis = DYN_CAST(GA3DBinaryStringGenome &, *c1);
+    GA3DBinaryStringGenome &bro = DYN_CAST(GA3DBinaryStringGenome &, *c2);
 
-    if(sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE &&
-       bro.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE){
-      if(mom.width() != dad.width() || 
-	 sis.width() != bro.width() || 
-	 sis.width() != mom.width()){
-	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
-	return nc;
+    if (sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE &&
+        bro.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE)
+    {
+      if (mom.width() != dad.width() ||
+          sis.width() != bro.width() ||
+          sis.width() != mom.width())
+      {
+        GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
+        return nc;
       }
       sitex = momsitex = dadsitex = GARandomInt(0, mom.width());
       lenx = momlenx = dadlenx = mom.width() - momsitex;
     }
-    else if(sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE ||
-	    bro.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE){
+    else if (sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE ||
+             bro.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE)
+    {
       GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameBehavReqd);
       return nc;
     }
-    else{
+    else
+    {
       momsitex = GARandomInt(0, mom.width());
       dadsitex = GARandomInt(0, dad.width());
       momlenx = mom.width() - momsitex;
@@ -817,24 +894,28 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitex = GAMin(momsitex, dadsitex);
       lenx = GAMin(momlenx, dadlenx);
     }
-    
-    if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE &&
-       bro.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
-      if(mom.height() != dad.height() || 
-	 sis.height() != bro.height() || 
-	 sis.height() != mom.height()){
-	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
-	return nc;
+
+    if (sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE &&
+        bro.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE)
+    {
+      if (mom.height() != dad.height() ||
+          sis.height() != bro.height() ||
+          sis.height() != mom.height())
+      {
+        GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
+        return nc;
       }
       sitey = momsitey = dadsitey = GARandomInt(0, mom.height());
       leny = momleny = dadleny = mom.height() - momsitey;
     }
-    else if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE ||
-	    bro.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
+    else if (sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE ||
+             bro.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE)
+    {
       GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameBehavReqd);
       return nc;
     }
-    else{
+    else
+    {
       momsitey = GARandomInt(0, mom.height());
       dadsitey = GARandomInt(0, dad.height());
       momleny = mom.height() - momsitey;
@@ -842,24 +923,28 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitey = GAMin(momsitey, dadsitey);
       leny = GAMin(momleny, dadleny);
     }
-    
-    if(sis.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE &&
-       bro.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE){
-      if(mom.depth() != dad.depth() || 
-	 sis.depth() != bro.depth() || 
-	 sis.depth() != mom.depth()){
-	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
-	return nc;
+
+    if (sis.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE &&
+        bro.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE)
+    {
+      if (mom.depth() != dad.depth() ||
+          sis.depth() != bro.depth() ||
+          sis.depth() != mom.depth())
+      {
+        GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
+        return nc;
       }
       sitez = momsitez = dadsitez = GARandomInt(0, mom.depth());
       lenz = momlenz = dadlenz = mom.depth() - momsitez;
     }
-    else if(sis.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE ||
-	    bro.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE){
+    else if (sis.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE ||
+             bro.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE)
+    {
       GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameBehavReqd);
       return nc;
     }
-    else{
+    else
+    {
       momsitez = GARandomInt(0, mom.depth());
       dadsitez = GARandomInt(0, dad.depth());
       momlenz = mom.depth() - momsitez;
@@ -868,91 +953,93 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       lenz = GAMin(momlenz, dadlenz);
     }
 
-    sis.resize(sitex+lenx, sitey+leny, sitez+lenz);
-    bro.resize(sitex+lenx, sitey+leny, sitez+lenz);
+    sis.resize(sitex + lenx, sitey + leny, sitez + lenz);
+    bro.resize(sitex + lenx, sitey + leny, sitez + lenz);
 
-    sis.copy(mom, 
-	     0, 0, 0, 
-	     momsitex-sitex, momsitey-sitey, momsitez-sitez,
-	     sitex, sitey, sitez);
-    sis.copy(dad,
-	     sitex, 0, 0,
-	     dadsitex, dadsitey-sitey, dadsitez-sitez,
-	     lenx, sitey, sitez);
-    sis.copy(dad,
-	     0, sitey, 0,
-	     dadsitex-sitex, dadsitey, dadsitez-sitez,
-	     sitex, leny, sitez);
     sis.copy(mom,
-	     sitex, sitey, 0,
-	     momsitex, momsitey, momsitez-sitez,
-	     lenx, leny, sitez);
-    sis.copy(dad, 
-	     0, 0, sitez, 
-	     dadsitex-sitex, dadsitey-sitey, dadsitez,
-	     sitex, sitey, lenz);
-    sis.copy(mom,
-	     sitex, 0, sitez,
-	     momsitex, momsitey-sitey, momsitez,
-	     lenx, sitey, lenz);
-    sis.copy(mom,
-	     0, sitey, sitez,
-	     momsitex-sitex, momsitey, momsitez,
-	     sitex, leny, lenz);
+             0, 0, 0,
+             momsitex - sitex, momsitey - sitey, momsitez - sitez,
+             sitex, sitey, sitez);
     sis.copy(dad,
-	     sitex, sitey, sitez,
-	     dadsitex, dadsitey, dadsitez,
-	     lenx, leny, lenz);
-    
-    bro.copy(dad, 
-	     0, 0, 0, 
-	     dadsitex-sitex, dadsitey-sitey, dadsitez-sitez,
-	     sitex, sitey, sitez);
-    bro.copy(mom,
-	     sitex, 0, 0,
-	     momsitex, momsitey-sitey, momsitez-sitez,
-	     lenx, sitey, sitez);
-    bro.copy(mom,
-	     0, sitey, 0,
-	     momsitex-sitex, momsitey, momsitez-sitez,
-	     sitex, leny, sitez);
+             sitex, 0, 0,
+             dadsitex, dadsitey - sitey, dadsitez - sitez,
+             lenx, sitey, sitez);
+    sis.copy(dad,
+             0, sitey, 0,
+             dadsitex - sitex, dadsitey, dadsitez - sitez,
+             sitex, leny, sitez);
+    sis.copy(mom,
+             sitex, sitey, 0,
+             momsitex, momsitey, momsitez - sitez,
+             lenx, leny, sitez);
+    sis.copy(dad,
+             0, 0, sitez,
+             dadsitex - sitex, dadsitey - sitey, dadsitez,
+             sitex, sitey, lenz);
+    sis.copy(mom,
+             sitex, 0, sitez,
+             momsitex, momsitey - sitey, momsitez,
+             lenx, sitey, lenz);
+    sis.copy(mom,
+             0, sitey, sitez,
+             momsitex - sitex, momsitey, momsitez,
+             sitex, leny, lenz);
+    sis.copy(dad,
+             sitex, sitey, sitez,
+             dadsitex, dadsitey, dadsitez,
+             lenx, leny, lenz);
+
     bro.copy(dad,
-	     sitex, sitey, 0,
-	     dadsitex, dadsitey, dadsitez-sitez,
-	     lenx, leny, sitez);
-    bro.copy(mom, 
-	     0, 0, sitez, 
-	     momsitex-sitex, momsitey-sitey, momsitez,
-	     sitex, sitey, lenz);
-    bro.copy(dad,
-	     sitex, 0, sitez,
-	     dadsitex, dadsitey-sitey, dadsitez,
-	     lenx, sitey, lenz);
-    bro.copy(dad,
-	     0, sitey, sitez,
-	     dadsitex-sitex, dadsitey, dadsitez,
-	     sitex, leny, lenz);
+             0, 0, 0,
+             dadsitex - sitex, dadsitey - sitey, dadsitez - sitez,
+             sitex, sitey, sitez);
     bro.copy(mom,
-	     sitex, sitey, sitez,
-	     momsitex, momsitey, momsitez,
-	     lenx, leny, lenz);
-    
+             sitex, 0, 0,
+             momsitex, momsitey - sitey, momsitez - sitez,
+             lenx, sitey, sitez);
+    bro.copy(mom,
+             0, sitey, 0,
+             momsitex - sitex, momsitey, momsitez - sitez,
+             sitex, leny, sitez);
+    bro.copy(dad,
+             sitex, sitey, 0,
+             dadsitex, dadsitey, dadsitez - sitez,
+             lenx, leny, sitez);
+    bro.copy(mom,
+             0, 0, sitez,
+             momsitex - sitex, momsitey - sitey, momsitez,
+             sitex, sitey, lenz);
+    bro.copy(dad,
+             sitex, 0, sitez,
+             dadsitex, dadsitey - sitey, dadsitez,
+             lenx, sitey, lenz);
+    bro.copy(dad,
+             0, sitey, sitez,
+             dadsitex - sitex, dadsitey, dadsitez,
+             sitex, leny, lenz);
+    bro.copy(mom,
+             sitex, sitey, sitez,
+             momsitex, momsitey, momsitez,
+             lenx, leny, lenz);
+
     nc = 2;
   }
-  else if(c1 || c2){
-    GA3DBinaryStringGenome &sis = (c1 ?
-				   DYN_CAST(GA3DBinaryStringGenome &, *c1) :
-				   DYN_CAST(GA3DBinaryStringGenome &, *c2));
+  else if (c1 || c2)
+  {
+    GA3DBinaryStringGenome &sis = (c1 ? DYN_CAST(GA3DBinaryStringGenome &, *c1) : DYN_CAST(GA3DBinaryStringGenome &, *c2));
 
-    if(sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE){
-      if(mom.width() != dad.width() || sis.width() != mom.width()){
-	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
-	return nc;
+    if (sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE)
+    {
+      if (mom.width() != dad.width() || sis.width() != mom.width())
+      {
+        GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
+        return nc;
       }
       sitex = momsitex = dadsitex = GARandomInt(0, mom.width());
       lenx = momlenx = dadlenx = mom.width() - momsitex;
     }
-    else{
+    else
+    {
       momsitex = GARandomInt(0, mom.width());
       dadsitex = GARandomInt(0, dad.width());
       momlenx = mom.width() - momsitex;
@@ -960,16 +1047,19 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitex = GAMin(momsitex, dadsitex);
       lenx = GAMin(momlenx, dadlenx);
     }
-    
-    if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
-      if(mom.height() != dad.height() || sis.height() != mom.height()){
-	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
-	return nc;
+
+    if (sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE)
+    {
+      if (mom.height() != dad.height() || sis.height() != mom.height())
+      {
+        GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
+        return nc;
       }
       sitey = momsitey = dadsitey = GARandomInt(0, mom.height());
       leny = momleny = dadleny = mom.height() - momsitey;
     }
-    else{
+    else
+    {
       momsitey = GARandomInt(0, mom.height());
       dadsitey = GARandomInt(0, dad.height());
       momleny = mom.height() - momsitey;
@@ -977,16 +1067,19 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitey = GAMin(momsitey, dadsitey);
       leny = GAMin(momleny, dadleny);
     }
-    
-    if(sis.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE){
-      if(mom.depth() != dad.depth() || sis.depth() != mom.depth()){
-	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
-	return nc;
+
+    if (sis.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE)
+    {
+      if (mom.depth() != dad.depth() || sis.depth() != mom.depth())
+      {
+        GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
+        return nc;
       }
       sitez = momsitez = dadsitez = GARandomInt(0, mom.depth());
       lenz = momlenz = dadlenz = mom.depth() - momsitez;
     }
-    else{
+    else
+    {
       momsitez = GARandomInt(0, mom.depth());
       dadsitez = GARandomInt(0, dad.depth());
       momlenz = mom.depth() - momsitez;
@@ -995,75 +1088,77 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       lenz = GAMin(momlenz, dadlenz);
     }
 
-    sis.resize(sitex+lenx, sitey+leny, sitez+lenz);
+    sis.resize(sitex + lenx, sitey + leny, sitez + lenz);
 
-    if(GARandomBit()){
-      sis.copy(mom, 
-	       0, 0, 0, 
-	       momsitex-sitex, momsitey-sitey, momsitez-sitez,
-	       sitex, sitey, sitez);
-      sis.copy(dad,
-	       sitex, 0, 0,
-	       dadsitex, dadsitey-sitey, dadsitez-sitez,
-	       lenx, sitey, sitez);
-      sis.copy(dad,
-	       0, sitey, 0,
-	       dadsitex-sitex, dadsitey, dadsitez-sitez,
-	       sitex, leny, sitez);
+    if (GARandomBit())
+    {
       sis.copy(mom,
-	       sitex, sitey, 0,
-	       momsitex, momsitey, momsitez-sitez,
-	       lenx, leny, sitez);
-      sis.copy(dad, 
-	       0, 0, sitez, 
-	       dadsitex-sitex, dadsitey-sitey, dadsitez,
-	       sitex, sitey, lenz);
-      sis.copy(mom,
-	       sitex, 0, sitez,
-	       momsitex, momsitey-sitey, momsitez,
-	       lenx, sitey, lenz);
-      sis.copy(mom,
-	       0, sitey, sitez,
-	       momsitex-sitex, momsitey, momsitez,
-	       sitex, leny, lenz);
+               0, 0, 0,
+               momsitex - sitex, momsitey - sitey, momsitez - sitez,
+               sitex, sitey, sitez);
       sis.copy(dad,
-	       sitex, sitey, sitez,
-	       dadsitex, dadsitey, dadsitez,
-	       lenx, leny, lenz);
+               sitex, 0, 0,
+               dadsitex, dadsitey - sitey, dadsitez - sitez,
+               lenx, sitey, sitez);
+      sis.copy(dad,
+               0, sitey, 0,
+               dadsitex - sitex, dadsitey, dadsitez - sitez,
+               sitex, leny, sitez);
+      sis.copy(mom,
+               sitex, sitey, 0,
+               momsitex, momsitey, momsitez - sitez,
+               lenx, leny, sitez);
+      sis.copy(dad,
+               0, 0, sitez,
+               dadsitex - sitex, dadsitey - sitey, dadsitez,
+               sitex, sitey, lenz);
+      sis.copy(mom,
+               sitex, 0, sitez,
+               momsitex, momsitey - sitey, momsitez,
+               lenx, sitey, lenz);
+      sis.copy(mom,
+               0, sitey, sitez,
+               momsitex - sitex, momsitey, momsitez,
+               sitex, leny, lenz);
+      sis.copy(dad,
+               sitex, sitey, sitez,
+               dadsitex, dadsitey, dadsitez,
+               lenx, leny, lenz);
     }
-    else{
-      sis.copy(dad, 
-	       0, 0, 0, 
-	       dadsitex-sitex, dadsitey-sitey, dadsitez-sitez,
-	       sitex, sitey, sitez);
-      sis.copy(mom,
-	       sitex, 0, 0,
-	       momsitex, momsitey-sitey, momsitez-sitez,
-	       lenx, sitey, sitez);
-      sis.copy(mom,
-	       0, sitey, 0,
-	       momsitex-sitex, momsitey, momsitez-sitez,
-	       sitex, leny, sitez);
+    else
+    {
       sis.copy(dad,
-	       sitex, sitey, 0,
-	       dadsitex, dadsitey, dadsitez-sitez,
-	       lenx, leny, sitez);
-      sis.copy(mom, 
-	       0, 0, sitez, 
-	       momsitex-sitex, momsitey-sitey, momsitez,
-	       sitex, sitey, lenz);
-      sis.copy(dad,
-	       sitex, 0, sitez,
-	       dadsitex, dadsitey-sitey, dadsitez,
-	       lenx, sitey, lenz);
-      sis.copy(dad,
-	       0, sitey, sitez,
-	       dadsitex-sitex, dadsitey, dadsitez,
-	       sitex, leny, lenz);
+               0, 0, 0,
+               dadsitex - sitex, dadsitey - sitey, dadsitez - sitez,
+               sitex, sitey, sitez);
       sis.copy(mom,
-	       sitex, sitey, sitez,
-	       momsitex, momsitey, momsitez,
-	       lenx, leny, lenz);
+               sitex, 0, 0,
+               momsitex, momsitey - sitey, momsitez - sitez,
+               lenx, sitey, sitez);
+      sis.copy(mom,
+               0, sitey, 0,
+               momsitex - sitex, momsitey, momsitez - sitez,
+               sitex, leny, sitez);
+      sis.copy(dad,
+               sitex, sitey, 0,
+               dadsitex, dadsitey, dadsitez - sitez,
+               lenx, leny, sitez);
+      sis.copy(mom,
+               0, 0, sitez,
+               momsitex - sitex, momsitey - sitey, momsitez,
+               sitex, sitey, lenz);
+      sis.copy(dad,
+               sitex, 0, sitez,
+               dadsitex, dadsitey - sitey, dadsitez,
+               lenx, sitey, lenz);
+      sis.copy(dad,
+               0, sitey, sitez,
+               dadsitex - sitex, dadsitey, dadsitez,
+               sitex, leny, lenz);
+      sis.copy(mom,
+               sitex, sitey, sitez,
+               momsitex, momsitey, momsitez,
+               lenx, leny, lenz);
     }
 
     nc = 1;

--- a/Global_dynamic_MPFA/source/ga-mpi/GAListGenome.C
+++ b/Global_dynamic_MPFA/source/ga-mpi/GAListGenome.C
@@ -17,7 +17,7 @@
 #include <ga-mpi/GAMask.h>
 #include <ga-mpi/garandom.h>
 
-template <class T> int 
+template <class T> int
 GAListIsHole(const GAListGenome<T>&, const GAListGenome<T>&, int, int, int);
 
 
@@ -30,8 +30,8 @@ GAListGenome<T>::className() const {return "GAListGenome";}
 template <class T> int
 GAListGenome<T>::classID() const {return GAID::ListGenome;}
 
-template <class T> 
-GAListGenome<T>::GAListGenome(GAGenome::Evaluator f, void * u) : 
+template <class T>
+GAListGenome<T>::GAListGenome(GAGenome::Evaluator f, void * u) :
 GAList<T>(),
 GAGenome(DEFAULT_LIST_INITIALIZER,
 	 DEFAULT_LIST_MUTATOR,
@@ -42,8 +42,8 @@ GAGenome(DEFAULT_LIST_INITIALIZER,
 }
 
 
-template <class T> 
-GAListGenome<T>::GAListGenome(const GAListGenome<T> & orig) : 
+template <class T>
+GAListGenome<T>::GAListGenome(const GAListGenome<T> & orig) :
 GAList<T>(),
 GAGenome() {
   GAListGenome<T>::copy(orig);
@@ -76,10 +76,10 @@ GAListGenome<T>::copy(const GAGenome & orig){
 
 #ifdef GALIB_USE_STREAMS
 // Traverse the list (breadth-first) and dump the contents as best we can to
-// the stream.  We don't try to write the contents of the nodes - we simply 
+// the stream.  We don't try to write the contents of the nodes - we simply
 // write a . for each node in the list.
 template <class T> int
-GAListGenome<T>::write(STD_OSTREAM & os) const 
+GAListGenome<T>::write(STD_OSTREAM & os) const
 {
   os << "node       next       prev       contents\n";
   if(!this->hd) return 0;;
@@ -105,7 +105,7 @@ GAListGenome<T>::write(STD_OSTREAM & os) const
 // then you have nothing to worry about.
 //   Neither of these operators affects the internal iterator of either
 // list genome in any way.
-template <class T> int 
+template <class T> int
 GAListGenome<T>::equal(const GAGenome & c) const
 {
   if(this == &c) return 1;
@@ -136,14 +136,14 @@ GAListGenome<T>::equal(const GAGenome & c) const
 ---------------------------------------------------------------------------- */
 // Mutate a list by nuking nodes.  Any node has a pmut chance of getting nuked.
 // This is actually kind of bogus for the second part of the if clause (if nMut
-// is greater than or equal to 1).  Nodes end up having more than pmut 
+// is greater than or equal to 1).  Nodes end up having more than pmut
 // probability of getting nuked.
 //   After the mutation the iterator is left at the head of the list.
 template <class T> int
 GAListGenome<T>::DestructiveMutator(GAGenome & c, float pmut)
 {
   GAListGenome<T> &child=DYN_CAST(GAListGenome<T> &, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return 0;
 
   n = child.size();
@@ -171,14 +171,14 @@ GAListGenome<T>::DestructiveMutator(GAGenome & c, float pmut)
 
 // Mutate a list by swapping two nodes.  Any node has a pmut chance of getting
 // swapped, and the swap could happen to any other node.  And in the case of
-// nMut < 1, the swap may generate a swap partner that is the same node, in 
+// nMut < 1, the swap may generate a swap partner that is the same node, in
 // which case no swap occurs (we don't check).
 //   After the mutation the iterator is left at the head of the list.
 template <class T> int
 GAListGenome<T>::SwapMutator(GAGenome & c, float pmut)
 {
   GAListGenome<T> &child=DYN_CAST(GAListGenome<T> &, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return 0;
 
   n = child.size();
@@ -205,7 +205,7 @@ GAListGenome<T>::SwapMutator(GAGenome & c, float pmut)
 
 // This comparator returns the number of elements that the two lists have
 // in common (both in position and in value).  If they are different lengths
-// then we just say they are completely different.  This is probably barely 
+// then we just say they are completely different.  This is probably barely
 // adequate for most applications - we really should give more credit for
 // nodes that are the same but in different positions.  But that would be
 // pretty nasty to compute.
@@ -213,7 +213,7 @@ GAListGenome<T>::SwapMutator(GAGenome & c, float pmut)
 // which to compare this diversity measure.  Its kind of hard to define this
 // one in a general way...
 template <class T> float
-GAListGenome<T>::NodeComparator(const GAGenome& a, const GAGenome& b) 
+GAListGenome<T>::NodeComparator(const GAGenome& a, const GAGenome& b)
 {
   if(&a == &b) return 0;
   const GAListGenome<T>& sis=DYN_CAST(const GAListGenome<T>&, a);
@@ -244,7 +244,7 @@ GAListGenome<T>::NodeComparator(const GAGenome& a, const GAGenome& b)
 
 #define SWAP(a,b) {unsigned int tmp=a; a=b; b=tmp;}
 
-// This crossover picks a site between nodes in each parent.  It is the same 
+// This crossover picks a site between nodes in each parent.  It is the same
 // as single point crossover on a resizeable binary string genome.  The site
 // in the mother is not necessarily the same as the site in the father!
 //   When we pick a crossover site, it is between nodes of the list (otherwise
@@ -253,7 +253,7 @@ GAListGenome<T>::NodeComparator(const GAGenome& a, const GAGenome& b)
 // whereas the cross site possibilities are numbered from 0 to size, inclusive.
 // This means we have to map the site to the list to determine whether an
 // insertion should occur before or after a node.
-//   We first copy the mother into the child (this deletes whatever contents 
+//   We first copy the mother into the child (this deletes whatever contents
 // were in the child originally).  Then we clone the father from the cross site
 // to the end of the list.  Then we delete the tail of the child from the
 // mother's cross site to the end of the list.  Finally, we insert the clone
@@ -265,7 +265,7 @@ GAListGenome<T>::NodeComparator(const GAGenome& a, const GAGenome& b)
 // do better by copying only what we need of the mother.
 template <class T> int
 GAListGenome<T>::
-OnePointCrossover(const GAGenome& p1, const GAGenome& p2, 
+OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 		  GAGenome* c1, GAGenome* c2){
   const GAListGenome<T> &mom=DYN_CAST(const GAListGenome<T> &, p1);
   const GAListGenome<T> &dad=DYN_CAST(const GAListGenome<T> &, p2);
@@ -330,13 +330,13 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 //   This version of the partial match crossover uses objects that are multiply
 // instantiated - each list genome contains its own objects in its nodes.
 // The operator== method must be defined on the object for this implementation
-// to work!  In this case, the 'object' is an int, so we're OK.  If you are 
+// to work!  In this case, the 'object' is an int, so we're OK.  If you are
 // putting your own objects in the nodes, be sure you have operator== defined
 // for your object.  You must also have operator!= defined for your object.  We
 // do not do any assignments, so operator= and/or copy is not required.
 //   We assume that none of the nodes will return a NULL pointer.  Also assume
 // that the cross site has been selected properly.
-//   First we make a copy of the mother.  Then we loop through the match 
+//   First we make a copy of the mother.  Then we loop through the match
 // section and try to swap each element in the child's match section with its
 // partner (as defined by the current node in the father's match section).
 //   Mirroring will work the same way - just swap mom & dad and you're all set.

--- a/Global_dynamic_MPFA/source/ga-mpi/GARealGenome.C
+++ b/Global_dynamic_MPFA/source/ga-mpi/GARealGenome.C
@@ -10,35 +10,43 @@
 ---------------------------------------------------------------------------- */
 #include <ga-mpi/GARealGenome.h>
 
-
 // We must also specialize the allele set so that the alleles are handled
 // properly.  Be sure to handle bounds correctly whether we are discretized
-// or continuous.  Handle the case where someone sets stupid bounds that 
+// or continuous.  Handle the case where someone sets stupid bounds that
 // might cause an infinite loop for exclusive bounds.
-template <> float
-GAAlleleSet<float>::allele() const {
+template <>
+float GAAlleleSet<float>::allele() const
+{
   float value = 0.0;
-  if(core->type == GAAllele::ENUMERATED)
-    value = core->a[GARandomInt(0, core->sz-1)];
-  else if(core->type == GAAllele::DISCRETIZED){
+  if (core->type == GAAllele::ENUMERATED)
+    value = core->a[GARandomInt(0, core->sz - 1)];
+  else if (core->type == GAAllele::DISCRETIZED)
+  {
     float n = (core->a[1] - core->a[0]) / core->a[2];
     int m = (int)n;
-    if(core->lowerb == GAAllele::EXCLUSIVE) m -= 1;
-    if(core->upperb == GAAllele::EXCLUSIVE) m -= 1;
-    value = core->a[0] + GARandomInt(0,(int)m) * core->a[2];
-    if(core->lowerb == GAAllele::EXCLUSIVE) value += core->a[2];
+    if (core->lowerb == GAAllele::EXCLUSIVE)
+      m -= 1;
+    if (core->upperb == GAAllele::EXCLUSIVE)
+      m -= 1;
+    value = core->a[0] + GARandomInt(0, (int)m) * core->a[2];
+    if (core->lowerb == GAAllele::EXCLUSIVE)
+      value += core->a[2];
   }
-  else{
-    if(core->a[0] == core->a[1] && 
-       core->lowerb == GAAllele::EXCLUSIVE && 
-       core->upperb == GAAllele::EXCLUSIVE) {
+  else
+  {
+    if (core->a[0] == core->a[1] &&
+        core->lowerb == GAAllele::EXCLUSIVE &&
+        core->upperb == GAAllele::EXCLUSIVE)
+    {
       value = core->a[0];
     }
-    else {
-      do {
-	value = GARandomFloat(core->a[0], core->a[1]);
+    else
+    {
+      do
+      {
+        value = GARandomFloat(core->a[0], core->a[1]);
       } while ((core->lowerb == GAAllele::EXCLUSIVE && value == core->a[0]) ||
-	       (core->upperb == GAAllele::EXCLUSIVE && value == core->a[1]));
+               (core->upperb == GAAllele::EXCLUSIVE && value == core->a[1]));
     }
   }
   return value;
@@ -47,42 +55,47 @@ GAAlleleSet<float>::allele() const {
 // If someone asks for a discretized item that is beyond the bounds, give them
 // one of the bounds.  If they ask for allele item when there is no
 // discretization or enumeration, then error and return lower bound.
-template <> float
-GAAlleleSet<float>::allele(unsigned int i) const {
+template <>
+float GAAlleleSet<float>::allele(unsigned int i) const
+{
   float value = 0.0;
-  if(core->type == GAAllele::ENUMERATED)
+  if (core->type == GAAllele::ENUMERATED)
     value = core->a[i % core->sz];
-  else if(core->type == GAAllele::DISCRETIZED){
-    float n = (core->a[1] - core->a[0])/core->a[2];
-    unsigned int m = (unsigned int)n;            // what about bogus limits?
-    if(core->lowerb == GAAllele::EXCLUSIVE) m -= 1;
-    if(core->upperb == GAAllele::EXCLUSIVE) m -= 1;
-    if(i > m) i = (int)m;
-    value = core->a[0] + i*core->a[2];
-    if(core->lowerb == GAAllele::EXCLUSIVE) value += core->a[2];
+  else if (core->type == GAAllele::DISCRETIZED)
+  {
+    float n = (core->a[1] - core->a[0]) / core->a[2];
+    unsigned int m = (unsigned int)n; // what about bogus limits?
+    if (core->lowerb == GAAllele::EXCLUSIVE)
+      m -= 1;
+    if (core->upperb == GAAllele::EXCLUSIVE)
+      m -= 1;
+    if (i > m)
+      i = (int)m;
+    value = core->a[0] + i * core->a[2];
+    if (core->lowerb == GAAllele::EXCLUSIVE)
+      value += core->a[2];
   }
-  else{
+  else
+  {
     GAErr(GA_LOC, "GAAlleleSet", "allele", gaErrNoAlleleIndex);
     value = core->a[0];
   }
   return value;
 }
 
-
-
-
-
 // now the specialization of the genome itself.
 
-template <> const char * 
-GA1DArrayAlleleGenome<float>::className() const {return "GARealGenome";}
-template <> int 
-GA1DArrayAlleleGenome<float>::classID() const {return GAID::FloatGenome;}
+template <>
+const char *
+GA1DArrayAlleleGenome<float>::className() const { return "GARealGenome"; }
+template <>
+int GA1DArrayAlleleGenome<float>::classID() const { return GAID::FloatGenome; }
 
-template <> GA1DArrayAlleleGenome<float>::
-GA1DArrayAlleleGenome(unsigned int length, const GAAlleleSet<float> & s,
-		      GAGenome::Evaluator f, void * u) :
-GA1DArrayGenome<float>(length, f, u){
+template <>
+GA1DArrayAlleleGenome<float>::
+    GA1DArrayAlleleGenome(unsigned int length, const GAAlleleSet<float> &s,
+                          GAGenome::Evaluator f, void *u) : GA1DArrayGenome<float>(length, f, u)
+{
   naset = 1;
   aset = new GAAlleleSet<float>[1];
   aset[0] = s;
@@ -93,13 +106,14 @@ GA1DArrayGenome<float>(length, f, u){
   crossover(DEFAULT_REAL_CROSSOVER);
 }
 
-template <> GA1DArrayAlleleGenome<float>::
-GA1DArrayAlleleGenome(const GAAlleleSetArray<float> & sa,
-		      GAGenome::Evaluator f, void * u) :
-GA1DArrayGenome<float>(sa.size(), f, u){
+template <>
+GA1DArrayAlleleGenome<float>::
+    GA1DArrayAlleleGenome(const GAAlleleSetArray<float> &sa,
+                          GAGenome::Evaluator f, void *u) : GA1DArrayGenome<float>(sa.size(), f, u)
+{
   naset = sa.size();
   aset = new GAAlleleSet<float>[naset];
-  for(int i=0; i<naset; i++)
+  for (int i = 0; i < naset; i++)
     aset[i] = sa.set(i);
 
   initializer(DEFAULT_REAL_INITIALIZER);
@@ -108,25 +122,28 @@ GA1DArrayGenome<float>(sa.size(), f, u){
   crossover(DEFAULT_REAL_CROSSOVER);
 }
 
-template <> 
-GA1DArrayAlleleGenome<float>::~GA1DArrayAlleleGenome(){
-  delete [] aset;
+template <>
+GA1DArrayAlleleGenome<float>::~GA1DArrayAlleleGenome()
+{
+  delete[] aset;
 }
-
-
 
 #ifdef GALIB_USE_STREAMS
 // The read specialization takes in each number and stuffs it into the array.
-template <> int
-GA1DArrayAlleleGenome<float>::read(STD_ISTREAM & is) {
-  unsigned int i=0;
+template <>
+int GA1DArrayAlleleGenome<float>::read(STD_ISTREAM &is)
+{
+  unsigned int i = 0;
   float val;
-  do{
+  do
+  {
     is >> val;
-    if(!is.fail()) gene(i++, val);
-  } while(!is.fail() && !is.eof() && i < nx);
+    if (!is.fail())
+      gene(i++, val);
+  } while (!is.fail() && !is.eof() && i < nx);
 
-  if(is.eof() && i < nx){
+  if (is.eof() && i < nx)
+  {
     GAErr(GA_LOC, className(), "read", gaErrUnexpectedEOF);
     is.clear(STD_IOS_BADBIT | is.rdstate());
     return 1;
@@ -137,97 +154,100 @@ GA1DArrayAlleleGenome<float>::read(STD_ISTREAM & is) {
 // No need to specialize the write method.
 #endif
 
-
-
-
-
-
-
 /* ----------------------------------------------------------------------------
    Operator specializations
 ---------------------------------------------------------------------------- */
 // The Gaussian mutator picks a new value based on a Gaussian distribution
 // around the current value.  We respect the bounds (if any).
-//*** need to figure out a way to make the stdev other than 1.0 
-int 
-GARealGaussianMutator(GAGenome& g, float pmut){
-  GA1DArrayAlleleGenome<float> &child=
-    DYN_CAST(GA1DArrayAlleleGenome<float> &, g);
-  register int n, i;
-  if(pmut <= 0.0) return(0);
+//*** need to figure out a way to make the stdev other than 1.0
+int GARealGaussianMutator(GAGenome &g, float pmut)
+{
+  GA1DArrayAlleleGenome<float> &child =
+      DYN_CAST(GA1DArrayAlleleGenome<float> &, g);
+  int n, i;
+  if (pmut <= 0.0)
+    return (0);
 
   float nMut = pmut * (float)(child.length());
-  int length = child.length()-1;
-  if(nMut < 1.0){		// we have to do a flip test on each element
+  int length = child.length() - 1;
+  if (nMut < 1.0)
+  { // we have to do a flip test on each element
     nMut = 0;
-    for(i=length; i>=0; i--){
+    for (i = length; i >= 0; i--)
+    {
       float value = child.gene(i);
-      if(GAFlipCoin(pmut)){
-	if(child.alleleset(i).type() == GAAllele::ENUMERATED ||
-	   child.alleleset(i).type() == GAAllele::DISCRETIZED)
-	  value = child.alleleset(i).allele();
-	else if(child.alleleset(i).type() == GAAllele::BOUNDED){
-	  value += GAUnitGaussian();
-	  value = GAMax(child.alleleset(i).lower(), value);
-	  value = GAMin(child.alleleset(i).upper(), value);
-	}
-	child.gene(i, value);
-	nMut++;
+      if (GAFlipCoin(pmut))
+      {
+        if (child.alleleset(i).type() == GAAllele::ENUMERATED ||
+            child.alleleset(i).type() == GAAllele::DISCRETIZED)
+          value = child.alleleset(i).allele();
+        else if (child.alleleset(i).type() == GAAllele::BOUNDED)
+        {
+          value += GAUnitGaussian();
+          value = GAMax(child.alleleset(i).lower(), value);
+          value = GAMin(child.alleleset(i).upper(), value);
+        }
+        child.gene(i, value);
+        nMut++;
       }
     }
   }
-  else{				// only mutate the ones we need to
-    for(n=0; n<nMut; n++){
-      int idx = GARandomInt(0,length);
+  else
+  { // only mutate the ones we need to
+    for (n = 0; n < nMut; n++)
+    {
+      int idx = GARandomInt(0, length);
       float value = child.gene(idx);
-      if(child.alleleset(idx).type() == GAAllele::ENUMERATED ||
-	 child.alleleset(idx).type() == GAAllele::DISCRETIZED)
-	value = child.alleleset(idx).allele();
-      else if(child.alleleset(idx).type() == GAAllele::BOUNDED){
-	value += GAUnitGaussian();
-	value = GAMax(child.alleleset(idx).lower(), value);
-	value = GAMin(child.alleleset(idx).upper(), value);
+      if (child.alleleset(idx).type() == GAAllele::ENUMERATED ||
+          child.alleleset(idx).type() == GAAllele::DISCRETIZED)
+        value = child.alleleset(idx).allele();
+      else if (child.alleleset(idx).type() == GAAllele::BOUNDED)
+      {
+        value += GAUnitGaussian();
+        value = GAMax(child.alleleset(idx).lower(), value);
+        value = GAMin(child.alleleset(idx).upper(), value);
       }
       child.gene(idx, value);
     }
   }
-  return((int)nMut);
+  return ((int)nMut);
 }
-
 
 // Arithmetic crossover generates a new value that is the average of the parent
 // values.  Note that this means both children in a sexual crossover will be
 // identical.  If parents are not the same length, the extra elements are not
 // set!  You might want to add some noise to this so that both children are not
 // the same...
-int 
-GARealArithmeticCrossover(const GAGenome& p1, const GAGenome& p2,
-			  GAGenome* c1, GAGenome* c2) {
-  const GA1DArrayGenome<float> &mom=
-    DYN_CAST(const GA1DArrayGenome<float> &, p1);
-  const GA1DArrayGenome<float> &dad=
-    DYN_CAST(const GA1DArrayGenome<float> &, p2);
+int GARealArithmeticCrossover(const GAGenome &p1, const GAGenome &p2,
+                              GAGenome *c1, GAGenome *c2)
+{
+  const GA1DArrayGenome<float> &mom =
+      DYN_CAST(const GA1DArrayGenome<float> &, p1);
+  const GA1DArrayGenome<float> &dad =
+      DYN_CAST(const GA1DArrayGenome<float> &, p2);
 
-  int n=0;
+  int n = 0;
 
-  if(c1 && c2){
-    GA1DArrayGenome<float> &sis=DYN_CAST(GA1DArrayGenome<float> &, *c1);
-    GA1DArrayGenome<float> &bro=DYN_CAST(GA1DArrayGenome<float> &, *c2);
+  if (c1 && c2)
+  {
+    GA1DArrayGenome<float> &sis = DYN_CAST(GA1DArrayGenome<float> &, *c1);
+    GA1DArrayGenome<float> &bro = DYN_CAST(GA1DArrayGenome<float> &, *c2);
 
     int len = GAMax(mom.length(), dad.length());
-    for(int i=0; i<len; i++) {
+    for (int i = 0; i < len; i++)
+    {
       sis.gene(i, 0.5 * (mom.gene(i) + dad.gene(i)));
       bro.gene(i, 0.5 * (mom.gene(i) + dad.gene(i)));
     }
     n = 2;
   }
-  else if(c1 || c2){
-    GA1DArrayGenome<float> &sis = (c1 ? 
-				   DYN_CAST(GA1DArrayGenome<float> &, *c1) : 
-				   DYN_CAST(GA1DArrayGenome<float> &, *c2));
+  else if (c1 || c2)
+  {
+    GA1DArrayGenome<float> &sis = (c1 ? DYN_CAST(GA1DArrayGenome<float> &, *c1) : DYN_CAST(GA1DArrayGenome<float> &, *c2));
 
     int len = GAMax(mom.length(), dad.length());
-    for(int i=0; i<len; i++) {
+    for (int i = 0; i < len; i++)
+    {
       sis.gene(i, 0.5 * (mom.gene(i) + dad.gene(i)));
     }
     n = 1;
@@ -236,52 +256,53 @@ GARealArithmeticCrossover(const GAGenome& p1, const GAGenome& p2,
   return n;
 }
 
-
 // Blend crossover generates a new value based on the interval between parents.
 // We generate a uniform distribution based on the distance between parent
 // values, then choose the child value based upon that distribution.
-int 
-GARealBlendCrossover(const GAGenome& p1, const GAGenome& p2,
-		     GAGenome* c1, GAGenome* c2) {
-  const GA1DArrayGenome<float> &mom=
-    DYN_CAST(const GA1DArrayGenome<float> &, p1);
-  const GA1DArrayGenome<float> &dad=
-    DYN_CAST(const GA1DArrayGenome<float> &, p2);
+int GARealBlendCrossover(const GAGenome &p1, const GAGenome &p2,
+                         GAGenome *c1, GAGenome *c2)
+{
+  const GA1DArrayGenome<float> &mom =
+      DYN_CAST(const GA1DArrayGenome<float> &, p1);
+  const GA1DArrayGenome<float> &dad =
+      DYN_CAST(const GA1DArrayGenome<float> &, p2);
 
-  int n=0;
+  int n = 0;
 
-  if(c1 && c2){
-    GA1DArrayGenome<float> &sis=DYN_CAST(GA1DArrayGenome<float> &, *c1);
-    GA1DArrayGenome<float> &bro=DYN_CAST(GA1DArrayGenome<float> &, *c2);
+  if (c1 && c2)
+  {
+    GA1DArrayGenome<float> &sis = DYN_CAST(GA1DArrayGenome<float> &, *c1);
+    GA1DArrayGenome<float> &bro = DYN_CAST(GA1DArrayGenome<float> &, *c2);
 
     int len = GAMax(mom.length(), dad.length());
-    for(int i=0; i<len; i++) {
+    for (int i = 0; i < len; i++)
+    {
       float dist = 0;
-      if(mom.gene(i) > dad.gene(i)) 
-	dist = mom.gene(i) - dad.gene(i);
-      else 
-	dist = dad.gene(i) - mom.gene(i);
-      float lo = (GAMin(mom.gene(i), dad.gene(i))) - 0.5*dist;
-      float hi = (GAMax(mom.gene(i), dad.gene(i))) + 0.5*dist;
+      if (mom.gene(i) > dad.gene(i))
+        dist = mom.gene(i) - dad.gene(i);
+      else
+        dist = dad.gene(i) - mom.gene(i);
+      float lo = (GAMin(mom.gene(i), dad.gene(i))) - 0.5 * dist;
+      float hi = (GAMax(mom.gene(i), dad.gene(i))) + 0.5 * dist;
       sis.gene(i, GARandomFloat(lo, hi));
       bro.gene(i, GARandomFloat(lo, hi));
     }
     n = 2;
   }
-  else if(c1 || c2){
-    GA1DArrayGenome<float> &sis = (c1 ?
-				   DYN_CAST(GA1DArrayGenome<float> &, *c1) :
-				   DYN_CAST(GA1DArrayGenome<float> &, *c2));
+  else if (c1 || c2)
+  {
+    GA1DArrayGenome<float> &sis = (c1 ? DYN_CAST(GA1DArrayGenome<float> &, *c1) : DYN_CAST(GA1DArrayGenome<float> &, *c2));
 
     int len = GAMax(mom.length(), dad.length());
-    for(int i=0; i<len; i++) {
+    for (int i = 0; i < len; i++)
+    {
       float dist = 0;
-      if(mom.gene(i) > dad.gene(i)) 
-	dist = mom.gene(i) - dad.gene(i);
-      else 
-	dist = dad.gene(i) - mom.gene(i);
-      float lo = (GAMin(mom.gene(i), dad.gene(i))) - 0.5*dist;
-      float hi = (GAMax(mom.gene(i), dad.gene(i))) + 0.5*dist;
+      if (mom.gene(i) > dad.gene(i))
+        dist = mom.gene(i) - dad.gene(i);
+      else
+        dist = dad.gene(i) - mom.gene(i);
+      float lo = (GAMin(mom.gene(i), dad.gene(i))) - 0.5 * dist;
+      float hi = (GAMax(mom.gene(i), dad.gene(i))) + 0.5 * dist;
       sis.gene(i, GARandomFloat(lo, hi));
     }
     n = 1;
@@ -290,15 +311,11 @@ GARealBlendCrossover(const GAGenome& p1, const GAGenome& p2,
   return n;
 }
 
-
-
-
-
 // force instantiations of this genome type.
 //
 // These must be included _after_ the specializations because some compilers
 // get all wigged out about the declaration/specialization order.  Note that
-// some compilers require a syntax different than others when forcing the 
+// some compilers require a syntax different than others when forcing the
 // instantiation (i.e. GNU wants the 'template class', borland does not).
 #ifndef GALIB_USE_AUTO_INST
 #include <ga-mpi/GAAllele.C>

--- a/Global_dynamic_MPFA/source/ga-mpi/GATreeGenome.C
+++ b/Global_dynamic_MPFA/source/ga-mpi/GATreeGenome.C
@@ -25,7 +25,7 @@ template <class T> int
 GATreeGenome<T>::classID() const {return GAID::TreeGenome;}
 
 template <class T>
-GATreeGenome<T>::GATreeGenome(GAGenome::Evaluator f, void * u) : 
+GATreeGenome<T>::GATreeGenome(GAGenome::Evaluator f, void * u) :
 GATree<T>(),
 GAGenome(DEFAULT_TREE_INITIALIZER,
 	 DEFAULT_TREE_MUTATOR,
@@ -37,7 +37,7 @@ GAGenome(DEFAULT_TREE_INITIALIZER,
 
 
 template <class T>
-GATreeGenome<T>::GATreeGenome(const GATreeGenome<T> & orig) : 
+GATreeGenome<T>::GATreeGenome(const GATreeGenome<T> & orig) :
 GATree<T>(),
 GAGenome() {
   GATreeGenome<T>::copy(orig);
@@ -70,7 +70,7 @@ GATreeGenome<T>::copy(const GAGenome & orig) {
 
 #ifdef GALIB_USE_STREAMS
 // Traverse the tree (breadth-first) and dump the contents as best we can to
-// the stream.  We don't try to write the contents of the nodes - we simply 
+// the stream.  We don't try to write the contents of the nodes - we simply
 // write a . for each node in the tree.
 //   We allocate space for x,y coord pair for each node in the tree.  Then we
 // do a depth-first traversal of the tree and assign coords to the nodes in the
@@ -102,7 +102,7 @@ _tt(STD_OSTREAM & os, GANode<T> * n)
 }
 
 template <class T> int
-GATreeGenome<T>::write(STD_OSTREAM & os) const 
+GATreeGenome<T>::write(STD_OSTREAM & os) const
 {
   os << "node       parent     child      next       prev       contents\n";
   _tt(os, (GANode<T> *)(this->rt));
@@ -111,7 +111,7 @@ GATreeGenome<T>::write(STD_OSTREAM & os) const
 #endif
 
 
-template <class T> int  
+template <class T> int
 GATreeGenome<T>::equal(const GAGenome & c) const
 {
   if(this == &c) return 1;
@@ -140,7 +140,7 @@ template <class T> int
 GATreeGenome<T>::DestructiveMutator(GAGenome & c, float pmut)
 {
   GATreeGenome<T> &child=DYN_CAST(GATreeGenome<T> &, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return 0;
 
   n = child.size();
@@ -169,14 +169,14 @@ GATreeGenome<T>::DestructiveMutator(GAGenome & c, float pmut)
 // This is a rearranging mutation operator.  It randomly picks two nodes in the
 // tree and swaps them.  Any node has a pmut chance of getting
 // swapped, and the swap could happen to any other node.  And in the case of
-// nMut < 1, the swap may generate a swap partner that is the same node, in 
+// nMut < 1, the swap may generate a swap partner that is the same node, in
 // which case no swap occurs (we don't check).
 //   After the mutation the iterator is left at the root of the tree.
 template <class T> int
 GATreeGenome<T>::SwapNodeMutator(GAGenome & c, float pmut)
 {
   GATreeGenome<T> &child=DYN_CAST(GATreeGenome<T> &, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return 0;
 
   n = child.size();
@@ -214,7 +214,7 @@ template <class T> int
 GATreeGenome<T>::SwapSubtreeMutator(GAGenome & c, float pmut)
 {
   GATreeGenome<T> &child=DYN_CAST(GATreeGenome<T> &, c);
-  register int n, i;
+  int n, i;
   int a, b;
   if(pmut <= 0.0) return 0;
 
@@ -247,7 +247,7 @@ GATreeGenome<T>::SwapSubtreeMutator(GAGenome & c, float pmut)
 // We use the recursive tree function to compare the tree structures.  This
 // does not compare the contents of the nodes.
 template <class T> float
-GATreeGenome<T>::TopologyComparator(const GAGenome& a, const GAGenome& b) 
+GATreeGenome<T>::TopologyComparator(const GAGenome& a, const GAGenome& b)
 {
   if(&a == &b) return 0;
   const GATreeGenome<T>& sis=DYN_CAST(const GATreeGenome<T>&, a);
@@ -277,7 +277,7 @@ GATreeGenome<T>::TopologyComparator(const GAGenome& a, const GAGenome& b)
 //     do the check to see if the crossover site is valid.
 template <class T> int
 GATreeGenome<T>::
-OnePointCrossover(const GAGenome& p1, const GAGenome& p2, 
+OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 		  GAGenome* c1, GAGenome* c2){
   const GATreeGenome<T> &mom=DYN_CAST(const GATreeGenome<T> &, p1);
   const GATreeGenome<T> &dad=DYN_CAST(const GATreeGenome<T> &, p2);

--- a/Global_static_MPFA/source/evolver.cpp
+++ b/Global_static_MPFA/source/evolver.cpp
@@ -11,7 +11,7 @@
 // For shared memory management
 #include <sys/mman.h>
 
-#include <ctime> // For clock()
+#include <ctime>  // For clock()
 #include <chrono> // For clock()
 #include <mpi.h>
 
@@ -31,12 +31,12 @@
 #include <source/CPFA/CPFA_loop_functions.h>
 
 // For timing
-#include <ctime> // For clock()
+#include <ctime>  // For clock()
 #include <chrono> // For clock()
 
 // For shared variable between child and parent process
-#include  <sys/ipc.h>
-#include  <sys/shm.h>
+#include <sys/ipc.h>
+#include <sys/shm.h>
 
 float objective(GAGenome &);
 float LaunchARGoS(GAGenome &);
@@ -44,11 +44,11 @@ float LaunchARGoS(GAGenome &);
 int mpi_tasks, mpi_rank;
 
 int elitism = 0;
-int n_trials = 20; // used by the objective function
+int n_trials = 20;            // used by the objective function
 double mutation_stdev = 1.00; // Gaussian mutation stdev - will be scaled by possible range
 string experiment_path;
 
-void CPFAInitializer(GAGenome & c);
+void CPFAInitializer(GAGenome &c);
 int GARealGaussianMutatorStdev(GAGenome &, float);
 
 std::default_random_engine generator;
@@ -62,125 +62,124 @@ int main(int argc, char **argv)
   MPI_Init(&argc, &argv);
   MPI_Comm_size(MPI_COMM_WORLD, &mpi_tasks);
   MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
-                         
-  char hostname[1024];                                                                                                       
-  hostname[1023] = '\0';                                          
+
+  char hostname[1024];
+  hostname[1023] = '\0';
   gethostname(hostname, 1023);
-  
+
   double mutation_rate = 0.01;
   double crossover_rate = 0.01;
   int population_size = 10;
   int n_generations = 10;
 
-    char c='h';
+  char c = 'h';
   // Handle command line arguments
-  while ((c = getopt (argc, argv, "t:g:p:c:m:s:h:e:x:")) != -1)
+  while ((c = getopt(argc, argv, "t:g:p:c:m:s:h:e:x:")) != -1)
     switch (c)
-      {
-      case 'x':
-	experiment_path = optarg;
+    {
+    case 'x':
+      experiment_path = optarg;
       break;
-      case 't':
-	n_trials = atoi(optarg);
-	break;
-      case 'g':
-        n_generations = atoi(optarg);
-        break;
-      case 'p':
-        population_size = atoi(optarg);
-        break;
-      case 'm':
-        mutation_rate = strtod(optarg, NULL);
-	break;
-      case 'c':
-	crossover_rate = strtod(optarg, NULL);
-	break;
-      case 's':
-        mutation_stdev = strtod(optarg, NULL);
-	break;
-      case 'e':
-        elitism = atoi(optarg);
-	break;
-      case 'h':
-	printf("Usage: %s -p {population size} -g {number of generations} -t {number of trials} -c {crossover rate} -m {mutation rate} -s {mutation standard deviation} -e {elitism 0 or 1}", argv[0]);
-	break;
-      case '?':
-        if (optopt == 'p')
-          fprintf (stderr, "Option -%c requires an argument specifying the population size.\n", optopt);
-	else if (optopt == 'g')
-	  fprintf (stderr, "Option -%c requires an argument specifying the number of generations.\n", optopt);
-	else if (optopt == 't')
-	  fprintf (stderr, "Option -%c requires an argument specifying the number of trials.\n", optopt);
-	else if (optopt == 'c')
-	  fprintf (stderr, "Option -%c requires an argument specifying the crossover rate.\n", optopt);
-	else if (optopt == 'm')
-	  fprintf (stderr, "Option -%c requires an argument specifying the mutation rate.\n", optopt);
-	else if (optopt == 's')
-	  fprintf (stderr, "Option -%c requires an argument specifying the mutation standard deviation.\n", optopt);
-        else if (isprint (optopt))
-          fprintf (stderr, "Unknown option `-%c'.\n", optopt);
-        else
-          fprintf (stderr,
-                   "Unknown option character `\\x%x'.\n",
-                   optopt);
-        return 1;
-      default:
-	printf("Usage: %s -p {population size} -g {number of generations} -t {number of trials} -c {crossover rate} -m {mutation rate} -s {mutation standard deviation}", argv[0]);
-        abort ();
-      }
+    case 't':
+      n_trials = atoi(optarg);
+      break;
+    case 'g':
+      n_generations = atoi(optarg);
+      break;
+    case 'p':
+      population_size = atoi(optarg);
+      break;
+    case 'm':
+      mutation_rate = strtod(optarg, NULL);
+      break;
+    case 'c':
+      crossover_rate = strtod(optarg, NULL);
+      break;
+    case 's':
+      mutation_stdev = strtod(optarg, NULL);
+      break;
+    case 'e':
+      elitism = atoi(optarg);
+      break;
+    case 'h':
+      printf("Usage: %s -p {population size} -g {number of generations} -t {number of trials} -c {crossover rate} -m {mutation rate} -s {mutation standard deviation} -e {elitism 0 or 1}", argv[0]);
+      break;
+    case '?':
+      if (optopt == 'p')
+        fprintf(stderr, "Option -%c requires an argument specifying the population size.\n", optopt);
+      else if (optopt == 'g')
+        fprintf(stderr, "Option -%c requires an argument specifying the number of generations.\n", optopt);
+      else if (optopt == 't')
+        fprintf(stderr, "Option -%c requires an argument specifying the number of trials.\n", optopt);
+      else if (optopt == 'c')
+        fprintf(stderr, "Option -%c requires an argument specifying the crossover rate.\n", optopt);
+      else if (optopt == 'm')
+        fprintf(stderr, "Option -%c requires an argument specifying the mutation rate.\n", optopt);
+      else if (optopt == 's')
+        fprintf(stderr, "Option -%c requires an argument specifying the mutation standard deviation.\n", optopt);
+      else if (isprint(optopt))
+        fprintf(stderr, "Unknown option `-%c'.\n", optopt);
+      else
+        fprintf(stderr,
+                "Unknown option character `\\x%x'.\n",
+                optopt);
+      return 1;
+    default:
+      printf("Usage: %s -p {population size} -g {number of generations} -t {number of trials} -c {crossover rate} -m {mutation rate} -s {mutation standard deviation}", argv[0]);
+      abort();
+    }
 
   if (experiment_path.empty())
-    {
-      printf("Usage: %s -p {population size} -g {number of generations} -t {number of trials} -c {crossover rate} -m {mutation rate} -s {mutation standard deviation} -x {argos experiment file}\n", argv[0]);
-      exit(1);
-    }
+  {
+    printf("Usage: %s -p {population size} -g {number of generations} -t {number of trials} -c {crossover rate} -m {mutation rate} -s {mutation standard deviation} -x {argos experiment file}\n", argv[0]);
+    exit(1);
+  }
 
   float max_float = std::numeric_limits<float>::max();
 
-    //printf("%s:\tworker %d ready.\n", hostname, mpi_rank);                                          
+  // printf("%s:\tworker %d ready.\n", hostname, mpi_rank);
 
   // See if we've been given a seed to use (for testing purposes).  When you
   // specify a random seed, the evolution will be exactly the same each time
   // you use that seed number
   unsigned int seed = 12345;
-  for(int i=1 ; i<argc ; i++)
-    if(strcmp(argv[i++],"seed") == 0)
+  for (int i = 1; i < argc; i++)
+    if (strcmp(argv[i++], "seed") == 0)
       seed = atoi(argv[i]);
 
   srand(seed);
   generator.seed(seed);
   // popsize / mpi_tasks must be an integer
-  population_size = mpi_tasks * int((double)population_size/(double)mpi_tasks+0.999);
-  
-  if (mpi_rank==0)
-    {
-      printf("Population size: %d\nNumber of trials: %d\nNumber of generations: %d\nCrossover rate: %f\nMutation rate: %f\nMutation stdev: %f\nAllocated MPI workers: %d\n", population_size, n_trials, n_generations, crossover_rate, mutation_rate, mutation_stdev, mpi_tasks);
-      	printf("elitism: %d\n", elitism);
-    }
+  population_size = mpi_tasks * int((double)population_size / (double)mpi_tasks + 0.999);
+
+  if (mpi_rank == 0)
+  {
+    printf("Population size: %d\nNumber of trials: %d\nNumber of generations: %d\nCrossover rate: %f\nMutation rate: %f\nMutation stdev: %f\nAllocated MPI workers: %d\n", population_size, n_trials, n_generations, crossover_rate, mutation_rate, mutation_stdev, mpi_tasks);
+    printf("elitism: %d\n", elitism);
+  }
 
   // Define the genome
   GARealAlleleSetArray allele_array;
-  
-  allele_array.add(0, 1.0); // Probability of switching to search
-  allele_array.add(0, 1.0); // Probability of returning to nest
-  allele_array.add(0, 4*M_PI); // Uninformed search variation
-  allele_array.add(0, 20); // Rate of informed search decay
-  allele_array.add(0, 20); // Rate of site fidelity
-  allele_array.add(0, 20); // Rate of laying pheremone
-  allele_array.add(0, 20); // Rate of pheremone decay
-  
-    
+
+  allele_array.add(0, 1.0);      // Probability of switching to search
+  allele_array.add(0, 1.0);      // Probability of returning to nest
+  allele_array.add(0, 4 * M_PI); // Uninformed search variation
+  allele_array.add(0, 20);       // Rate of informed search decay
+  allele_array.add(0, 20);       // Rate of site fidelity
+  allele_array.add(0, 20);       // Rate of laying pheremone
+  allele_array.add(0, 20);       // Rate of pheremone decay
+
   // Create the template genome using the phenotype map we just made.
   GARealGenome genome(allele_array, objective);
   genome.crossover(GARealUniformCrossover);
   genome.mutator(GARealGaussianMutatorStdev); // Specify our version of the Gaussuan mutator
   genome.initializer(CPFAInitializer);
- 
+
   // Now create the GA using the genome and run it.
   GASimpleGA ga(genome);
   GALinearScaling scaling;
-  ga.maximize();		// Maximize the objective
- 
+  ga.maximize(); // Maximize the objective
+
   ga.populationSize(population_size);
   ga.nGenerations(n_generations);
   ga.pMutation(mutation_rate);
@@ -190,7 +189,7 @@ int main(int argc, char **argv)
     ga.elitist(gaTrue);
   else
     ga.elitist(gaFalse);
-  if(mpi_rank == 0)
+  if (mpi_rank == 0)
     ga.scoreFilename("evolution.txt");
   else
     ga.scoreFilename("/dev/null");
@@ -198,338 +197,363 @@ int main(int argc, char **argv)
   ga.scoreFrequency(1);
   ga.flushFrequency(1);
   ga.selectScores(GAStatistics::AllScores);
-  
+
   // Pass MPI data to the GA class
   ga.mpi_rank(mpi_rank);
   ga.mpi_tasks(mpi_tasks);
-  //ga.evolve(seed); // Manual generations
+  // ga.evolve(seed); // Manual generations
 
-// initialize the ga since we are not using the evolve function
+  // initialize the ga since we are not using the evolve function
   ga.initialize(seed); // This is essential for the mpi workers to be sychronized
 
-    // Name the results file with the current time and date
- time_t t = time(0);   // get time now
-    struct tm * now = localtime( & t );
-    stringstream ss;
+  // Name the results file with the current time and date
+  time_t t = time(0); // get time now
+  struct tm *now = localtime(&t);
+  stringstream ss;
 
-    boost::filesystem::path exp_path(experiment_path);
-    
-    ss << "results/CPFA-evolution-"
-       << exp_path.stem().string() << '-'
-       <<GIT_BRANCH<<"-"<<GIT_COMMIT_HASH<<"-"
-       << (now->tm_year) << '-'
-       << (now->tm_mon + 1) << '-'
-       <<  now->tm_mday << '-'
-       <<  now->tm_hour << '-'
-       <<  now->tm_min << '-'
-       <<  now->tm_sec << ".csv";
+  boost::filesystem::path exp_path(experiment_path);
 
-    string results_file_name = ss.str();
+  ss << "results/CPFA-evolution-"
+     << exp_path.stem().string() << '-'
+     << GIT_BRANCH << "-" << GIT_COMMIT_HASH << "-"
+     << (now->tm_year) << '-'
+     << (now->tm_mon + 1) << '-'
+     << now->tm_mday << '-'
+     << now->tm_hour << '-'
+     << now->tm_min << '-'
+     << now->tm_sec << ".csv";
 
-    if (mpi_rank == 0)
-      {
+  string results_file_name = ss.str();
+
+  if (mpi_rank == 0)
+  {
     // Write output file header
     ofstream results_output_stream;
-	results_output_stream.open(results_file_name, ios::app);
-	results_output_stream << "Population size: " << population_size << "\nNumber of trials: " << n_trials << "\nNumber of generations: "<< n_generations<<"\nCrossover rate: "<< crossover_rate<<"\nMutation rate: " << mutation_rate << "\nMutation stdev: "<< mutation_stdev << "Algorithm: CPFA\n" << "Number of searchers: 6\n" << "Number of targets: 256\n" << "Target distribution: power law" << endl;
-	results_output_stream << "Generation" 
-			      << ", " << "Compute Time (s)"
-			      << ", " << "Convergence"
-			      << ", " << "Mean"
-			      << ", " << "Maximum"
-			      << ", " << "Minimum"
-			      << ", " << "Standard Deviation"
-			      << ", " << "Diversity"
-			      << ", " << "ProbabilityOfSwitchingToSearching"
-			      << ", " << "ProbabilityOfReturningToNest"
-			      << ", " << "UninformedSearchVariation"
-			      << ", " << "RateOfInformedSearchDecay"
-			      << ", " << "RateOfSiteFidelity"
-			      << ", " << "RateOfLayingPheromone"
-			      << ", " << "RateOfPheromoneDecay";
+    results_output_stream.open(results_file_name, ios::app);
+    results_output_stream << "Population size: " << population_size << "\nNumber of trials: " << n_trials << "\nNumber of generations: " << n_generations << "\nCrossover rate: " << crossover_rate << "\nMutation rate: " << mutation_rate << "\nMutation stdev: " << mutation_stdev << "Algorithm: CPFA\n"
+                          << "Number of searchers: 6\n"
+                          << "Number of targets: 256\n"
+                          << "Target distribution: power law" << endl;
+    results_output_stream << "Generation"
+                          << ", "
+                          << "Compute Time (s)"
+                          << ", "
+                          << "Convergence"
+                          << ", "
+                          << "Mean"
+                          << ", "
+                          << "Maximum"
+                          << ", "
+                          << "Minimum"
+                          << ", "
+                          << "Standard Deviation"
+                          << ", "
+                          << "Diversity"
+                          << ", "
+                          << "ProbabilityOfSwitchingToSearching"
+                          << ", "
+                          << "ProbabilityOfReturningToNest"
+                          << ", "
+                          << "UninformedSearchVariation"
+                          << ", "
+                          << "RateOfInformedSearchDecay"
+                          << ", "
+                          << "RateOfSiteFidelity"
+                          << ", "
+                          << "RateOfLayingPheromone"
+                          << ", "
+                          << "RateOfPheromoneDecay";
 
-	results_output_stream << endl;
-	results_output_stream.close();
-      }
+    results_output_stream << endl;
+    results_output_stream.close();
+  }
 
-	while(!ga.done())
-	  {
+  while (!ga.done())
+  {
 
-	    std::chrono::time_point<std::chrono::system_clock>generation_start, generation_end;
-	    if (mpi_rank == 0)
-	      {
-		generation_start = std::chrono::system_clock::now();
-	      }
-	    
-      // Calculate the generation
-      ga.step();
+    std::chrono::time_point<std::chrono::system_clock> generation_start, generation_end;
+    if (mpi_rank == 0)
+    {
+      generation_start = std::chrono::system_clock::now();
+    }
 
-    if(mpi_rank == 0)
-      {
-	generation_end = std::chrono::system_clock::now();
-	std::chrono::duration<double> generation_elapsed_seconds = generation_end-generation_start;
-	ofstream results_output_stream;
-	results_output_stream.open(results_file_name, ios::app);
-       results_output_stream << ga.statistics().generation() 
-			     << ", " << generation_elapsed_seconds.count()
-			     << ", " << ga.statistics().convergence()
-			     << ", " << ga.statistics().current(GAStatistics::Mean)
-			     << ", " << ga.statistics().current(GAStatistics::Maximum)
-			     << ", " << ga.statistics().current(GAStatistics::Minimum)
-			     << ", " << ga.statistics().current(GAStatistics::Deviation)
-			     << ", " << ga.statistics().current(GAStatistics::Diversity);
-       
-	  for (int i = 0; i < GENOME_SIZE; i++)
-	    results_output_stream << ", " << dynamic_cast<const GARealGenome&>(ga.population().best()).gene(i);
+    // Calculate the generation
+    ga.step();
 
-	  
-	  const GARealGenome& best_genome = dynamic_cast<const GARealGenome&>(ga.statistics().bestIndividual());
-	  results_output_stream << endl;
-	  
-	  results_output_stream << "The GA found an optimum at: ";
-	  results_output_stream << best_genome.gene(0);
-	  for (int i = 1; i < GENOME_SIZE; i++)
-	    results_output_stream << ", " << best_genome.gene(i);
-	  results_output_stream << " with score: " << best_genome.score();
-	  results_output_stream << endl;
-	  results_output_stream.close();
-      }
-	  }
-	// Display the GA's progress
-	if(mpi_rank == 0)
-	  {
-	    cout << ga.statistics() << " " << ga.parameters() << endl;
-	  }
-	
+    if (mpi_rank == 0)
+    {
+      generation_end = std::chrono::system_clock::now();
+      std::chrono::duration<double> generation_elapsed_seconds = generation_end - generation_start;
+      ofstream results_output_stream;
+      results_output_stream.open(results_file_name, ios::app);
+      results_output_stream << ga.statistics().generation()
+                            << ", " << generation_elapsed_seconds.count()
+                            << ", " << ga.statistics().convergence()
+                            << ", " << ga.statistics().current(GAStatistics::Mean)
+                            << ", " << ga.statistics().current(GAStatistics::Maximum)
+                            << ", " << ga.statistics().current(GAStatistics::Minimum)
+                            << ", " << ga.statistics().current(GAStatistics::Deviation)
+                            << ", " << ga.statistics().current(GAStatistics::Diversity);
+
+      for (int i = 0; i < GENOME_SIZE; i++)
+        results_output_stream << ", " << dynamic_cast<const GARealGenome &>(ga.population().best()).gene(i);
+
+      const GARealGenome &best_genome = dynamic_cast<const GARealGenome &>(ga.statistics().bestIndividual());
+      results_output_stream << endl;
+
+      results_output_stream << "The GA found an optimum at: ";
+      results_output_stream << best_genome.gene(0);
+      for (int i = 1; i < GENOME_SIZE; i++)
+        results_output_stream << ", " << best_genome.gene(i);
+      results_output_stream << " with score: " << best_genome.score();
+      results_output_stream << endl;
+      results_output_stream.close();
+    }
+  }
+  // Display the GA's progress
+  if (mpi_rank == 0)
+  {
+    cout << ga.statistics() << " " << ga.parameters() << endl;
+  }
+
   MPI_Finalize();
 
   program_end = std::chrono::system_clock::now();
- 
-  std::chrono::duration<double> program_elapsed_seconds = program_end-program_start;
 
-  if(mpi_rank == 0)
+  std::chrono::duration<double> program_elapsed_seconds = program_end - program_start;
+
+  if (mpi_rank == 0)
     printf("Run time was %f seconds\n", program_elapsed_seconds.count());
 
   return 0;
-  }
+}
 
-// Initializes the genome according to the Beyond Pheromones paper 
-void CPFAInitializer(GAGenome & c)
+// Initializes the genome according to the Beyond Pheromones paper
+void CPFAInitializer(GAGenome &c)
 {
   // For the exponential PDF needed to initialize some of the genes
-  
+
   std::exponential_distribution<double> exponential_distribution_10(10.0);
   std::exponential_distribution<double> exponential_distribution_5(5.0);
   std::uniform_real_distribution<double> uniform_distribution_0_1(0.0, 1.0);
-  std::uniform_real_distribution<double> uniform_distribution_0_4PI(0.0, 4.0*M_PI);
+  std::uniform_real_distribution<double> uniform_distribution_0_4PI(0.0, 4.0 * M_PI);
   std::uniform_real_distribution<double> uniform_distribution_0_20(0.0, 20.0);
 
-  GA1DArrayAlleleGenome<float> &child= DYN_CAST(GA1DArrayAlleleGenome<float> &, c);
+  GA1DArrayAlleleGenome<float> &child = DYN_CAST(GA1DArrayAlleleGenome<float> &, c);
   child.resize(GAGenome::ANY_SIZE); // let chrom resize if it can
-  
-  child.gene(0, uniform_distribution_0_1(generator)); // Probability of switching to search
-  child.gene(1, uniform_distribution_0_1(generator)); // Probability of returning to nest
-  child.gene(2, uniform_distribution_0_4PI(generator)); // Uninformed search variation
-  child.gene(3, exponential_distribution_5(generator)); // Rate of informed search decay
-  child.gene(4, uniform_distribution_0_20(generator)); // Rate of site fidelity
-  child.gene(5, uniform_distribution_0_20(generator)); // Rate of laying pheremone
+
+  child.gene(0, uniform_distribution_0_1(generator));    // Probability of switching to search
+  child.gene(1, uniform_distribution_0_1(generator));    // Probability of returning to nest
+  child.gene(2, uniform_distribution_0_4PI(generator));  // Uninformed search variation
+  child.gene(3, exponential_distribution_5(generator));  // Rate of informed search decay
+  child.gene(4, uniform_distribution_0_20(generator));   // Rate of site fidelity
+  child.gene(5, uniform_distribution_0_20(generator));   // Rate of laying pheremone
   child.gene(6, exponential_distribution_10(generator)); // Rate of pheremone decay
 }
 
 // The mutation operator based on the original from GALib but adds stdev
 // The Gaussian mutator picks a new value based on a Gaussian distribution
 // around the current value.  We respect the bounds (if any).
-int GARealGaussianMutatorStdev(GAGenome& g, float pmut)
+int GARealGaussianMutatorStdev(GAGenome &g, float pmut)
 {
-  GA1DArrayAlleleGenome<float> &child=
-    DYN_CAST(GA1DArrayAlleleGenome<float> &, g);
-  register int n, i;
-  if(pmut <= 0.0) return(0);
+  GA1DArrayAlleleGenome<float> &child =
+      DYN_CAST(GA1DArrayAlleleGenome<float> &, g);
+  int n, i;
+  if (pmut <= 0.0)
+    return (0);
 
   float nMut = pmut * (float)(child.length());
-  int length = child.length()-1;
-  if(nMut < 1.0){// we have to do a flip test on each element
+  int length = child.length() - 1;
+  if (nMut < 1.0)
+  { // we have to do a flip test on each element
     nMut = 0;
-    for(i=length; i>=0; i--){
+    for (i = length; i >= 0; i--)
+    {
       float value = child.gene(i);
-      if(GAFlipCoin(pmut)){
-	if(child.alleleset(i).type() == GAAllele::ENUMERATED ||
-	   child.alleleset(i).type() == GAAllele::DISCRETIZED)
-	  value = child.alleleset(i).allele();
-	else if(child.alleleset(i).type() == GAAllele::BOUNDED){
-	  value += GAUnitGaussian()*mutation_stdev;//*(child.alleleset(i).upper()-child.alleleset(i).lower()); // since the standard deviation varies proportionally to a constant multiplier 
-	  value = GAMax(child.alleleset(i).lower(), value);
-	  value = GAMin(child.alleleset(i).upper(), value);
-	}
-	child.gene(i, value);
-	nMut++;
+      if (GAFlipCoin(pmut))
+      {
+        if (child.alleleset(i).type() == GAAllele::ENUMERATED ||
+            child.alleleset(i).type() == GAAllele::DISCRETIZED)
+          value = child.alleleset(i).allele();
+        else if (child.alleleset(i).type() == GAAllele::BOUNDED)
+        {
+          value += GAUnitGaussian() * mutation_stdev; //*(child.alleleset(i).upper()-child.alleleset(i).lower()); // since the standard deviation varies proportionally to a constant multiplier
+          value = GAMax(child.alleleset(i).lower(), value);
+          value = GAMin(child.alleleset(i).upper(), value);
+        }
+        child.gene(i, value);
+        nMut++;
       }
     }
   }
-  else{// only mutate the ones we need to
-    for(n=0; n<nMut; n++){
-      int idx = GARandomInt(0,length);
+  else
+  { // only mutate the ones we need to
+    for (n = 0; n < nMut; n++)
+    {
+      int idx = GARandomInt(0, length);
       float value = child.gene(idx);
-      if(child.alleleset(idx).type() == GAAllele::ENUMERATED ||
-	 child.alleleset(idx).type() == GAAllele::DISCRETIZED)
-	value = child.alleleset(idx).allele();
-      else if(child.alleleset(idx).type() == GAAllele::BOUNDED){
-	value += GAUnitGaussian()*mutation_stdev*(child.alleleset(i).upper()-child.alleleset(i).lower()); // since the standard deviation varies proportionally to a constant multiplier 
-	value = GAMax(child.alleleset(idx).lower(), value);
-	value = GAMin(child.alleleset(idx).upper(), value);
+      if (child.alleleset(idx).type() == GAAllele::ENUMERATED ||
+          child.alleleset(idx).type() == GAAllele::DISCRETIZED)
+        value = child.alleleset(idx).allele();
+      else if (child.alleleset(idx).type() == GAAllele::BOUNDED)
+      {
+        value += GAUnitGaussian() * mutation_stdev * (child.alleleset(i).upper() - child.alleleset(i).lower()); // since the standard deviation varies proportionally to a constant multiplier
+        value = GAMax(child.alleleset(idx).lower(), value);
+        value = GAMin(child.alleleset(idx).upper(), value);
       }
       child.gene(idx, value);
     }
   }
-  return((int)nMut);
+  return ((int)nMut);
 }
-
 
 float objective(GAGenome &c)
 {
   float avg = 0;
-  
+
   // For timing
   std::chrono::time_point<std::chrono::system_clock> start, end;
   start = std::chrono::system_clock::now();
 
-  for (int i = 0; i < n_trials; i++) avg += LaunchARGoS(c);
-  
+  for (int i = 0; i < n_trials; i++)
+    avg += LaunchARGoS(c);
+
   avg /= n_trials;
 
-  
   end = std::chrono::system_clock::now();
-  
-  std::chrono::duration<double> elapsed_seconds = end-start;
 
-  MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);     
+  std::chrono::duration<double> elapsed_seconds = end - start;
 
-      char hostname[1024];              
-      hostname[1023] = '\0';                                          
-      gethostname(hostname, 1023);     
- 
-      /*
-      printf("Worker %d on %s evaluated genome [", mpi_rank, hostname);
-      for (int i = 0; i < GENOME_SIZE; i++)
-	printf("%f ",dynamic_cast<const GARealGenome&>(c).gene(i));
-      printf("] in %f seconds. ", elapsed_seconds.count());
-      printf("Fitness: %f.\n", avg );
-      */
+  MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
 
-      return avg;
+  char hostname[1024];
+  hostname[1023] = '\0';
+  gethostname(hostname, 1023);
+
+  /*
+  printf("Worker %d on %s evaluated genome [", mpi_rank, hostname);
+  for (int i = 0; i < GENOME_SIZE; i++)
+printf("%f ",dynamic_cast<const GARealGenome&>(c).gene(i));
+  printf("] in %f seconds. ", elapsed_seconds.count());
+  printf("Fitness: %f.\n", avg );
+  */
+
+  return avg;
 }
 
 /*
  * Launch ARGoS to evaluate a genome.
  */
-float LaunchARGoS(GAGenome& c_genome) 
+float LaunchARGoS(GAGenome &c_genome)
 {
   // Declate the fitness value and the shared memory segment id and address
   float fitness = 0;
-  int    ShmID;
-  float*   ShmPTR;
-  
+  int ShmID;
+  float *ShmPTR;
+
   // Allocate the shared memory to use between this process and the child argos process
   ShmID = shmget(IPC_PRIVATE, sizeof(float), IPC_CREAT | 0666);
-  if (ShmID < 0) {
+  if (ShmID < 0)
+  {
     printf("ERROR: Allocating shared memory segment in main.cpp:LaunchARGoS() failed.\n");
     exit(1);
   }
-  
+
   // Attach to the shared memory segment
-  ShmPTR = (float*) shmat(ShmID, NULL, 0);
-  if ((float*) ShmPTR == (float*)-1) 
-    {
-      printf("ERROR: Attaching to shared memory segment in main.cpp:LaunchARGoS() failed.\n");
-      exit(1);
-    }
+  ShmPTR = (float *)shmat(ShmID, NULL, 0);
+  if ((float *)ShmPTR == (float *)-1)
+  {
+    printf("ERROR: Attaching to shared memory segment in main.cpp:LaunchARGoS() failed.\n");
+    exit(1);
+  }
 
   *ShmPTR = 0; // Initialise
 
   pid_t pid = fork(); // Create the new process with a copy of this memory space
 
   if (pid == 0)
-    {
-      // In child process - run the argos3 simulation
+  {
+    // In child process - run the argos3 simulation
 
-      /* Convert the received genome to the actual genome type */
-      GARealGenome& cRealGenome = dynamic_cast<GARealGenome&>(c_genome);
-  
-      Real* cpfa_genome = new Real[GENOME_SIZE];
+    /* Convert the received genome to the actual genome type */
+    GARealGenome &cRealGenome = dynamic_cast<GARealGenome &>(c_genome);
 
-      // Convert to a convenient format for the argos controller
-      for (int i = 0; i < GENOME_SIZE; i++)
-	cpfa_genome[i] = cRealGenome.gene(i);
-       
-      /*      
-      printf("%s: worker %d started a genome evaluation. (%f, %f, %f, %f, %f, %f, %f)\n", hostname, mpi_rank, 
-	     cpfa_genome[0],
-	     cpfa_genome[1],
-	     cpfa_genome[2],
-	     cpfa_genome[3],
-	     cpfa_genome[4],
-	     cpfa_genome[5],
-	     cpfa_genome[6]);
-      */
+    Real *cpfa_genome = new Real[GENOME_SIZE];
 
-      /* Redirect LOG and LOGERR to dedicated files to prevent clutter on the screen */
-      std::ofstream cLOGFile("argos_logs/ARGoS_LOG_" + ToString(::getpid()), std::ios::out);
-      LOG.DisableColoredOutput();
-      LOG.GetStream().rdbuf(cLOGFile.rdbuf());
-      std::ofstream cLOGERRFile("argos_logs/ARGoS_LOGERR_" + ToString(::getpid()), std::ios::out);
-      LOGERR.DisableColoredOutput();
-      LOGERR.GetStream().rdbuf(cLOGERRFile.rdbuf());
+    // Convert to a convenient format for the argos controller
+    for (int i = 0; i < GENOME_SIZE; i++)
+      cpfa_genome[i] = cRealGenome.gene(i);
 
-      /*
-       * Initialize ARGoS
-       */
-      /* The CSimulator class of ARGoS is a singleton. Therefore, to
-       * manipulate an ARGoS experiment, it is enough to get its instance */
-      argos::CSimulator& cSimulator = argos::CSimulator::GetInstance();
+    /*
+    printf("%s: worker %d started a genome evaluation. (%f, %f, %f, %f, %f, %f, %f)\n", hostname, mpi_rank,
+     cpfa_genome[0],
+     cpfa_genome[1],
+     cpfa_genome[2],
+     cpfa_genome[3],
+     cpfa_genome[4],
+     cpfa_genome[5],
+     cpfa_genome[6]);
+    */
 
-      // Set the .argos configuration file
-      cSimulator.SetExperimentFileName(experiment_path);
-      
-      // Load it to configure ARGoS 
-      cSimulator.LoadExperiment();
+    /* Redirect LOG and LOGERR to dedicated files to prevent clutter on the screen */
+    std::ofstream cLOGFile("argos_logs/ARGoS_LOG_" + ToString(::getpid()), std::ios::out);
+    LOG.DisableColoredOutput();
+    LOG.GetStream().rdbuf(cLOGFile.rdbuf());
+    std::ofstream cLOGERRFile("argos_logs/ARGoS_LOGERR_" + ToString(::getpid()), std::ios::out);
+    LOGERR.DisableColoredOutput();
+    LOGERR.GetStream().rdbuf(cLOGERRFile.rdbuf());
 
-      // Get a reference to the loop functions
-      CPFA_loop_functions& cLoopFunctions = dynamic_cast<CPFA_loop_functions&>(cSimulator.GetLoopFunctions());
+    /*
+     * Initialize ARGoS
+     */
+    /* The CSimulator class of ARGoS is a singleton. Therefore, to
+     * manipulate an ARGoS experiment, it is enough to get its instance */
+    argos::CSimulator &cSimulator = argos::CSimulator::GetInstance();
 
-      // Configure the controller with the genome
-      cLoopFunctions.ConfigureFromGenome(cpfa_genome);
+    // Set the .argos configuration file
+    cSimulator.SetExperimentFileName(experiment_path);
 
-      // Run the experiment
-      cSimulator.Execute();
+    // Load it to configure ARGoS
+    cSimulator.LoadExperiment();
 
-      // Update performance and store in the shared memory segment
-      *ShmPTR = cLoopFunctions.Score();;
+    // Get a reference to the loop functions
+    CPFA_loop_functions &cLoopFunctions = dynamic_cast<CPFA_loop_functions &>(cSimulator.GetLoopFunctions());
 
-      // For testing
-      //float score = 0;
-      //for (int i = 0; i < GENOME_SIZE; i++) score += cpfa_genome[i];
-      //*ShmPTR = score;
+    // Configure the controller with the genome
+    cLoopFunctions.ConfigureFromGenome(cpfa_genome);
 
-      // Clean up the simulation
-      cSimulator.Destroy();
-      
-      // Clean up the temp genome copy
-	delete [] cpfa_genome;
+    // Run the experiment
+    cSimulator.Execute();
 
-	// Make this process exit
-      _Exit(0); 
-    }
-  
+    // Update performance and store in the shared memory segment
+    *ShmPTR = cLoopFunctions.Score();
+    ;
+
+    // For testing
+    // float score = 0;
+    // for (int i = 0; i < GENOME_SIZE; i++) score += cpfa_genome[i];
+    //*ShmPTR = score;
+
+    // Clean up the simulation
+    cSimulator.Destroy();
+
+    // Clean up the temp genome copy
+    delete[] cpfa_genome;
+
+    // Make this process exit
+    _Exit(0);
+  }
+
   // In parent - wait for child to finish
   int status = wait(&status);
 
   // Make a local copy of the shared fitness value
-  fitness = *ShmPTR;  
+  fitness = *ShmPTR;
 
   // Release shared memory
-  shmdt((void *) ShmPTR);
+  shmdt((void *)ShmPTR);
   shmctl(ShmID, IPC_RMID, NULL);
 
-  /* Return the result of the evaluation */  
+  /* Return the result of the evaluation */
   return fitness;
 }

--- a/Global_static_MPFA/source/ga-mpi/GA1DArrayGenome.C
+++ b/Global_static_MPFA/source/ga-mpi/GA1DArrayGenome.C
@@ -18,7 +18,7 @@
 #include <ga-mpi/GA1DArrayGenome.h>
 #include <ga-mpi/GAMask.h>
 
-template <class T> int 
+template <class T> int
 GA1DArrayIsHole(const GA1DArrayGenome<T>&, const GA1DArrayGenome<T>&,
 		int, int, int);
 
@@ -36,15 +36,15 @@ GA1DArrayGenome<T>::classID() const {return GAID::ArrayGenome;}
 // this point - initialization must be done explicitly by the user of the
 // genome (eg when the population is created or reset).  If we called the
 // initializer routine here then we could end up with multiple initializations
-// and/or calls to dummy initializers (for example when the genome is 
+// and/or calls to dummy initializers (for example when the genome is
 // created with a dummy initializer and the initializer is assigned later on).
 // Besides, we default to the no-initialization initializer by calling the
 // default genome constructor.
-template <class T> 
+template <class T>
 GA1DArrayGenome<T>::
 GA1DArrayGenome(unsigned int length, GAGenome::Evaluator f, void * u) :
 GAArray<T>(length),
-GAGenome(DEFAULT_1DARRAY_INITIALIZER, 
+GAGenome(DEFAULT_1DARRAY_INITIALIZER,
 	 DEFAULT_1DARRAY_MUTATOR,
 	 DEFAULT_1DARRAY_COMPARATOR) {
   evaluator(f);
@@ -56,9 +56,9 @@ GAGenome(DEFAULT_1DARRAY_INITIALIZER,
 
 // This is the copy initializer.  We set everything to the default values, then
 // copy the original.  The Array creator takes care of zeroing the data.
-template <class T> 
+template <class T>
 GA1DArrayGenome<T>::
-GA1DArrayGenome(const GA1DArrayGenome<T> & orig) : 
+GA1DArrayGenome(const GA1DArrayGenome<T> & orig) :
 GAArray<T>(orig.sz), GAGenome() {
   GA1DArrayGenome<T>::copy(orig);
 }
@@ -74,7 +74,7 @@ GA1DArrayGenome<T>::~GA1DArrayGenome() { }
 // what we define here - a virtual function).  We should check to be sure that
 // both genomes are the same class and same dimension.  This function tries
 // to be smart about they way it copies.  If we already have data, then we do
-// a memcpy of the one we're supposed to copy.  If we don't or we're not the 
+// a memcpy of the one we're supposed to copy.  If we don't or we're not the
 // same size as the one we're supposed to copy, then we adjust ourselves.
 //   The Array takes care of the resize in its copy method.
 template <class T> void
@@ -92,7 +92,7 @@ GA1DArrayGenome<T>::copy(const GAGenome & orig){
 template <class T> GAGenome *
 GA1DArrayGenome<T>::clone(GAGenome::CloneMethod flag) const {
   GA1DArrayGenome<T> *cpy = new GA1DArrayGenome<T>(nx);
-  if(flag == CONTENTS){ 
+  if(flag == CONTENTS){
     cpy->copy(*this);
   }
   else{
@@ -110,10 +110,10 @@ GA1DArrayGenome<T>::clone(GAGenome::CloneMethod flag) const {
 // length, then we don't do anything.
 //   We pay attention to the values of minX and maxX - they determine what kind
 // of resizing we are allowed to do.  If a resize is requested with a length
-// less than the min length specified by the behaviour, we set the minimum 
+// less than the min length specified by the behaviour, we set the minimum
 // to the length.  If the length is longer than the max length specified by
 // the behaviour, we set the max value to the length.
-//   We return the total size (in bits) of the genome after resize. 
+//   We return the total size (in bits) of the genome after resize.
 //   We don't do anything to the new contents!
 template <class T> int
 GA1DArrayGenome<T>::resize(int len)
@@ -160,7 +160,7 @@ GA1DArrayGenome<T>::write(STD_OSTREAM & os) const {
 //   Set the resize behaviour of the genome.  A genome can be fixed
 // length, resizeable with a max and min limit, or resizeable with no limits
 // (other than an implicit one that we use internally).
-//   A value of 0 means no resize, a value less than zero mean unlimited 
+//   A value of 0 means no resize, a value less than zero mean unlimited
 // resize, and a positive value means resize with that value as the limit.
 template <class T> int
 GA1DArrayGenome<T>::
@@ -183,7 +183,7 @@ GA1DArrayGenome<T>::resizeBehaviour() const {
   return val;
 }
 
-template <class T> int 
+template <class T> int
 GA1DArrayGenome<T>::equal(const GAGenome & c) const {
   const GA1DArrayGenome<T> & b = DYN_CAST(const GA1DArrayGenome<T> &, c);
   return((this == &c) ? 1 : ((nx != b.nx) ? 0 : GAArray<T>::equal(b,0,0,nx)));
@@ -205,7 +205,7 @@ its own, independent allele set.  If we clone a new genome, the new one gets a
 link to our allele set (so we don't end up with zillions of allele sets).  Same
 is true for the copy constructor.
   The array may have a single allele set or an array of allele sets, depending
-on which creator was called.  Either way, the allele set cannot be changed 
+on which creator was called.  Either way, the allele set cannot be changed
 once the array is created.
 ---------------------------------------------------------------------------- */
 template <class T> const char *
@@ -213,7 +213,7 @@ GA1DArrayAlleleGenome<T>::className() const {return "GA1DArrayAlleleGenome";}
 template <class T> int
 GA1DArrayAlleleGenome<T>::classID() const {return GAID::ArrayAlleleGenome;}
 
-template <class T> 
+template <class T>
 GA1DArrayAlleleGenome<T>::
 GA1DArrayAlleleGenome(unsigned int length, const GAAlleleSet<T> & s,
 		      GAGenome::Evaluator f, void * u) :
@@ -228,7 +228,7 @@ GA1DArrayGenome<T>(length, f, u){
   this->crossover(GA1DArrayAlleleGenome<T>::DEFAULT_1DARRAY_ALLELE_CROSSOVER);
 }
 
-template <class T> 
+template <class T>
 GA1DArrayAlleleGenome<T>::
 GA1DArrayAlleleGenome(const GAAlleleSetArray<T> & sa,
 		      GAGenome::Evaluator f, void * u) :
@@ -247,9 +247,9 @@ GA1DArrayGenome<T>(sa.size(), f, u) {
 
 // The copy constructor creates a new genome whose allele set refers to the
 // original's allele set.
-template <class T> 
+template <class T>
 GA1DArrayAlleleGenome<T>::
-GA1DArrayAlleleGenome(const GA1DArrayAlleleGenome<T>& orig) : 
+GA1DArrayAlleleGenome(const GA1DArrayAlleleGenome<T>& orig) :
 GA1DArrayGenome<T>(orig.sz) {
   naset = 0;
   aset = (GAAlleleSet<T>*)0;
@@ -265,7 +265,7 @@ GA1DArrayAlleleGenome<T>::~GA1DArrayAlleleGenome(){
 
 
 // This implementation of clone does not make use of the contents/attributes
-// capability because this whole interface isn't quite right yet...  Just 
+// capability because this whole interface isn't quite right yet...  Just
 // clone the entire thing, contents and all.
 template <class T> GAGenome *
 GA1DArrayAlleleGenome<T>::clone(GAGenome::CloneMethod) const {
@@ -273,10 +273,10 @@ GA1DArrayAlleleGenome<T>::clone(GAGenome::CloneMethod) const {
 }
 
 
-template <class T> void 
+template <class T> void
 GA1DArrayAlleleGenome<T>::copy(const GAGenome& orig){
   if(&orig == this) return;
-  const GA1DArrayAlleleGenome<T> * c = 
+  const GA1DArrayAlleleGenome<T> * c =
     DYN_CAST(const GA1DArrayAlleleGenome<T>*, &orig);
   if(c) {
     GA1DArrayGenome<T>::copy(*c);
@@ -339,7 +339,7 @@ GA1DArrayAlleleGenome<T>::equal(const GAGenome & c) const {
 ---------------------------------------------------------------------------- */
 // The random initializer sets the elements of the array based on the alleles
 // set.  We choose randomly the allele for each element.
-template <class ARRAY_TYPE> void 
+template <class ARRAY_TYPE> void
 GA1DArrayAlleleGenome<ARRAY_TYPE>::UniformInitializer(GAGenome & c)
 {
   GA1DArrayAlleleGenome<ARRAY_TYPE> &child=
@@ -354,7 +354,7 @@ GA1DArrayAlleleGenome<ARRAY_TYPE>::UniformInitializer(GAGenome & c)
 // and assign each element the next allele in the allele set.  Once each
 // element has been initialized, scramble the contents by swapping elements.
 // This assumes that there is only one allele set for the array.
-template <class ARRAY_TYPE> void 
+template <class ARRAY_TYPE> void
 GA1DArrayAlleleGenome<ARRAY_TYPE>::OrderedInitializer(GAGenome & c)
 {
   GA1DArrayAlleleGenome<ARRAY_TYPE> &child=
@@ -372,15 +372,15 @@ GA1DArrayAlleleGenome<ARRAY_TYPE>::OrderedInitializer(GAGenome & c)
 }
 
 
-// Randomly pick elements in the array then set the element to any of the 
+// Randomly pick elements in the array then set the element to any of the
 // alleles in the allele set for this genome.  This will work for any number
 // of allele sets for a given array.
-template <class ARRAY_TYPE> int 
+template <class ARRAY_TYPE> int
 GA1DArrayAlleleGenome<ARRAY_TYPE>::FlipMutator(GAGenome & c, float pmut)
 {
   GA1DArrayAlleleGenome<ARRAY_TYPE> &child=
     DYN_CAST(GA1DArrayAlleleGenome<ARRAY_TYPE> &, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.length());
@@ -404,11 +404,11 @@ GA1DArrayAlleleGenome<ARRAY_TYPE>::FlipMutator(GAGenome & c, float pmut)
 
 
 // Randomly swap elements in the array.
-template <class ARRAY_TYPE> int 
+template <class ARRAY_TYPE> int
 GA1DArrayGenome<ARRAY_TYPE>::SwapMutator(GAGenome & c, float pmut)
 {
   GA1DArrayGenome<ARRAY_TYPE> &child=DYN_CAST(GA1DArrayGenome<ARRAY_TYPE>&, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.length());
@@ -469,7 +469,7 @@ ElementComparator(const GAGenome& a, const GAGenome& b)
 #define SWAP(a,b) {unsigned int tmp=a; a=b; b=tmp;}
 
 // Randomly take bits from each parent.  For each bit we flip a coin to see if
-// that bit should come from the mother or the father.  If strings are 
+// that bit should come from the mother or the father.  If strings are
 // different lengths then we need to use the mask to get things right.
 template <class T> int
 GA1DArrayGenome<T>::
@@ -517,8 +517,8 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
     n = 2;
   }
   else if(c1 || c2){
-    GA1DArrayGenome<T> &sis = (c1 ? 
-			       DYN_CAST(GA1DArrayGenome<T> &, *c1) : 
+    GA1DArrayGenome<T> &sis = (c1 ?
+			       DYN_CAST(GA1DArrayGenome<T> &, *c1) :
 			       DYN_CAST(GA1DArrayGenome<T> &, *c2));
 
     if(mom.length() == dad.length() && sis.length() == mom.length()){
@@ -550,7 +550,7 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
 // we cannot handle that and post an error message.
 template <class T> int
 GA1DArrayGenome<T>::
-OnePointCrossover(const GAGenome& p1, const GAGenome& p2, 
+OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 		  GAGenome* c1, GAGenome* c2){
   const GA1DArrayGenome<T> &mom=DYN_CAST(const GA1DArrayGenome<T> &, p1);
   const GA1DArrayGenome<T> &dad=DYN_CAST(const GA1DArrayGenome<T> &, p2);
@@ -565,7 +565,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour() == GAGenome::FIXED_SIZE){
-      if(mom.length() != dad.length() || 
+      if(mom.length() != dad.length() ||
 	 sis.length() != bro.length() ||
 	 sis.length() != mom.length()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -587,17 +587,17 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sis.resize(momsite+dadlen);
       bro.resize(dadsite+momlen);
     }
-    
+
     sis.copy(mom, 0, 0, momsite);
     sis.copy(dad, momsite, dadsite, dadlen);
     bro.copy(dad, 0, 0, dadsite);
     bro.copy(mom, dadsite, momsite, momlen);
-  
+
     nc = 2;
   }
   else if(c1 || c2){
-    GA1DArrayGenome<T> &sis = (c1 ? 
-			       DYN_CAST(GA1DArrayGenome<T> &, *c1) : 
+    GA1DArrayGenome<T> &sis = (c1 ?
+			       DYN_CAST(GA1DArrayGenome<T> &, *c1) :
 			       DYN_CAST(GA1DArrayGenome<T> &, *c2));
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE){
@@ -615,7 +615,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       dadlen = dad.length() - dadsite;
       sis.resize(momsite+dadlen);
     }
-    
+
     if(GARandomBit()){
       sis.copy(mom, 0, 0, momsite);
       sis.copy(dad, momsite, dadsite, dadlen);
@@ -642,14 +642,14 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
 
 // Two point crossover for the 1D array genome.  Similar to the single point
-// crossover, but here we pick two points then grab the sections based upon 
+// crossover, but here we pick two points then grab the sections based upon
 // those two points.
 //   When we pick the points, it doesn't matter where they fall (one is not
 // dependent upon the other).  Make sure we get the lesser one into the first
 // position of our site array.
 template <class T> int
 GA1DArrayGenome<T>::
-TwoPointCrossover(const GAGenome& p1, const GAGenome& p2, 
+TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
 		  GAGenome* c1, GAGenome* c2){
   const GA1DArrayGenome<T> &mom=DYN_CAST(const GA1DArrayGenome<T> &, p1);
   const GA1DArrayGenome<T> &dad=DYN_CAST(const GA1DArrayGenome<T> &, p2);
@@ -664,7 +664,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour() == GAGenome::FIXED_SIZE){
-      if(mom.length() != dad.length() || 
+      if(mom.length() != dad.length() ||
 	 sis.length() != bro.length() ||
 	 sis.length() != mom.length()){
 	GAErr(GA_LOC, mom.className(), "two-point cross", gaErrSameLengthReqd);
@@ -675,7 +675,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
       if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
-      
+
       dadsite[0] = momsite[0];
       dadsite[1] = momsite[1];
       dadlen[0] = momlen[0];
@@ -691,13 +691,13 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
       if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
-      
+
       dadsite[0] = GARandomInt(0, dad.length());
       dadsite[1] = GARandomInt(0, dad.length());
       if(dadsite[0] > dadsite[1]) SWAP(dadsite[0], dadsite[1]);
       dadlen[0] = dadsite[1] - dadsite[0];
       dadlen[1] = dad.length() - dadsite[1];
-      
+
       sis.resize(momsite[0]+dadlen[0]+momlen[1]);
       bro.resize(dadsite[0]+momlen[0]+dadlen[1]);
     }
@@ -726,7 +726,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
       if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
-      
+
       dadsite[0] = momsite[0];
       dadsite[1] = momsite[1];
       dadlen[0] = momlen[0];
@@ -738,7 +738,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
       if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
-      
+
       dadsite[0] = GARandomInt(0, dad.length());
       dadsite[1] = GARandomInt(0, dad.length());
       if(dadsite[0] > dadsite[1]) SWAP(dadsite[0], dadsite[1]);
@@ -771,13 +771,13 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
 
 
 
-// Even and odd crossover for the array works just like it does for the 
+// Even and odd crossover for the array works just like it does for the
 // binary strings.  For even crossover we take the 0th element and every other
 // one after that from the mother.  The 1st and every other come from the
 // father.  For odd crossover, we do just the opposite.
 template <class T> int
 GA1DArrayGenome<T>::
-EvenOddCrossover(const GAGenome& p1, const GAGenome& p2, 
+EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
 		 GAGenome* c1, GAGenome* c2){
   const GA1DArrayGenome<T> &mom=DYN_CAST(const GA1DArrayGenome<T> &, p1);
   const GA1DArrayGenome<T> &dad=DYN_CAST(const GA1DArrayGenome<T> &, p2);
@@ -816,10 +816,10 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
     nc = 2;
   }
   else if(c1 || c2){
-    GA1DArrayGenome<T> &sis = (c1 ? 
-			       DYN_CAST(GA1DArrayGenome<T> &, *c1) : 
+    GA1DArrayGenome<T> &sis = (c1 ?
+			       DYN_CAST(GA1DArrayGenome<T> &, *c1) :
 			       DYN_CAST(GA1DArrayGenome<T> &, *c2));
-    
+
     if(mom.length() == dad.length() && sis.length() == mom.length()){
       for(i=sis.length()-1; i>=1; i-=2){
 	sis.gene(i, mom.gene(i));
@@ -853,7 +853,7 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
 //   We make sure that b will be greater than a.
 template <class T> int
 GA1DArrayGenome<T>::
-PartialMatchCrossover(const GAGenome& p1, const GAGenome& p2, 
+PartialMatchCrossover(const GAGenome& p1, const GAGenome& p2,
 		      GAGenome* c1, GAGenome* c2){
   const GA1DArrayGenome<T> &mom=DYN_CAST(const GA1DArrayGenome<T> &, p1);
   const GA1DArrayGenome<T> &dad=DYN_CAST(const GA1DArrayGenome<T> &, p2);
@@ -868,7 +868,7 @@ PartialMatchCrossover(const GAGenome& p1, const GAGenome& p2,
     GAErr(GA_LOC, mom.className(), "parial match cross", gaErrBadParentLength);
     return nc;
   }
-  
+
   if(c1 && c2){
     GA1DArrayGenome<T> &sis=DYN_CAST(GA1DArrayGenome<T> &, *c1);
     GA1DArrayGenome<T> &bro=DYN_CAST(GA1DArrayGenome<T> &, *c2);
@@ -887,8 +887,8 @@ PartialMatchCrossover(const GAGenome& p1, const GAGenome& p2,
     nc = 2;
   }
   else if(c1 || c2){
-    GA1DArrayGenome<T> &sis = (c1 ? 
-			       DYN_CAST(GA1DArrayGenome<T> &, *c1) : 
+    GA1DArrayGenome<T> &sis = (c1 ?
+			       DYN_CAST(GA1DArrayGenome<T> &, *c1) :
 			       DYN_CAST(GA1DArrayGenome<T> &, *c2));
 
     const GA1DArrayGenome<T> *parent1, *parent2;
@@ -929,7 +929,7 @@ GA1DArrayIsHole(const GA1DArrayGenome<T> &c, const GA1DArrayGenome<T> &dad,
 //   This implementation isn't terribly smart.  For example, I do a linear
 // search rather than caching and doing binary search or smarter hash tables.
 //   First we copy the mother into the sister.  Then move the 'holes' into the
-// crossover section and maintain the ordering of the non-hole elements.  
+// crossover section and maintain the ordering of the non-hole elements.
 // Finally, put the 'holes' in the proper order within the crossover section.
 // After we have done the sister, we do the brother.
 template <class T> int
@@ -949,7 +949,7 @@ OrderCrossover(const GAGenome& p1, const GAGenome& p2,
     GAErr(GA_LOC, mom.className(), "order cross", gaErrBadParentLength);
     return nc;
   }
-  
+
   if(c1 && c2){
     GA1DArrayGenome<T> &sis=DYN_CAST(GA1DArrayGenome<T> &, *c1);
     GA1DArrayGenome<T> &bro=DYN_CAST(GA1DArrayGenome<T> &, *c2);
@@ -962,7 +962,7 @@ OrderCrossover(const GAGenome& p1, const GAGenome& p2,
       if(index >= sis.size()) index=0;
       if(GA1DArrayIsHole(sis,dad,index,a,b)) break;
     }
-    
+
     for(; i<sis.size()-b+a; i++, index++){
       if(index >= sis.size()) index=0;
       j=index;
@@ -999,7 +999,7 @@ OrderCrossover(const GAGenome& p1, const GAGenome& p2,
       } while(GA1DArrayIsHole(bro,mom,j,a,b));
       bro.swap(index,j);
     }
-    
+
 // Now put the 'holes' in the proper order within the crossover section.
     for(i=a; i<b; i++){
       if(bro.gene(i) != mom.gene(i)){
@@ -1011,8 +1011,8 @@ OrderCrossover(const GAGenome& p1, const GAGenome& p2,
     nc = 2;
   }
   else if(c1 || c2){
-    GA1DArrayGenome<T> &sis = (c1 ? 
-			       DYN_CAST(GA1DArrayGenome<T> &, *c1) : 
+    GA1DArrayGenome<T> &sis = (c1 ?
+			       DYN_CAST(GA1DArrayGenome<T> &, *c1) :
 			       DYN_CAST(GA1DArrayGenome<T> &, *c2));
 
     const GA1DArrayGenome<T> *parent1, *parent2;
@@ -1053,7 +1053,7 @@ OrderCrossover(const GAGenome& p1, const GAGenome& p2,
 
 
 
-// Cycle crossover for the 1D array genome.  This is implemented as described 
+// Cycle crossover for the 1D array genome.  This is implemented as described
 // in goldberg's book.  The first is picked from mom, then cycle using dad.
 // Finally, fill in the gaps with the elements from dad.
 //   We allocate space for a temporary array in this routine.  It never frees
@@ -1063,8 +1063,8 @@ OrderCrossover(const GAGenome& p1, const GAGenome& p2,
 //  Allocate space for an array of flags.  We use this to keep track of whether
 // the child's contents came from the mother or the father.  We don't free the
 // space here, but it is not a memory leak.
-//   The first step is to cycle through mom & dad to get the cyclic part of 
-// the crossover.  Then fill in the rest of the sis with dad's contents that 
+//   The first step is to cycle through mom & dad to get the cyclic part of
+// the crossover.  Then fill in the rest of the sis with dad's contents that
 // we didn't use in the cycle.  Finally, do the same thing for the other child.
 //   Notice that this implementation makes serious use of the operator= for the
 // objects in the array.  It also requires the operator != and == comparators.
@@ -1139,7 +1139,7 @@ CycleCrossover(const GAGenome& p1, const GAGenome& p2,
     GAMask mask;
     mask.size(sis.length());
     mask.clear();
-    
+
     sis.gene(0, parent1->gene(0));
     mask[0] = 1;
     while(parent2->gene(current) != parent1->gene(0)){

--- a/Global_static_MPFA/source/ga-mpi/GA1DBinStrGenome.C
+++ b/Global_static_MPFA/source/ga-mpi/GA1DBinStrGenome.C
@@ -27,13 +27,13 @@
 // this point - initialization must be done explicitly by the user of the
 // genome (eg when the population is created or reset).  If we called the
 // initializer routine here then we could end up with multiple initializations
-// and/or calls to dummy initializers (for example when the genome is 
+// and/or calls to dummy initializers (for example when the genome is
 // created with a dummy initializer and the initializer is assigned later on).
 GA1DBinaryStringGenome::
-GA1DBinaryStringGenome(unsigned int len, 
+GA1DBinaryStringGenome(unsigned int len,
 		       GAGenome::Evaluator f, void * u) :
 GABinaryString(len),
-GAGenome(DEFAULT_1DBINSTR_INITIALIZER, 
+GAGenome(DEFAULT_1DBINSTR_INITIALIZER,
 	 DEFAULT_1DBINSTR_MUTATOR,
 	 DEFAULT_1DBINSTR_COMPARATOR) {
   evaluator(f);
@@ -60,7 +60,7 @@ GA1DBinaryStringGenome::~GA1DBinaryStringGenome() {
 
 
 // The clone member creates a duplicate (exact or just attributes, depending
-// on the flag).  The caller is responsible for freeing the memory that is 
+// on the flag).  The caller is responsible for freeing the memory that is
 // allocated by this method.
 GAGenome*
 GA1DBinaryStringGenome::clone(GAGenome::CloneMethod flag) const {
@@ -81,7 +81,7 @@ GA1DBinaryStringGenome::clone(GAGenome::CloneMethod flag) const {
 // what we define here - a virtual function).  We should check to be sure that
 // both genomes are the same class and same dimension.  This function tries
 // to be smart about they way it copies.  If we already have data, then we do
-// a memcpy of the one we're supposed to copy.  If we don't or we're not the 
+// a memcpy of the one we're supposed to copy.  If we don't or we're not the
 // same size as the one we're supposed to copy, then we adjust ourselves.
 //   The BinaryStringGenome takes care of the resize in its copy method.
 // It also copies the bitstring for us.
@@ -89,7 +89,7 @@ void
 GA1DBinaryStringGenome::copy(const GAGenome & orig)
 {
   if(&orig == this) return;
-  const GA1DBinaryStringGenome* c = 
+  const GA1DBinaryStringGenome* c =
     DYN_CAST(const GA1DBinaryStringGenome*, &orig);
   if(c) {
     GAGenome::copy(*c);
@@ -173,7 +173,7 @@ GA1DBinaryStringGenome::write(STD_OSTREAM & os) const
 //   Set the resize behaviour of the genome.  A genome can be fixed
 // length, resizeable with a max and min limit, or resizeable with no limits
 // (other than an implicit one that we use internally).
-//   A value of 0 means no resize, a value less than zero mean unlimited 
+//   A value of 0 means no resize, a value less than zero mean unlimited
 // resize, and a positive value means resize with that value as the limit.
 //   We return the upper limit of the genome's size.
 int
@@ -190,21 +190,21 @@ resizeBehaviour(unsigned int lower, unsigned int upper)
   return resizeBehaviour();
 }
 
-int 
+int
 GA1DBinaryStringGenome::resizeBehaviour() const {
   int val = maxX;
   if(maxX == minX) val = FIXED_SIZE;
   return val;
 }
 
-int 
+int
 GA1DBinaryStringGenome::
 equal(const GA1DBinaryStringGenome& c,
       unsigned int dest, unsigned int src, unsigned int len) const {
   return GABinaryString::equal(c,dest,src,len);
 }
 
-int 
+int
 GA1DBinaryStringGenome::equal(const GAGenome & c) const {
   if(this == &c) return 1;
   const GA1DBinaryStringGenome* b = DYN_CAST(const GA1DBinaryStringGenome*,&c);
@@ -231,7 +231,7 @@ GA1DBinaryStringGenome::equal(const GAGenome & c) const {
 // random bit function so we don't have to worry about machine-specific stuff.
 //   We also do a resize so the genome can resize itself (randomly) if it
 // is a resizeable genome.
-void 
+void
 GA1DBinaryStringGenome::UniformInitializer(GAGenome & c)
 {
   GA1DBinaryStringGenome &child=DYN_CAST(GA1DBinaryStringGenome &, c);
@@ -242,7 +242,7 @@ GA1DBinaryStringGenome::UniformInitializer(GAGenome & c)
 
 
 //   Unset all of the bits in the genome.
-void 
+void
 GA1DBinaryStringGenome::UnsetInitializer(GAGenome & c)
 {
   GA1DBinaryStringGenome &child=DYN_CAST(GA1DBinaryStringGenome &, c);
@@ -252,7 +252,7 @@ GA1DBinaryStringGenome::UnsetInitializer(GAGenome & c)
 
 
 //   Set all of the bits in the genome.
-void 
+void
 GA1DBinaryStringGenome::SetInitializer(GAGenome & c)
 {
   GA1DBinaryStringGenome &child=DYN_CAST(GA1DBinaryStringGenome &, c);
@@ -271,11 +271,11 @@ GA1DBinaryStringGenome::SetInitializer(GAGenome & c)
 // better the chance that it will match the desired mutation rate.
 //   If nMut is greater than 1, then we round up, so a mutation of 2.2 would
 // be 3 mutations, and 2.9 would be 3 as well.  nMut of 3 would be 3 mutations.
-int 
+int
 GA1DBinaryStringGenome::FlipMutator(GAGenome & c, float pmut)
 {
   GA1DBinaryStringGenome &child=DYN_CAST(GA1DBinaryStringGenome &, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float, child.length());
@@ -298,10 +298,10 @@ GA1DBinaryStringGenome::FlipMutator(GAGenome & c, float pmut)
 }
 
 
-// Return a number from 0 to 1 to indicate how similar two genomes are.  For 
+// Return a number from 0 to 1 to indicate how similar two genomes are.  For
 // the binary strings we compare bits.  We count the number of bits that are
 // the same then divide by the number of bits.  If the genomes are different
-// length then we return a -1 to indicate that we cannot calculate the 
+// length then we return a -1 to indicate that we cannot calculate the
 // similarity.
 //   Normal hamming distance makes use of population information - this is not
 // a hamming measure!  This is a similarity measure of two individuals, not
@@ -334,7 +334,7 @@ GA1DBinaryStringGenome::BitComparator(const GAGenome& a, const GAGenome& b){
 
 
 // Randomly take bits from each parent.  For each bit we flip a coin to see if
-// that bit should come from the mother or the father.  This operator can be 
+// that bit should come from the mother or the father.  This operator can be
 // used on genomes of different lengths, but the crossover is truncated to the
 // shorter of the parents and child.
 int
@@ -385,8 +385,8 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
     n = 2;
   }
   else if(c1 || c2){
-    GA1DBinaryStringGenome &sis = (c1 ? 
-				   DYN_CAST(GA1DBinaryStringGenome&, *c1) : 
+    GA1DBinaryStringGenome &sis = (c1 ?
+				   DYN_CAST(GA1DBinaryStringGenome&, *c1) :
 				   DYN_CAST(GA1DBinaryStringGenome&, *c2));
 
     if(mom.length() == dad.length() && sis.length() == mom.length()){
@@ -434,7 +434,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour() == GAGenome::FIXED_SIZE){
-      if(mom.length() != dad.length() || 
+      if(mom.length() != dad.length() ||
 	 sis.length() != bro.length() ||
 	 sis.length() != mom.length()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -461,12 +461,12 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
     sis.copy(dad, momsite, dadsite, dadlen);
     bro.copy(dad, 0, 0, dadsite);
     bro.copy(mom, dadsite, momsite, momlen);
-  
+
     n = 2;
   }
   else if(c1 || c2){
-    GA1DBinaryStringGenome &sis = (c1 ? 
-				   DYN_CAST(GA1DBinaryStringGenome&, *c1) : 
+    GA1DBinaryStringGenome &sis = (c1 ?
+				   DYN_CAST(GA1DBinaryStringGenome&, *c1) :
 				   DYN_CAST(GA1DBinaryStringGenome&, *c2));
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE){
@@ -530,7 +530,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour() == GAGenome::FIXED_SIZE){
-      if(mom.length() != dad.length() || 
+      if(mom.length() != dad.length() ||
 	 sis.length() != bro.length() ||
 	 sis.length() != mom.length()){
 	GAErr(GA_LOC, mom.className(), "two-point cross", gaErrSameLengthReqd);
@@ -558,7 +558,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
       if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
-      
+
       dadsite[0] = GARandomInt(0, dad.length());
       dadsite[1] = GARandomInt(0, dad.length());
       if(dadsite[0] > dadsite[1]) SWAP(dadsite[0], dadsite[1]);
@@ -579,8 +579,8 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
     n = 2;
   }
   else if(c1 || c2){
-    GA1DBinaryStringGenome &sis = (c1 ? 
-				   DYN_CAST(GA1DBinaryStringGenome&, *c1) : 
+    GA1DBinaryStringGenome &sis = (c1 ?
+				   DYN_CAST(GA1DBinaryStringGenome&, *c1) :
 				   DYN_CAST(GA1DBinaryStringGenome&, *c2));
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE){
@@ -605,7 +605,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
       if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
-      
+
       dadsite[0] = GARandomInt(0, dad.length());
       dadsite[1] = GARandomInt(0, dad.length());
       if(dadsite[0] > dadsite[1]) SWAP(dadsite[0], dadsite[1]);
@@ -639,10 +639,10 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
 //   Even and odd crossovers take alternating bits from the mother and father.
 // For even crossover, we take every even bit from the mother and every odd bit
 // from the father (the first bit is the 0th bit, so it is even).  Odd
-// crossover is just the opposite.  
+// crossover is just the opposite.
 int
 GA1DBinaryStringGenome::
-EvenOddCrossover(const GAGenome& p1, const GAGenome& p2, 
+EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
 		 GAGenome* c1, GAGenome* c2){
   const GA1DBinaryStringGenome &mom=
     DYN_CAST(const GA1DBinaryStringGenome &, p1);
@@ -685,7 +685,7 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
   }
   else if(c1 || c2){
     GA1DBinaryStringGenome &sis = (c1 ?
-				   DYN_CAST(GA1DBinaryStringGenome&, *c1) : 
+				   DYN_CAST(GA1DBinaryStringGenome&, *c1) :
 				   DYN_CAST(GA1DBinaryStringGenome&, *c2));
 
     if(mom.length() == dad.length() && sis.length() == mom.length()){

--- a/Global_static_MPFA/source/ga-mpi/GA2DArrayGenome.C
+++ b/Global_static_MPFA/source/ga-mpi/GA2DArrayGenome.C
@@ -27,13 +27,13 @@ GA2DArrayGenome<T>::className() const {return "GA2DArrayGenome";}
 template <class T> int
 GA2DArrayGenome<T>::classID() const {return GAID::ArrayGenome2D;}
 
-template <class T> 
+template <class T>
 GA2DArrayGenome<T>::
-GA2DArrayGenome(unsigned int width, unsigned int height, 
+GA2DArrayGenome(unsigned int width, unsigned int height,
 		GAGenome::Evaluator f,
 		void * u) :
 GAArray<T>(width*height),
-GAGenome(DEFAULT_2DARRAY_INITIALIZER, 
+GAGenome(DEFAULT_2DARRAY_INITIALIZER,
 	 DEFAULT_2DARRAY_MUTATOR,
 	 DEFAULT_2DARRAY_COMPARATOR)
 {
@@ -44,7 +44,7 @@ GAGenome(DEFAULT_2DARRAY_INITIALIZER,
 }
 
 
-template <class T> 
+template <class T>
 GA2DArrayGenome<T>::
 GA2DArrayGenome(const GA2DArrayGenome<T> & orig) : GAArray<T>(orig.sz){
   GA2DArrayGenome<T>::copy(orig);
@@ -62,10 +62,10 @@ GA2DArrayGenome<T>::copy(const GAGenome & orig){
   if(c) {
     GAGenome::copy(*c);
     GAArray<T>::copy(*c);
-    nx = c->nx; ny = c->ny; 
-    minX = c->minX; minY = c->minY; 
+    nx = c->nx; ny = c->ny;
+    minX = c->minX; minY = c->minY;
     maxX = c->maxX; maxY = c->maxY;
-  } 
+  }
 }
 
 
@@ -77,8 +77,8 @@ GA2DArrayGenome<T>::clone(GAGenome::CloneMethod flag) const {
   }
   else{
     cpy->GAGenome::copy(*this);
-    cpy->minX = minX; cpy->minY = minY; 
-    cpy->maxX = maxX; cpy->maxY = maxY; 
+    cpy->minX = minX; cpy->minY = minY;
+    cpy->maxX = maxX; cpy->maxY = maxY;
   }
   return cpy;
 }
@@ -137,7 +137,7 @@ GA2DArrayGenome<T>::read(STD_ISTREAM &) {
 
 
 template <class T> int
-GA2DArrayGenome<T>::write(STD_OSTREAM & os) const 
+GA2DArrayGenome<T>::write(STD_OSTREAM & os) const
 {
   for(unsigned int j=0; j<ny; j++){
     for(unsigned int i=0; i<nx; i++){
@@ -167,7 +167,7 @@ GA2DArrayGenome<T>::resizeBehaviour(GAGenome::Dimension which) const {
 
 template <class T> int
 GA2DArrayGenome<T>::
-resizeBehaviour(GAGenome::Dimension which, 
+resizeBehaviour(GAGenome::Dimension which,
 		unsigned int lower, unsigned int upper)
 {
   if(upper < lower){
@@ -212,12 +212,12 @@ GA2DArrayGenome<T>::copy(const GA2DArrayGenome<T> & orig,
   for(unsigned int j=0; j<h; j++)
     GAArray<T>::copy(orig, (s+j)*nx+r, (y+j)*orig.nx+x, w);
 
-  _evaluated = gaFalse; 
+  _evaluated = gaFalse;
 }
 
 
 
-template <class T> int 
+template <class T> int
 GA2DArrayGenome<T>::equal(const GAGenome & c) const
 {
   if(this == &c) return 1;
@@ -259,9 +259,9 @@ GA2DArrayAlleleGenome<T>::className() const {return "GA2DArrayAlleleGenome";}
 template <class T> int
 GA2DArrayAlleleGenome<T>::classID() const {return GAID::ArrayAlleleGenome2D;}
 
-template <class T> 
+template <class T>
 GA2DArrayAlleleGenome<T>::
-GA2DArrayAlleleGenome(unsigned int width, unsigned int height, 
+GA2DArrayAlleleGenome(unsigned int width, unsigned int height,
 		      const GAAlleleSet<T> & s,
 		      GAGenome::Evaluator f, void * u) :
 GA2DArrayGenome<T>(width,height,f,u){
@@ -275,9 +275,9 @@ GA2DArrayGenome<T>(width,height,f,u){
   this->crossover(GA2DArrayAlleleGenome<T>::DEFAULT_2DARRAY_ALLELE_CROSSOVER);
 }
 
-template <class T> 
+template <class T>
 GA2DArrayAlleleGenome<T>::
-GA2DArrayAlleleGenome(unsigned int width, unsigned int height, 
+GA2DArrayAlleleGenome(unsigned int width, unsigned int height,
 		      const GAAlleleSetArray<T> & sa,
 		      GAGenome::Evaluator f, void * u) :
 GA2DArrayGenome<T>(width,height, f, u) {
@@ -293,9 +293,9 @@ GA2DArrayGenome<T>(width,height, f, u) {
 }
 
 
-template <class T> 
+template <class T>
 GA2DArrayAlleleGenome<T>::
-GA2DArrayAlleleGenome(const GA2DArrayAlleleGenome<T> & orig) : 
+GA2DArrayAlleleGenome(const GA2DArrayAlleleGenome<T> & orig) :
 GA2DArrayGenome<T>(orig.nx, orig.ny) {
   naset = 0;
   aset = (GAAlleleSet<T>*)0;
@@ -315,10 +315,10 @@ GA2DArrayAlleleGenome<T>::clone(GAGenome::CloneMethod) const {
 }
 
 
-template <class T> void 
+template <class T> void
 GA2DArrayAlleleGenome<T>::copy(const GAGenome& orig){
   if(&orig == this) return;
-  const GA2DArrayAlleleGenome<T>* c = 
+  const GA2DArrayAlleleGenome<T>* c =
     DYN_CAST(const GA2DArrayAlleleGenome<T>*, &orig);
   if(c) {
     GA2DArrayGenome<T>::copy(*c);
@@ -386,24 +386,24 @@ GA2DArrayAlleleGenome<T>::equal(const GAGenome & c) const {
    Operator definitions
 ---------------------------------------------------------------------------- */
 // this does not handle genomes with multiple allele sets!
-template <class ARRAY_TYPE> void 
+template <class ARRAY_TYPE> void
 GA2DArrayAlleleGenome<ARRAY_TYPE>::UniformInitializer(GAGenome & c)
 {
   GA2DArrayAlleleGenome<ARRAY_TYPE> &child=
     DYN_CAST(GA2DArrayAlleleGenome<ARRAY_TYPE> &, c);
-  child.resize(GAGenome::ANY_SIZE,GAGenome::ANY_SIZE); 
+  child.resize(GAGenome::ANY_SIZE,GAGenome::ANY_SIZE);
   for(int i=child.width()-1; i>=0; i--)
     for(int j=child.height()-1; j>=0; j--)
       child.gene(i, j, child.alleleset().allele());
 }
 
 
-template <class ARRAY_TYPE> int 
+template <class ARRAY_TYPE> int
 GA2DArrayAlleleGenome<ARRAY_TYPE>::FlipMutator(GAGenome & c, float pmut)
 {
   GA2DArrayAlleleGenome<ARRAY_TYPE> &child=
     DYN_CAST(GA2DArrayAlleleGenome<ARRAY_TYPE> &, c);
-  register int n, m, i, j;
+  int n, m, i, j;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.size());
@@ -430,11 +430,11 @@ GA2DArrayAlleleGenome<ARRAY_TYPE>::FlipMutator(GAGenome & c, float pmut)
 }
 
 
-template <class ARRAY_TYPE> int 
+template <class ARRAY_TYPE> int
 GA2DArrayGenome<ARRAY_TYPE>::SwapMutator(GAGenome & c, float pmut)
 {
   GA2DArrayGenome<ARRAY_TYPE> &child=DYN_CAST(GA2DArrayGenome<ARRAY_TYPE>&, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.size());
@@ -496,7 +496,7 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
   if(c1 && c2){
     GA2DArrayGenome<T> &sis=DYN_CAST(GA2DArrayGenome<T> &, *c1);
     GA2DArrayGenome<T> &bro=DYN_CAST(GA2DArrayGenome<T> &, *c2);
-    
+
     if(sis.width() == bro.width() && sis.height() == bro.height() &&
        mom.width() == dad.width() && mom.height() == dad.height() &&
        sis.width() == mom.width() && sis.height() == mom.height()){
@@ -567,7 +567,7 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
 
 
 // This crossover does clipping (no padding) for resizables.  Notice that this
-// means that any resizable children of two parents will have identical 
+// means that any resizable children of two parents will have identical
 // dimensions no matter what.
 template <class T> int
 GA2DArrayGenome<T>::
@@ -587,8 +587,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE){
-      if(mom.width() != dad.width() || 
-	 sis.width() != bro.width() || 
+      if(mom.width() != dad.width() ||
+	 sis.width() != bro.width() ||
 	 sis.width() != mom.width()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -612,8 +612,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
-      if(mom.height() != dad.height() || 
-	 sis.height() != bro.height() || 
+      if(mom.height() != dad.height() ||
+	 sis.height() != bro.height() ||
 	 sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -637,12 +637,12 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     sis.resize(sitex+lenx, sitey+leny);
     bro.resize(sitex+lenx, sitey+leny);
-    
+
     sis.copy(mom, 0, 0, momsitex-sitex, momsitey-sitey, sitex, sitey);
     sis.copy(dad, sitex, 0, dadsitex, dadsitey-sitey, lenx, sitey);
     sis.copy(dad, 0, sitey, dadsitex-sitex, dadsitey, sitex, leny);
     sis.copy(mom, sitex, sitey, momsitex, momsitey, lenx, leny);
-    
+
     bro.copy(dad, 0, 0, dadsitex-sitex, dadsitey-sitey, sitex, sitey);
     bro.copy(mom, sitex, 0, momsitex, momsitey-sitey, lenx, sitey);
     bro.copy(mom, 0, sitey, momsitex-sitex, momsitey, sitex, leny);
@@ -652,7 +652,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
   }
   else if(c1){
     GA2DArrayGenome<T> &sis=DYN_CAST(GA2DArrayGenome<T> &, *c1);
-    
+
     if(sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE){
       if(mom.width() != dad.width() || sis.width() != mom.width()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -669,7 +669,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitex = GAMin(momsitex, dadsitex);
       lenx = GAMin(momlenx, dadlenx);
     }
-    
+
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
       if(mom.height() != dad.height() || sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -686,9 +686,9 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitey = GAMin(momsitey, dadsitey);
       leny = GAMin(momleny, dadleny);
     }
-    
+
     sis.resize(sitex+lenx, sitey+leny);
-    
+
     if(GARandomBit()){
       sis.copy(mom, 0, 0, momsitex-sitex, momsitey-sitey, sitex, sitey);
       sis.copy(dad, sitex, 0, dadsitex, dadsitey-sitey, lenx, sitey);
@@ -759,7 +759,7 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
   }
   else if(c1){
     GA2DArrayGenome<T> &sis=DYN_CAST(GA2DArrayGenome<T> &, *c1);
-    
+
     if(mom.width() == dad.width() && mom.height() == dad.height() &&
        sis.width() == mom.width() && sis.height() == mom.height()){
       int count=0;

--- a/Global_static_MPFA/source/ga-mpi/GA2DBinStrGenome.C
+++ b/Global_static_MPFA/source/ga-mpi/GA2DBinStrGenome.C
@@ -21,7 +21,7 @@
    Genome class definition
 ---------------------------------------------------------------------------- */
 GA2DBinaryStringGenome::
-GA2DBinaryStringGenome(unsigned int width, unsigned int height, 
+GA2DBinaryStringGenome(unsigned int width, unsigned int height,
 		       GAGenome::Evaluator f, void * u) :
 GABinaryString(width*height),
 GAGenome(DEFAULT_2DBINSTR_INITIALIZER,
@@ -54,8 +54,8 @@ GA2DBinaryStringGenome::clone(GAGenome::CloneMethod flag) const {
   }
   else{
     cpy->GAGenome::copy(*this);
-    cpy->minX = minX; cpy->minY = minY; 
-    cpy->maxX = maxX; cpy->maxY = maxY; 
+    cpy->minX = minX; cpy->minY = minY;
+    cpy->maxX = maxX; cpy->maxY = maxY;
   }
   return cpy;
 }
@@ -69,10 +69,10 @@ GA2DBinaryStringGenome::copy(const GAGenome & orig)
   if(c) {
     GAGenome::copy(*c);
     GABinaryString::copy(*c);
-    nx = c->nx; ny = c->ny; 
-    minX = c->minX; minY = c->minY; 
+    nx = c->nx; ny = c->ny;
+    minX = c->minX; minY = c->minY;
     maxX = c->maxX; maxY = c->maxY;
-  } 
+  }
 }
 
 
@@ -105,7 +105,7 @@ GA2DBinaryStringGenome::resize(int w, int h)
 
 // Move the bits into the right position.  If we're smaller, then shift to
 // the smaller size before we do the resize (the resize method maintains bit
-// integrety).  If we're larger, do the move after the resize.  If we're the 
+// integrety).  If we're larger, do the move after the resize.  If we're the
 // same size the we don't do anything.  When we're adding more bits, the new
 // bits get set randomly to 0 or 1.
 
@@ -153,7 +153,7 @@ GA2DBinaryStringGenome::read(STD_ISTREAM & is)
 
   _evaluated = gaFalse;
 
-  if(is.eof() && 
+  if(is.eof() &&
      ((j < ny) ||	     // didn't get some lines
       (i < nx && i != 0))){   // stopped early on a row
     GAErr(GA_LOC, className(), "read", gaErrUnexpectedEOF);
@@ -168,7 +168,7 @@ GA2DBinaryStringGenome::read(STD_ISTREAM & is)
 // Dump the digits to the stream with a newline between each row.  No newline
 // at the end of the whole thing.
 int
-GA2DBinaryStringGenome::write(STD_OSTREAM & os) const 
+GA2DBinaryStringGenome::write(STD_OSTREAM & os) const
 {
   for(unsigned int j=0; j<ny; j++){
     for(unsigned int i=0; i<nx; i++)
@@ -180,7 +180,7 @@ GA2DBinaryStringGenome::write(STD_OSTREAM & os) const
 #endif
 
 
-int 
+int
 GA2DBinaryStringGenome::resizeBehaviour(GAGenome::Dimension which) const {
   int val = 0;
   if(which == WIDTH) {
@@ -318,7 +318,7 @@ GA2DBinaryStringGenome::equal(const GA2DBinaryStringGenome& orig,
 }
 
 
-int 
+int
 GA2DBinaryStringGenome::equal(const GAGenome & c) const
 {
   if(this == &c) return 1;
@@ -344,7 +344,7 @@ GA2DBinaryStringGenome::equal(const GAGenome & c) const
   The order for looping through indices is height-then-width (ie height loops
 before a single width increment)
 ---------------------------------------------------------------------------- */
-void 
+void
 GA2DBinaryStringGenome::UniformInitializer(GAGenome & c)
 {
   GA2DBinaryStringGenome &child=DYN_CAST(GA2DBinaryStringGenome &, c);
@@ -355,7 +355,7 @@ GA2DBinaryStringGenome::UniformInitializer(GAGenome & c)
 }
 
 
-void 
+void
 GA2DBinaryStringGenome::UnsetInitializer(GAGenome & c)
 {
   GA2DBinaryStringGenome &child=DYN_CAST(GA2DBinaryStringGenome &, c);
@@ -364,20 +364,20 @@ GA2DBinaryStringGenome::UnsetInitializer(GAGenome & c)
 }
 
 
-void 
+void
 GA2DBinaryStringGenome::SetInitializer(GAGenome & c)
 {
   GA2DBinaryStringGenome &child=DYN_CAST(GA2DBinaryStringGenome &, c);
-  child.resize(GAGenome::ANY_SIZE, GAGenome::ANY_SIZE);	
+  child.resize(GAGenome::ANY_SIZE, GAGenome::ANY_SIZE);
   child.set(0, 0, child.width(), child.height());
 }
 
 
-int 
+int
 GA2DBinaryStringGenome::FlipMutator(GAGenome & c, float pmut)
 {
   GA2DBinaryStringGenome &child=DYN_CAST(GA2DBinaryStringGenome &, c);
-  register int n, m, i, j;
+  int n, m, i, j;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float, child.size());
@@ -431,7 +431,7 @@ GA2DBinaryStringGenome::BitComparator(const GAGenome& a, const GAGenome& b){
 
 int
 GA2DBinaryStringGenome::
-UniformCrossover(const GAGenome& p1, const GAGenome& p2, 
+UniformCrossover(const GAGenome& p1, const GAGenome& p2,
 		 GAGenome* c1, GAGenome* c2){
   const GA2DBinaryStringGenome &mom=
     DYN_CAST(const GA2DBinaryStringGenome &, p1);
@@ -486,8 +486,8 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
     nc = 2;
   }
   else if(c1 || c2){
-    GA2DBinaryStringGenome &sis = (c1 ? 
-				   DYN_CAST(GA2DBinaryStringGenome&, *c1) : 
+    GA2DBinaryStringGenome &sis = (c1 ?
+				   DYN_CAST(GA2DBinaryStringGenome&, *c1) :
 				   DYN_CAST(GA2DBinaryStringGenome&, *c2));
 
     if(mom.width() == dad.width() && mom.height() == dad.height() &&
@@ -515,13 +515,13 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
 
 //   When we do single point crossover on resizable 2D genomes we can either
 // clip or pad to make the mismatching geometries work out.  Either way, both
-// children end up with the same dimensions (the children have the same 
+// children end up with the same dimensions (the children have the same
 // dimensions as each other, not the same as if they were clipped/padded).
 //   When we pad, the extra space is filled with random bits.  This
 // implementation does only clipping, no padding!
 int
 GA2DBinaryStringGenome::
-OnePointCrossover(const GAGenome& p1, const GAGenome& p2, 
+OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 		  GAGenome* c1, GAGenome* c2){
   const GA2DBinaryStringGenome &mom=
     DYN_CAST(const GA2DBinaryStringGenome &, p1);
@@ -539,8 +539,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE){
-      if(mom.width() != dad.width() || 
-	 sis.width() != bro.width() || 
+      if(mom.width() != dad.width() ||
+	 sis.width() != bro.width() ||
 	 sis.width() != mom.width()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -564,8 +564,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
-      if(mom.height() != dad.height() || 
-	 sis.height() != bro.height() || 
+      if(mom.height() != dad.height() ||
+	 sis.height() != bro.height() ||
 	 sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -640,9 +640,9 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitey = GAMin(momsitey, dadsitey);
       leny = GAMin(momleny, dadleny);
     }
-    
+
     sis.resize(sitex+lenx, sitey+leny);
-    
+
     if(GARandomBit()){
       sis.copy(mom, 0, 0, momsitex-sitex, momsitey-sitey, sitex, sitey);
       sis.copy(dad, sitex, 0, dadsitex, dadsitey-sitey, lenx, sitey);
@@ -666,7 +666,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
 int
 GA2DBinaryStringGenome::
-EvenOddCrossover(const GAGenome& p1, const GAGenome& p2, 
+EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
 		 GAGenome* c1, GAGenome* c2){
   const GA2DBinaryStringGenome &mom=
     DYN_CAST(const GA2DBinaryStringGenome &, p1);
@@ -679,7 +679,7 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
   if(c1 && c2){
     GA2DBinaryStringGenome &sis=DYN_CAST(GA2DBinaryStringGenome &, *c1);
     GA2DBinaryStringGenome &bro=DYN_CAST(GA2DBinaryStringGenome &, *c2);
-    
+
     if(sis.width() == bro.width() && sis.height() == bro.height() &&
        mom.width() == dad.width() && mom.height() == dad.height() &&
        sis.width() == mom.width() && sis.height() == mom.height()){
@@ -719,10 +719,10 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
     nc = 2;
   }
   else if(c1 || c2){
-    GA2DBinaryStringGenome &sis = (c1 ? 
+    GA2DBinaryStringGenome &sis = (c1 ?
 				   DYN_CAST(GA2DBinaryStringGenome&, *c1) :
 				   DYN_CAST(GA2DBinaryStringGenome&, *c2));
-    
+
     if(mom.width() == dad.width() && mom.height() == dad.height() &&
        sis.width() == mom.width() && sis.height() == mom.height()){
       int count=0;

--- a/Global_static_MPFA/source/ga-mpi/GA3DArrayGenome.C
+++ b/Global_static_MPFA/source/ga-mpi/GA3DArrayGenome.C
@@ -27,13 +27,13 @@ GA3DArrayGenome<T>::className() const {return "GA3DArrayGenome";}
 template <class T> int
 GA3DArrayGenome<T>::classID() const {return GAID::ArrayGenome3D;}
 
-template <class T> 
+template <class T>
 GA3DArrayGenome<T>::
 GA3DArrayGenome(unsigned int w, unsigned int h, unsigned int d,
 		GAGenome::Evaluator f,
 		void * u) :
 GAArray<T>(w*h*d),
-GAGenome(DEFAULT_3DARRAY_INITIALIZER, 
+GAGenome(DEFAULT_3DARRAY_INITIALIZER,
 	 DEFAULT_3DARRAY_MUTATOR,
 	 DEFAULT_3DARRAY_COMPARATOR)
 {
@@ -44,7 +44,7 @@ GAGenome(DEFAULT_3DARRAY_INITIALIZER,
 }
 
 
-template <class T> 
+template <class T>
 GA3DArrayGenome<T>::
 GA3DArrayGenome(const GA3DArrayGenome<T> & orig) :
 GAArray<T>(orig.sz), GAGenome(){
@@ -78,7 +78,7 @@ GA3DArrayGenome<T>::clone(GAGenome::CloneMethod flag) const {
   }
   else{
     cpy->GAGenome::copy(*this);
-    cpy->minX = minX; cpy->minY = minY; cpy->minZ = minZ; 
+    cpy->minX = minX; cpy->minY = minY; cpy->minZ = minZ;
     cpy->maxX = maxX; cpy->maxY = maxY; cpy->maxZ = maxZ;
   }
   return cpy;
@@ -145,7 +145,7 @@ GA3DArrayGenome<T>::resize(int w, int h, int d)
 
   GAArray<T>::size(w*h*d);
 
-  if(w > STA_CAST(int,nx) && h > STA_CAST(int,ny)){ 
+  if(w > STA_CAST(int,nx) && h > STA_CAST(int,ny)){
     int z=GAMin(STA_CAST(int,nz),d);
     for(int k=z-1; k>=0; k--)
       for(int j=ny-1; j>=0; j--)
@@ -179,7 +179,7 @@ GA3DArrayGenome<T>::read(STD_ISTREAM &) {
 
 
 template <class T> int
-GA3DArrayGenome<T>::write(STD_OSTREAM & os) const 
+GA3DArrayGenome<T>::write(STD_OSTREAM & os) const
 {
   for(unsigned int k=0; k<nz; k++){
     for(unsigned int j=0; j<ny; j++){
@@ -216,7 +216,7 @@ GA3DArrayGenome<T>::resizeBehaviour(GAGenome::Dimension which) const {
 
 template <class T> int
 GA3DArrayGenome<T>::
-resizeBehaviour(GAGenome::Dimension which, 
+resizeBehaviour(GAGenome::Dimension which,
 		unsigned int lower, unsigned int upper)
 {
   if(upper < lower){
@@ -278,7 +278,7 @@ copy(const GA3DArrayGenome<T> & orig,
 }
 
 
-template <class T> int 
+template <class T> int
 GA3DArrayGenome<T>::equal(const GAGenome & c) const
 {
   if(this == &c) return 1;
@@ -312,7 +312,7 @@ GA3DArrayAlleleGenome<T>::className() const {return "GA3DArrayAlleleGenome";}
 template <class T> int
 GA3DArrayAlleleGenome<T>::classID() const {return GAID::ArrayAlleleGenome3D;}
 
-template <class T> 
+template <class T>
 GA3DArrayAlleleGenome<T>::
 GA3DArrayAlleleGenome(unsigned int w, unsigned int h, unsigned int d,
 		      const GAAlleleSet<T> & s,
@@ -328,7 +328,7 @@ GA3DArrayGenome<T>(w,h,d,f,u) {
   this->crossover(GA3DArrayAlleleGenome<T>::DEFAULT_3DARRAY_ALLELE_CROSSOVER);
 }
 
-template <class T> 
+template <class T>
 GA3DArrayAlleleGenome<T>::
 GA3DArrayAlleleGenome(unsigned int w, unsigned int h, unsigned int d,
 		      const GAAlleleSetArray<T> & sa,
@@ -346,9 +346,9 @@ GA3DArrayGenome<T>(w,h,d, f, u) {
 }
 
 
-template <class T> 
+template <class T>
 GA3DArrayAlleleGenome<T>::
-GA3DArrayAlleleGenome(const GA3DArrayAlleleGenome<T> & orig) : 
+GA3DArrayAlleleGenome(const GA3DArrayAlleleGenome<T> & orig) :
 GA3DArrayGenome<T>(orig.nx, orig.ny, orig.nz) {
   naset = 0;
   aset = (GAAlleleSet<T>*)0;
@@ -368,10 +368,10 @@ GA3DArrayAlleleGenome<T>::clone(GAGenome::CloneMethod) const {
 }
 
 
-template <class T> void 
+template <class T> void
 GA3DArrayAlleleGenome<T>::copy(const GAGenome& orig){
   if(&orig == this) return;
-  const GA3DArrayAlleleGenome<T>* c = 
+  const GA3DArrayAlleleGenome<T>* c =
     DYN_CAST(const GA3DArrayAlleleGenome<T>*, &orig);
   if(c) {
     GA3DArrayGenome<T>::copy(*c);
@@ -414,7 +414,7 @@ GA3DArrayAlleleGenome<T>::resize(int w, int h, int d){
     for(int k=z-1; k>=0; k--)
       for(int j=this->ny-1; j>=0; j--)
 	for(unsigned int i=oldx; i<this->nx; i++)
-	  this->a[k*this->ny*this->nx+j*this->nx+i] = 
+	  this->a[k*this->ny*this->nx+j*this->nx+i] =
 	    aset[(k*this->ny*this->nx+j*this->nx+i) % naset].allele();
   }
   else if(this->ny > oldy){
@@ -463,7 +463,7 @@ GA3DArrayAlleleGenome<T>::equal(const GAGenome & c) const {
    Operator definitions
 ---------------------------------------------------------------------------- */
 // this does not handle genomes with multiple allele sets!
-template <class ARRAY_TYPE> void 
+template <class ARRAY_TYPE> void
 GA3DArrayAlleleGenome<ARRAY_TYPE>::UniformInitializer(GAGenome & c)
 {
   GA3DArrayAlleleGenome<ARRAY_TYPE> &child=
@@ -476,12 +476,12 @@ GA3DArrayAlleleGenome<ARRAY_TYPE>::UniformInitializer(GAGenome & c)
 }
 
 
-template <class ARRAY_TYPE> int 
+template <class ARRAY_TYPE> int
 GA3DArrayAlleleGenome<ARRAY_TYPE>::FlipMutator(GAGenome & c, float pmut)
 {
   GA3DArrayAlleleGenome<ARRAY_TYPE> &child=
     DYN_CAST(GA3DArrayAlleleGenome<ARRAY_TYPE> &, c);
-  register int n, m, d, i, j, k;
+  int n, m, d, i, j, k;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.size());
@@ -512,11 +512,11 @@ GA3DArrayAlleleGenome<ARRAY_TYPE>::FlipMutator(GAGenome & c, float pmut)
 }
 
 
-template <class ARRAY_TYPE> int 
+template <class ARRAY_TYPE> int
 GA3DArrayGenome<ARRAY_TYPE>::SwapMutator(GAGenome & c, float pmut)
 {
   GA3DArrayGenome<ARRAY_TYPE> &child=DYN_CAST(GA3DArrayGenome<ARRAY_TYPE>&, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.size());
@@ -568,7 +568,7 @@ ElementComparator(const GAGenome& a, const GAGenome& b)
 
 
 
-// Make sure our bitmask is big enough, generate a mask, then use it to 
+// Make sure our bitmask is big enough, generate a mask, then use it to
 // extract the information from each parent to stuff the two children.
 // We don't deallocate any space for the masks under the assumption that we'll
 // have to use them again in the future.
@@ -680,12 +680,12 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
 //   This is designed only for genomes that are the same length.  If the child
 // is not the same length as the parent, or if the children are not the same
 // size, we don't do the crossover.
-//   In the interest of speed we do not do any checks for size.  Do not use 
+//   In the interest of speed we do not do any checks for size.  Do not use
 // this crossover method when the parents and children may be different sizes.
 // It might break!
 template <class T> int
 GA3DArrayGenome<T>::
-EvenOddCrossover(const GAGenome& p1, const GAGenome& p2, 
+EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
 GAGenome* c1, GAGenome* c2){
   const GA3DArrayGenome<T> &mom=DYN_CAST(const GA3DArrayGenome<T> &, p1);
   const GA3DArrayGenome<T> &dad=DYN_CAST(const GA3DArrayGenome<T> &, p2);
@@ -696,7 +696,7 @@ GAGenome* c1, GAGenome* c2){
   if(c1 && c2){
     GA3DArrayGenome<T> &sis=DYN_CAST(GA3DArrayGenome<T> &, *c1);
     GA3DArrayGenome<T> &bro=DYN_CAST(GA3DArrayGenome<T> &, *c2);
-    
+
     if(sis.width() == bro.width() && sis.height() == bro.height() &&
        sis.depth() == bro.depth() &&
        mom.width() == dad.width() && mom.height() == dad.height() &&
@@ -806,8 +806,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE){
-      if(mom.width() != dad.width() || 
-	 sis.width() != bro.width() || 
+      if(mom.width() != dad.width() ||
+	 sis.width() != bro.width() ||
 	 sis.width() != mom.width()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -828,11 +828,11 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitex = GAMin(momsitex, dadsitex);
       lenx = GAMin(momlenx, dadlenx);
     }
-    
+
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
-      if(mom.height() != dad.height() || 
-	 sis.height() != bro.height() || 
+      if(mom.height() != dad.height() ||
+	 sis.height() != bro.height() ||
 	 sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -856,8 +856,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE){
-      if(mom.depth() != dad.depth() || 
-	 sis.depth() != bro.depth() || 
+      if(mom.depth() != dad.depth() ||
+	 sis.depth() != bro.depth() ||
 	 sis.depth() != mom.depth()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -882,8 +882,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
     sis.resize(sitex+lenx, sitey+leny, sitez+lenz);
     bro.resize(sitex+lenx, sitey+leny, sitez+lenz);
 
-    sis.copy(mom, 
-	     0, 0, 0, 
+    sis.copy(mom,
+	     0, 0, 0,
 	     momsitex-sitex, momsitey-sitey, momsitez-sitez,
 	     sitex, sitey, sitez);
     sis.copy(dad,
@@ -898,8 +898,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	     sitex, sitey, 0,
 	     momsitex, momsitey, momsitez-sitez,
 	     lenx, leny, sitez);
-    sis.copy(dad, 
-	     0, 0, sitez, 
+    sis.copy(dad,
+	     0, 0, sitez,
 	     dadsitex-sitex, dadsitey-sitey, dadsitez,
 	     sitex, sitey, lenz);
     sis.copy(mom,
@@ -914,9 +914,9 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	     sitex, sitey, sitez,
 	     dadsitex, dadsitey, dadsitez,
 	     lenx, leny, lenz);
-    
-    bro.copy(dad, 
-	     0, 0, 0, 
+
+    bro.copy(dad,
+	     0, 0, 0,
 	     dadsitex-sitex, dadsitey-sitey, dadsitez-sitez,
 	     sitex, sitey, sitez);
     bro.copy(mom,
@@ -931,8 +931,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	     sitex, sitey, 0,
 	     dadsitex, dadsitey, dadsitez-sitez,
 	     lenx, leny, sitez);
-    bro.copy(mom, 
-	     0, 0, sitez, 
+    bro.copy(mom,
+	     0, 0, sitez,
 	     momsitex-sitex, momsitey-sitey, momsitez,
 	     sitex, sitey, lenz);
     bro.copy(dad,
@@ -969,7 +969,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitex = GAMin(momsitex, dadsitex);
       lenx = GAMin(momlenx, dadlenx);
     }
-    
+
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
       if(mom.height() != dad.height() || sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -1003,12 +1003,12 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitez = GAMin(momsitez, dadsitez);
       lenz = GAMin(momlenz, dadlenz);
     }
-    
+
     sis.resize(sitex+lenx, sitey+leny, sitez+lenz);
-    
+
     if(GARandomBit()){
-      sis.copy(mom, 
-	       0, 0, 0, 
+      sis.copy(mom,
+	       0, 0, 0,
 	       momsitex-sitex, momsitey-sitey, momsitez-sitez,
 	       sitex, sitey, sitez);
       sis.copy(dad,
@@ -1023,8 +1023,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	       sitex, sitey, 0,
 	       momsitex, momsitey, momsitez-sitez,
 	       lenx, leny, sitez);
-      sis.copy(dad, 
-	       0, 0, sitez, 
+      sis.copy(dad,
+	       0, 0, sitez,
 	       dadsitex-sitex, dadsitey-sitey, dadsitez,
 	       sitex, sitey, lenz);
       sis.copy(mom,
@@ -1041,8 +1041,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	       lenx, leny, lenz);
     }
     else{
-      sis.copy(dad, 
-	       0, 0, 0, 
+      sis.copy(dad,
+	       0, 0, 0,
 	       dadsitex-sitex, dadsitey-sitey, dadsitez-sitez,
 	       sitex, sitey, sitez);
       sis.copy(mom,
@@ -1057,8 +1057,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	       sitex, sitey, 0,
 	       dadsitex, dadsitey, dadsitez-sitez,
 	       lenx, leny, sitez);
-      sis.copy(mom, 
-	       0, 0, sitez, 
+      sis.copy(mom,
+	       0, 0, sitez,
 	       momsitex-sitex, momsitey-sitey, momsitez,
 	       sitex, sitey, lenz);
       sis.copy(dad,

--- a/Global_static_MPFA/source/ga-mpi/GA3DBinStrGenome.C
+++ b/Global_static_MPFA/source/ga-mpi/GA3DBinStrGenome.C
@@ -56,7 +56,7 @@ GA3DBinaryStringGenome::clone(GAGenome::CloneMethod flag) const {
   }
   else{
     cpy->GAGenome::copy(*this);
-    cpy->minX = minX; cpy->minY = minY; cpy->minZ = minZ; 
+    cpy->minX = minX; cpy->minY = minY; cpy->minZ = minZ;
     cpy->maxX = maxX; cpy->maxY = maxY; cpy->maxZ = maxZ;
   }
   return cpy;
@@ -66,7 +66,7 @@ void
 GA3DBinaryStringGenome::copy(const GAGenome & orig)
 {
   if(&orig == this) return;
-  const GA3DBinaryStringGenome* c = 
+  const GA3DBinaryStringGenome* c =
     DYN_CAST(const GA3DBinaryStringGenome*, &orig);
   if(c) {
     GAGenome::copy(*c);
@@ -206,7 +206,7 @@ GA3DBinaryStringGenome::read(STD_ISTREAM & is)
 
   _evaluated = gaFalse;
 
-  if(is.eof() && 
+  if(is.eof() &&
      ((k < nz) ||		// didn't get some lines
       (j < ny && j != 0) ||	// didn't get some lines
       (i < nx && i != 0))){	// didn't get some lines
@@ -219,10 +219,10 @@ GA3DBinaryStringGenome::read(STD_ISTREAM & is)
 }
 
 
-// Dump the bits to the stream with a newline at the end of each row and 
+// Dump the bits to the stream with a newline at the end of each row and
 // another at the end of each layer.  No newline at the end of the block.
 int
-GA3DBinaryStringGenome::write(STD_OSTREAM & os) const 
+GA3DBinaryStringGenome::write(STD_OSTREAM & os) const
 {
   for(unsigned int k=0; k<nz; k++){
     for(unsigned int j=0; j<ny; j++){
@@ -424,13 +424,13 @@ equal(const GA3DBinaryStringGenome& orig,
     for(unsigned int j=0; j<h; j++)
       eq += GABinaryString::equal(orig,
 				  (z+k)*ny*nx + (y+j)*nx + x,
-				  (srcz+k)*ny*nx + (srcy+j)*nx + srcx, 
+				  (srcz+k)*ny*nx + (srcy+j)*nx + srcx,
 				  w);
   return eq==d*h ? 1 : 0;
 }
 
 
-int 
+int
 GA3DBinaryStringGenome::equal(const GAGenome & c) const
 {
   if(this == &c) return 1;
@@ -459,7 +459,7 @@ GA3DBinaryStringGenome::equal(const GAGenome & c) const
 (ie depth loops before a single height increment, height loops before a single
 width increment)
 ---------------------------------------------------------------------------- */
-void 
+void
 GA3DBinaryStringGenome::UniformInitializer(GAGenome & c)
 {
   GA3DBinaryStringGenome &child=DYN_CAST(GA3DBinaryStringGenome &, c);
@@ -471,7 +471,7 @@ GA3DBinaryStringGenome::UniformInitializer(GAGenome & c)
 }
 
 
-void 
+void
 GA3DBinaryStringGenome::UnsetInitializer(GAGenome & c)
 {
   GA3DBinaryStringGenome &child=DYN_CAST(GA3DBinaryStringGenome &, c);
@@ -480,7 +480,7 @@ GA3DBinaryStringGenome::UnsetInitializer(GAGenome & c)
 }
 
 
-void 
+void
 GA3DBinaryStringGenome::SetInitializer(GAGenome & c)
 {
   GA3DBinaryStringGenome &child=DYN_CAST(GA3DBinaryStringGenome &, c);
@@ -489,11 +489,11 @@ GA3DBinaryStringGenome::SetInitializer(GAGenome & c)
 }
 
 
-int 
+int
 GA3DBinaryStringGenome::FlipMutator(GAGenome & c, float pmut)
 {
   GA3DBinaryStringGenome &child=DYN_CAST(GA3DBinaryStringGenome &, c);
-  register int n, m, i, j, k, d;
+  int n, m, i, j, k, d;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.size());
@@ -550,7 +550,7 @@ GA3DBinaryStringGenome::BitComparator(const GAGenome& a, const GAGenome& b){
 
 
 
-// Make sure our bitmask is big enough, generate a mask, then use it to 
+// Make sure our bitmask is big enough, generate a mask, then use it to
 // extract the information from each parent to stuff the two children.
 // We don't deallocate any space for the masks under the assumption that we'll
 // have to use them again in the future.
@@ -626,10 +626,10 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
     nc = 2;
   }
   else if(c1 || c2){
-    GA3DBinaryStringGenome &sis = (c1 ? 
-				   DYN_CAST(GA3DBinaryStringGenome&, *c1) : 
+    GA3DBinaryStringGenome &sis = (c1 ?
+				   DYN_CAST(GA3DBinaryStringGenome&, *c1) :
 				   DYN_CAST(GA3DBinaryStringGenome&, *c2));
-    
+
     if(mom.width() == dad.width() && mom.height() == dad.height() &&
        mom.depth() == dad.depth() &&
        sis.width() == mom.width() && sis.height() == mom.height() &&
@@ -665,7 +665,7 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
 //   This is designed only for genomes that are the same length.  If the child
 // is not the same length as the parent, or if the children are not the same
 // size, we don't do the crossover.
-//   In the interest of speed we do not do any checks for size.  Do not use 
+//   In the interest of speed we do not do any checks for size.  Do not use
 // this crossover method when the parents and children may be different sizes.
 // It might break!
 int
@@ -733,7 +733,7 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
   }
   else if(c1 || c2){
     GA3DBinaryStringGenome &sis = (c1 ?
-				   DYN_CAST(GA3DBinaryStringGenome &, *c1) : 
+				   DYN_CAST(GA3DBinaryStringGenome &, *c1) :
 				   DYN_CAST(GA3DBinaryStringGenome &, *c2));
 
     if(mom.width() == dad.width() && mom.height() == dad.height() &&
@@ -772,7 +772,7 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
 
 
 // Pick a single point in the 3D block and grab alternating quadrants for each
-// child.  If the children are resizable, this crossover does clipping or 
+// child.  If the children are resizable, this crossover does clipping or
 // padding depending on the setting of the clip flag.  If we pad, we fill the
 // additional bits with random contents.
 int
@@ -795,8 +795,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE){
-      if(mom.width() != dad.width() || 
-	 sis.width() != bro.width() || 
+      if(mom.width() != dad.width() ||
+	 sis.width() != bro.width() ||
 	 sis.width() != mom.width()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -817,11 +817,11 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitex = GAMin(momsitex, dadsitex);
       lenx = GAMin(momlenx, dadlenx);
     }
-    
+
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
-      if(mom.height() != dad.height() || 
-	 sis.height() != bro.height() || 
+      if(mom.height() != dad.height() ||
+	 sis.height() != bro.height() ||
 	 sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -842,11 +842,11 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitey = GAMin(momsitey, dadsitey);
       leny = GAMin(momleny, dadleny);
     }
-    
+
     if(sis.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE){
-      if(mom.depth() != dad.depth() || 
-	 sis.depth() != bro.depth() || 
+      if(mom.depth() != dad.depth() ||
+	 sis.depth() != bro.depth() ||
 	 sis.depth() != mom.depth()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -871,8 +871,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
     sis.resize(sitex+lenx, sitey+leny, sitez+lenz);
     bro.resize(sitex+lenx, sitey+leny, sitez+lenz);
 
-    sis.copy(mom, 
-	     0, 0, 0, 
+    sis.copy(mom,
+	     0, 0, 0,
 	     momsitex-sitex, momsitey-sitey, momsitez-sitez,
 	     sitex, sitey, sitez);
     sis.copy(dad,
@@ -887,8 +887,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	     sitex, sitey, 0,
 	     momsitex, momsitey, momsitez-sitez,
 	     lenx, leny, sitez);
-    sis.copy(dad, 
-	     0, 0, sitez, 
+    sis.copy(dad,
+	     0, 0, sitez,
 	     dadsitex-sitex, dadsitey-sitey, dadsitez,
 	     sitex, sitey, lenz);
     sis.copy(mom,
@@ -903,9 +903,9 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	     sitex, sitey, sitez,
 	     dadsitex, dadsitey, dadsitez,
 	     lenx, leny, lenz);
-    
-    bro.copy(dad, 
-	     0, 0, 0, 
+
+    bro.copy(dad,
+	     0, 0, 0,
 	     dadsitex-sitex, dadsitey-sitey, dadsitez-sitez,
 	     sitex, sitey, sitez);
     bro.copy(mom,
@@ -920,8 +920,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	     sitex, sitey, 0,
 	     dadsitex, dadsitey, dadsitez-sitez,
 	     lenx, leny, sitez);
-    bro.copy(mom, 
-	     0, 0, sitez, 
+    bro.copy(mom,
+	     0, 0, sitez,
 	     momsitex-sitex, momsitey-sitey, momsitez,
 	     sitex, sitey, lenz);
     bro.copy(dad,
@@ -936,7 +936,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	     sitex, sitey, sitez,
 	     momsitex, momsitey, momsitez,
 	     lenx, leny, lenz);
-    
+
     nc = 2;
   }
   else if(c1 || c2){
@@ -960,7 +960,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitex = GAMin(momsitex, dadsitex);
       lenx = GAMin(momlenx, dadlenx);
     }
-    
+
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
       if(mom.height() != dad.height() || sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -977,7 +977,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitey = GAMin(momsitey, dadsitey);
       leny = GAMin(momleny, dadleny);
     }
-    
+
     if(sis.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE){
       if(mom.depth() != dad.depth() || sis.depth() != mom.depth()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -998,8 +998,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
     sis.resize(sitex+lenx, sitey+leny, sitez+lenz);
 
     if(GARandomBit()){
-      sis.copy(mom, 
-	       0, 0, 0, 
+      sis.copy(mom,
+	       0, 0, 0,
 	       momsitex-sitex, momsitey-sitey, momsitez-sitez,
 	       sitex, sitey, sitez);
       sis.copy(dad,
@@ -1014,8 +1014,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	       sitex, sitey, 0,
 	       momsitex, momsitey, momsitez-sitez,
 	       lenx, leny, sitez);
-      sis.copy(dad, 
-	       0, 0, sitez, 
+      sis.copy(dad,
+	       0, 0, sitez,
 	       dadsitex-sitex, dadsitey-sitey, dadsitez,
 	       sitex, sitey, lenz);
       sis.copy(mom,
@@ -1032,8 +1032,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	       lenx, leny, lenz);
     }
     else{
-      sis.copy(dad, 
-	       0, 0, 0, 
+      sis.copy(dad,
+	       0, 0, 0,
 	       dadsitex-sitex, dadsitey-sitey, dadsitez-sitez,
 	       sitex, sitey, sitez);
       sis.copy(mom,
@@ -1048,8 +1048,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	       sitex, sitey, 0,
 	       dadsitex, dadsitey, dadsitez-sitez,
 	       lenx, leny, sitez);
-      sis.copy(mom, 
-	       0, 0, sitez, 
+      sis.copy(mom,
+	       0, 0, sitez,
 	       momsitex-sitex, momsitey-sitey, momsitez,
 	       sitex, sitey, lenz);
       sis.copy(dad,

--- a/Global_static_MPFA/source/ga-mpi/GAListGenome.C
+++ b/Global_static_MPFA/source/ga-mpi/GAListGenome.C
@@ -17,7 +17,7 @@
 #include <ga-mpi/GAMask.h>
 #include <ga-mpi/garandom.h>
 
-template <class T> int 
+template <class T> int
 GAListIsHole(const GAListGenome<T>&, const GAListGenome<T>&, int, int, int);
 
 
@@ -30,8 +30,8 @@ GAListGenome<T>::className() const {return "GAListGenome";}
 template <class T> int
 GAListGenome<T>::classID() const {return GAID::ListGenome;}
 
-template <class T> 
-GAListGenome<T>::GAListGenome(GAGenome::Evaluator f, void * u) : 
+template <class T>
+GAListGenome<T>::GAListGenome(GAGenome::Evaluator f, void * u) :
 GAList<T>(),
 GAGenome(DEFAULT_LIST_INITIALIZER,
 	 DEFAULT_LIST_MUTATOR,
@@ -42,8 +42,8 @@ GAGenome(DEFAULT_LIST_INITIALIZER,
 }
 
 
-template <class T> 
-GAListGenome<T>::GAListGenome(const GAListGenome<T> & orig) : 
+template <class T>
+GAListGenome<T>::GAListGenome(const GAListGenome<T> & orig) :
 GAList<T>(),
 GAGenome() {
   GAListGenome<T>::copy(orig);
@@ -76,10 +76,10 @@ GAListGenome<T>::copy(const GAGenome & orig){
 
 #ifdef GALIB_USE_STREAMS
 // Traverse the list (breadth-first) and dump the contents as best we can to
-// the stream.  We don't try to write the contents of the nodes - we simply 
+// the stream.  We don't try to write the contents of the nodes - we simply
 // write a . for each node in the list.
 template <class T> int
-GAListGenome<T>::write(STD_OSTREAM & os) const 
+GAListGenome<T>::write(STD_OSTREAM & os) const
 {
   os << "node       next       prev       contents\n";
   if(!this->hd) return 0;;
@@ -105,7 +105,7 @@ GAListGenome<T>::write(STD_OSTREAM & os) const
 // then you have nothing to worry about.
 //   Neither of these operators affects the internal iterator of either
 // list genome in any way.
-template <class T> int 
+template <class T> int
 GAListGenome<T>::equal(const GAGenome & c) const
 {
   if(this == &c) return 1;
@@ -136,14 +136,14 @@ GAListGenome<T>::equal(const GAGenome & c) const
 ---------------------------------------------------------------------------- */
 // Mutate a list by nuking nodes.  Any node has a pmut chance of getting nuked.
 // This is actually kind of bogus for the second part of the if clause (if nMut
-// is greater than or equal to 1).  Nodes end up having more than pmut 
+// is greater than or equal to 1).  Nodes end up having more than pmut
 // probability of getting nuked.
 //   After the mutation the iterator is left at the head of the list.
 template <class T> int
 GAListGenome<T>::DestructiveMutator(GAGenome & c, float pmut)
 {
   GAListGenome<T> &child=DYN_CAST(GAListGenome<T> &, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return 0;
 
   n = child.size();
@@ -171,14 +171,14 @@ GAListGenome<T>::DestructiveMutator(GAGenome & c, float pmut)
 
 // Mutate a list by swapping two nodes.  Any node has a pmut chance of getting
 // swapped, and the swap could happen to any other node.  And in the case of
-// nMut < 1, the swap may generate a swap partner that is the same node, in 
+// nMut < 1, the swap may generate a swap partner that is the same node, in
 // which case no swap occurs (we don't check).
 //   After the mutation the iterator is left at the head of the list.
 template <class T> int
 GAListGenome<T>::SwapMutator(GAGenome & c, float pmut)
 {
   GAListGenome<T> &child=DYN_CAST(GAListGenome<T> &, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return 0;
 
   n = child.size();
@@ -205,7 +205,7 @@ GAListGenome<T>::SwapMutator(GAGenome & c, float pmut)
 
 // This comparator returns the number of elements that the two lists have
 // in common (both in position and in value).  If they are different lengths
-// then we just say they are completely different.  This is probably barely 
+// then we just say they are completely different.  This is probably barely
 // adequate for most applications - we really should give more credit for
 // nodes that are the same but in different positions.  But that would be
 // pretty nasty to compute.
@@ -213,7 +213,7 @@ GAListGenome<T>::SwapMutator(GAGenome & c, float pmut)
 // which to compare this diversity measure.  Its kind of hard to define this
 // one in a general way...
 template <class T> float
-GAListGenome<T>::NodeComparator(const GAGenome& a, const GAGenome& b) 
+GAListGenome<T>::NodeComparator(const GAGenome& a, const GAGenome& b)
 {
   if(&a == &b) return 0;
   const GAListGenome<T>& sis=DYN_CAST(const GAListGenome<T>&, a);
@@ -244,7 +244,7 @@ GAListGenome<T>::NodeComparator(const GAGenome& a, const GAGenome& b)
 
 #define SWAP(a,b) {unsigned int tmp=a; a=b; b=tmp;}
 
-// This crossover picks a site between nodes in each parent.  It is the same 
+// This crossover picks a site between nodes in each parent.  It is the same
 // as single point crossover on a resizeable binary string genome.  The site
 // in the mother is not necessarily the same as the site in the father!
 //   When we pick a crossover site, it is between nodes of the list (otherwise
@@ -253,7 +253,7 @@ GAListGenome<T>::NodeComparator(const GAGenome& a, const GAGenome& b)
 // whereas the cross site possibilities are numbered from 0 to size, inclusive.
 // This means we have to map the site to the list to determine whether an
 // insertion should occur before or after a node.
-//   We first copy the mother into the child (this deletes whatever contents 
+//   We first copy the mother into the child (this deletes whatever contents
 // were in the child originally).  Then we clone the father from the cross site
 // to the end of the list.  Then we delete the tail of the child from the
 // mother's cross site to the end of the list.  Finally, we insert the clone
@@ -265,7 +265,7 @@ GAListGenome<T>::NodeComparator(const GAGenome& a, const GAGenome& b)
 // do better by copying only what we need of the mother.
 template <class T> int
 GAListGenome<T>::
-OnePointCrossover(const GAGenome& p1, const GAGenome& p2, 
+OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 		  GAGenome* c1, GAGenome* c2){
   const GAListGenome<T> &mom=DYN_CAST(const GAListGenome<T> &, p1);
   const GAListGenome<T> &dad=DYN_CAST(const GAListGenome<T> &, p2);
@@ -330,13 +330,13 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 //   This version of the partial match crossover uses objects that are multiply
 // instantiated - each list genome contains its own objects in its nodes.
 // The operator== method must be defined on the object for this implementation
-// to work!  In this case, the 'object' is an int, so we're OK.  If you are 
+// to work!  In this case, the 'object' is an int, so we're OK.  If you are
 // putting your own objects in the nodes, be sure you have operator== defined
 // for your object.  You must also have operator!= defined for your object.  We
 // do not do any assignments, so operator= and/or copy is not required.
 //   We assume that none of the nodes will return a NULL pointer.  Also assume
 // that the cross site has been selected properly.
-//   First we make a copy of the mother.  Then we loop through the match 
+//   First we make a copy of the mother.  Then we loop through the match
 // section and try to swap each element in the child's match section with its
 // partner (as defined by the current node in the father's match section).
 //   Mirroring will work the same way - just swap mom & dad and you're all set.

--- a/Global_static_MPFA/source/ga-mpi/GARealGenome.C
+++ b/Global_static_MPFA/source/ga-mpi/GARealGenome.C
@@ -13,7 +13,7 @@
 
 // We must also specialize the allele set so that the alleles are handled
 // properly.  Be sure to handle bounds correctly whether we are discretized
-// or continuous.  Handle the case where someone sets stupid bounds that 
+// or continuous.  Handle the case where someone sets stupid bounds that
 // might cause an infinite loop for exclusive bounds.
 template <> float
 GAAlleleSet<float>::allele() const {
@@ -29,8 +29,8 @@ GAAlleleSet<float>::allele() const {
     if(core->lowerb == GAAllele::EXCLUSIVE) value += core->a[2];
   }
   else{
-    if(core->a[0] == core->a[1] && 
-       core->lowerb == GAAllele::EXCLUSIVE && 
+    if(core->a[0] == core->a[1] &&
+       core->lowerb == GAAllele::EXCLUSIVE &&
        core->upperb == GAAllele::EXCLUSIVE) {
       value = core->a[0];
     }
@@ -74,9 +74,9 @@ GAAlleleSet<float>::allele(unsigned int i) const {
 
 // now the specialization of the genome itself.
 
-template <> const char * 
+template <> const char *
 GA1DArrayAlleleGenome<float>::className() const {return "GARealGenome";}
-template <> int 
+template <> int
 GA1DArrayAlleleGenome<float>::classID() const {return GAID::FloatGenome;}
 
 template <> GA1DArrayAlleleGenome<float>::
@@ -108,7 +108,7 @@ GA1DArrayGenome<float>(sa.size(), f, u){
   crossover(DEFAULT_REAL_CROSSOVER);
 }
 
-template <> 
+template <>
 GA1DArrayAlleleGenome<float>::~GA1DArrayAlleleGenome(){
   delete [] aset;
 }
@@ -148,12 +148,12 @@ GA1DArrayAlleleGenome<float>::read(STD_ISTREAM & is) {
 ---------------------------------------------------------------------------- */
 // The Gaussian mutator picks a new value based on a Gaussian distribution
 // around the current value.  We respect the bounds (if any).
-//*** need to figure out a way to make the stdev other than 1.0 
-int 
+//*** need to figure out a way to make the stdev other than 1.0
+int
 GARealGaussianMutator(GAGenome& g, float pmut){
   GA1DArrayAlleleGenome<float> &child=
     DYN_CAST(GA1DArrayAlleleGenome<float> &, g);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * (float)(child.length());
@@ -200,7 +200,7 @@ GARealGaussianMutator(GAGenome& g, float pmut){
 // identical.  If parents are not the same length, the extra elements are not
 // set!  You might want to add some noise to this so that both children are not
 // the same...
-int 
+int
 GARealArithmeticCrossover(const GAGenome& p1, const GAGenome& p2,
 			  GAGenome* c1, GAGenome* c2) {
   const GA1DArrayGenome<float> &mom=
@@ -222,8 +222,8 @@ GARealArithmeticCrossover(const GAGenome& p1, const GAGenome& p2,
     n = 2;
   }
   else if(c1 || c2){
-    GA1DArrayGenome<float> &sis = (c1 ? 
-				   DYN_CAST(GA1DArrayGenome<float> &, *c1) : 
+    GA1DArrayGenome<float> &sis = (c1 ?
+				   DYN_CAST(GA1DArrayGenome<float> &, *c1) :
 				   DYN_CAST(GA1DArrayGenome<float> &, *c2));
 
     int len = GAMax(mom.length(), dad.length());
@@ -240,7 +240,7 @@ GARealArithmeticCrossover(const GAGenome& p1, const GAGenome& p2,
 // Blend crossover generates a new value based on the interval between parents.
 // We generate a uniform distribution based on the distance between parent
 // values, then choose the child value based upon that distribution.
-int 
+int
 GARealBlendCrossover(const GAGenome& p1, const GAGenome& p2,
 		     GAGenome* c1, GAGenome* c2) {
   const GA1DArrayGenome<float> &mom=
@@ -257,9 +257,9 @@ GARealBlendCrossover(const GAGenome& p1, const GAGenome& p2,
     int len = GAMax(mom.length(), dad.length());
     for(int i=0; i<len; i++) {
       float dist = 0;
-      if(mom.gene(i) > dad.gene(i)) 
+      if(mom.gene(i) > dad.gene(i))
 	dist = mom.gene(i) - dad.gene(i);
-      else 
+      else
 	dist = dad.gene(i) - mom.gene(i);
       float lo = (GAMin(mom.gene(i), dad.gene(i))) - 0.5*dist;
       float hi = (GAMax(mom.gene(i), dad.gene(i))) + 0.5*dist;
@@ -276,9 +276,9 @@ GARealBlendCrossover(const GAGenome& p1, const GAGenome& p2,
     int len = GAMax(mom.length(), dad.length());
     for(int i=0; i<len; i++) {
       float dist = 0;
-      if(mom.gene(i) > dad.gene(i)) 
+      if(mom.gene(i) > dad.gene(i))
 	dist = mom.gene(i) - dad.gene(i);
-      else 
+      else
 	dist = dad.gene(i) - mom.gene(i);
       float lo = (GAMin(mom.gene(i), dad.gene(i))) - 0.5*dist;
       float hi = (GAMax(mom.gene(i), dad.gene(i))) + 0.5*dist;
@@ -298,7 +298,7 @@ GARealBlendCrossover(const GAGenome& p1, const GAGenome& p2,
 //
 // These must be included _after_ the specializations because some compilers
 // get all wigged out about the declaration/specialization order.  Note that
-// some compilers require a syntax different than others when forcing the 
+// some compilers require a syntax different than others when forcing the
 // instantiation (i.e. GNU wants the 'template class', borland does not).
 #ifndef GALIB_USE_AUTO_INST
 #include <ga-mpi/GAAllele.C>

--- a/Global_static_MPFA/source/ga-mpi/GATreeGenome.C
+++ b/Global_static_MPFA/source/ga-mpi/GATreeGenome.C
@@ -25,7 +25,7 @@ template <class T> int
 GATreeGenome<T>::classID() const {return GAID::TreeGenome;}
 
 template <class T>
-GATreeGenome<T>::GATreeGenome(GAGenome::Evaluator f, void * u) : 
+GATreeGenome<T>::GATreeGenome(GAGenome::Evaluator f, void * u) :
 GATree<T>(),
 GAGenome(DEFAULT_TREE_INITIALIZER,
 	 DEFAULT_TREE_MUTATOR,
@@ -37,7 +37,7 @@ GAGenome(DEFAULT_TREE_INITIALIZER,
 
 
 template <class T>
-GATreeGenome<T>::GATreeGenome(const GATreeGenome<T> & orig) : 
+GATreeGenome<T>::GATreeGenome(const GATreeGenome<T> & orig) :
 GATree<T>(),
 GAGenome() {
   GATreeGenome<T>::copy(orig);
@@ -70,7 +70,7 @@ GATreeGenome<T>::copy(const GAGenome & orig) {
 
 #ifdef GALIB_USE_STREAMS
 // Traverse the tree (breadth-first) and dump the contents as best we can to
-// the stream.  We don't try to write the contents of the nodes - we simply 
+// the stream.  We don't try to write the contents of the nodes - we simply
 // write a . for each node in the tree.
 //   We allocate space for x,y coord pair for each node in the tree.  Then we
 // do a depth-first traversal of the tree and assign coords to the nodes in the
@@ -102,7 +102,7 @@ _tt(STD_OSTREAM & os, GANode<T> * n)
 }
 
 template <class T> int
-GATreeGenome<T>::write(STD_OSTREAM & os) const 
+GATreeGenome<T>::write(STD_OSTREAM & os) const
 {
   os << "node       parent     child      next       prev       contents\n";
   _tt(os, (GANode<T> *)(this->rt));
@@ -111,7 +111,7 @@ GATreeGenome<T>::write(STD_OSTREAM & os) const
 #endif
 
 
-template <class T> int  
+template <class T> int
 GATreeGenome<T>::equal(const GAGenome & c) const
 {
   if(this == &c) return 1;
@@ -140,7 +140,7 @@ template <class T> int
 GATreeGenome<T>::DestructiveMutator(GAGenome & c, float pmut)
 {
   GATreeGenome<T> &child=DYN_CAST(GATreeGenome<T> &, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return 0;
 
   n = child.size();
@@ -169,14 +169,14 @@ GATreeGenome<T>::DestructiveMutator(GAGenome & c, float pmut)
 // This is a rearranging mutation operator.  It randomly picks two nodes in the
 // tree and swaps them.  Any node has a pmut chance of getting
 // swapped, and the swap could happen to any other node.  And in the case of
-// nMut < 1, the swap may generate a swap partner that is the same node, in 
+// nMut < 1, the swap may generate a swap partner that is the same node, in
 // which case no swap occurs (we don't check).
 //   After the mutation the iterator is left at the root of the tree.
 template <class T> int
 GATreeGenome<T>::SwapNodeMutator(GAGenome & c, float pmut)
 {
   GATreeGenome<T> &child=DYN_CAST(GATreeGenome<T> &, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return 0;
 
   n = child.size();
@@ -214,7 +214,7 @@ template <class T> int
 GATreeGenome<T>::SwapSubtreeMutator(GAGenome & c, float pmut)
 {
   GATreeGenome<T> &child=DYN_CAST(GATreeGenome<T> &, c);
-  register int n, i;
+  int n, i;
   int a, b;
   if(pmut <= 0.0) return 0;
 
@@ -247,7 +247,7 @@ GATreeGenome<T>::SwapSubtreeMutator(GAGenome & c, float pmut)
 // We use the recursive tree function to compare the tree structures.  This
 // does not compare the contents of the nodes.
 template <class T> float
-GATreeGenome<T>::TopologyComparator(const GAGenome& a, const GAGenome& b) 
+GATreeGenome<T>::TopologyComparator(const GAGenome& a, const GAGenome& b)
 {
   if(&a == &b) return 0;
   const GATreeGenome<T>& sis=DYN_CAST(const GATreeGenome<T>&, a);
@@ -277,7 +277,7 @@ GATreeGenome<T>::TopologyComparator(const GAGenome& a, const GAGenome& b)
 //     do the check to see if the crossover site is valid.
 template <class T> int
 GATreeGenome<T>::
-OnePointCrossover(const GAGenome& p1, const GAGenome& p2, 
+OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 		  GAGenome* c1, GAGenome* c2){
   const GATreeGenome<T> &mom=DYN_CAST(const GATreeGenome<T> &, p1);
   const GATreeGenome<T> &dad=DYN_CAST(const GATreeGenome<T> &, p2);

--- a/Ideal_Static_MPFA/source/evolver.cpp
+++ b/Ideal_Static_MPFA/source/evolver.cpp
@@ -11,7 +11,7 @@
 // For shared memory management
 #include <sys/mman.h>
 
-#include <ctime> // For clock()
+#include <ctime>  // For clock()
 #include <chrono> // For clock()
 #include <mpi.h>
 
@@ -31,12 +31,12 @@
 #include <source/CPFA/CPFA_loop_functions.h>
 
 // For timing
-#include <ctime> // For clock()
+#include <ctime>  // For clock()
 #include <chrono> // For clock()
 
 // For shared variable between child and parent process
-#include  <sys/ipc.h>
-#include  <sys/shm.h>
+#include <sys/ipc.h>
+#include <sys/shm.h>
 
 float objective(GAGenome &);
 float LaunchARGoS(GAGenome &);
@@ -44,11 +44,11 @@ float LaunchARGoS(GAGenome &);
 int mpi_tasks, mpi_rank;
 
 int elitism = 0;
-int n_trials = 20; // used by the objective function
+int n_trials = 20;            // used by the objective function
 double mutation_stdev = 1.00; // Gaussian mutation stdev - will be scaled by possible range
 string experiment_path;
 
-void CPFAInitializer(GAGenome & c);
+void CPFAInitializer(GAGenome &c);
 int GARealGaussianMutatorStdev(GAGenome &, float);
 
 std::default_random_engine generator;
@@ -62,125 +62,124 @@ int main(int argc, char **argv)
   MPI_Init(&argc, &argv);
   MPI_Comm_size(MPI_COMM_WORLD, &mpi_tasks);
   MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
-                         
-  char hostname[1024];                                                                                                       
-  hostname[1023] = '\0';                                          
+
+  char hostname[1024];
+  hostname[1023] = '\0';
   gethostname(hostname, 1023);
-  
+
   double mutation_rate = 0.01;
   double crossover_rate = 0.01;
   int population_size = 10;
   int n_generations = 10;
 
-    char c='h';
+  char c = 'h';
   // Handle command line arguments
-  while ((c = getopt (argc, argv, "t:g:p:c:m:s:h:e:x:")) != -1)
+  while ((c = getopt(argc, argv, "t:g:p:c:m:s:h:e:x:")) != -1)
     switch (c)
-      {
-      case 'x':
-	experiment_path = optarg;
+    {
+    case 'x':
+      experiment_path = optarg;
       break;
-      case 't':
-	n_trials = atoi(optarg);
-	break;
-      case 'g':
-        n_generations = atoi(optarg);
-        break;
-      case 'p':
-        population_size = atoi(optarg);
-        break;
-      case 'm':
-        mutation_rate = strtod(optarg, NULL);
-	break;
-      case 'c':
-	crossover_rate = strtod(optarg, NULL);
-	break;
-      case 's':
-        mutation_stdev = strtod(optarg, NULL);
-	break;
-      case 'e':
-        elitism = atoi(optarg);
-	break;
-      case 'h':
-	printf("Usage: %s -p {population size} -g {number of generations} -t {number of trials} -c {crossover rate} -m {mutation rate} -s {mutation standard deviation} -e {elitism 0 or 1}", argv[0]);
-	break;
-      case '?':
-        if (optopt == 'p')
-          fprintf (stderr, "Option -%c requires an argument specifying the population size.\n", optopt);
-	else if (optopt == 'g')
-	  fprintf (stderr, "Option -%c requires an argument specifying the number of generations.\n", optopt);
-	else if (optopt == 't')
-	  fprintf (stderr, "Option -%c requires an argument specifying the number of trials.\n", optopt);
-	else if (optopt == 'c')
-	  fprintf (stderr, "Option -%c requires an argument specifying the crossover rate.\n", optopt);
-	else if (optopt == 'm')
-	  fprintf (stderr, "Option -%c requires an argument specifying the mutation rate.\n", optopt);
-	else if (optopt == 's')
-	  fprintf (stderr, "Option -%c requires an argument specifying the mutation standard deviation.\n", optopt);
-        else if (isprint (optopt))
-          fprintf (stderr, "Unknown option `-%c'.\n", optopt);
-        else
-          fprintf (stderr,
-                   "Unknown option character `\\x%x'.\n",
-                   optopt);
-        return 1;
-      default:
-	printf("Usage: %s -p {population size} -g {number of generations} -t {number of trials} -c {crossover rate} -m {mutation rate} -s {mutation standard deviation}", argv[0]);
-        abort ();
-      }
+    case 't':
+      n_trials = atoi(optarg);
+      break;
+    case 'g':
+      n_generations = atoi(optarg);
+      break;
+    case 'p':
+      population_size = atoi(optarg);
+      break;
+    case 'm':
+      mutation_rate = strtod(optarg, NULL);
+      break;
+    case 'c':
+      crossover_rate = strtod(optarg, NULL);
+      break;
+    case 's':
+      mutation_stdev = strtod(optarg, NULL);
+      break;
+    case 'e':
+      elitism = atoi(optarg);
+      break;
+    case 'h':
+      printf("Usage: %s -p {population size} -g {number of generations} -t {number of trials} -c {crossover rate} -m {mutation rate} -s {mutation standard deviation} -e {elitism 0 or 1}", argv[0]);
+      break;
+    case '?':
+      if (optopt == 'p')
+        fprintf(stderr, "Option -%c requires an argument specifying the population size.\n", optopt);
+      else if (optopt == 'g')
+        fprintf(stderr, "Option -%c requires an argument specifying the number of generations.\n", optopt);
+      else if (optopt == 't')
+        fprintf(stderr, "Option -%c requires an argument specifying the number of trials.\n", optopt);
+      else if (optopt == 'c')
+        fprintf(stderr, "Option -%c requires an argument specifying the crossover rate.\n", optopt);
+      else if (optopt == 'm')
+        fprintf(stderr, "Option -%c requires an argument specifying the mutation rate.\n", optopt);
+      else if (optopt == 's')
+        fprintf(stderr, "Option -%c requires an argument specifying the mutation standard deviation.\n", optopt);
+      else if (isprint(optopt))
+        fprintf(stderr, "Unknown option `-%c'.\n", optopt);
+      else
+        fprintf(stderr,
+                "Unknown option character `\\x%x'.\n",
+                optopt);
+      return 1;
+    default:
+      printf("Usage: %s -p {population size} -g {number of generations} -t {number of trials} -c {crossover rate} -m {mutation rate} -s {mutation standard deviation}", argv[0]);
+      abort();
+    }
 
   if (experiment_path.empty())
-    {
-      printf("Usage: %s -p {population size} -g {number of generations} -t {number of trials} -c {crossover rate} -m {mutation rate} -s {mutation standard deviation} -x {argos experiment file}\n", argv[0]);
-      exit(1);
-    }
+  {
+    printf("Usage: %s -p {population size} -g {number of generations} -t {number of trials} -c {crossover rate} -m {mutation rate} -s {mutation standard deviation} -x {argos experiment file}\n", argv[0]);
+    exit(1);
+  }
 
   float max_float = std::numeric_limits<float>::max();
 
-    //printf("%s:\tworker %d ready.\n", hostname, mpi_rank);                                          
+  // printf("%s:\tworker %d ready.\n", hostname, mpi_rank);
 
   // See if we've been given a seed to use (for testing purposes).  When you
   // specify a random seed, the evolution will be exactly the same each time
   // you use that seed number
   unsigned int seed = 12345;
-  for(int i=1 ; i<argc ; i++)
-    if(strcmp(argv[i++],"seed") == 0)
+  for (int i = 1; i < argc; i++)
+    if (strcmp(argv[i++], "seed") == 0)
       seed = atoi(argv[i]);
 
   srand(seed);
   generator.seed(seed);
   // popsize / mpi_tasks must be an integer
-  population_size = mpi_tasks * int((double)population_size/(double)mpi_tasks+0.999);
-  
-  if (mpi_rank==0)
-    {
-      printf("Population size: %d\nNumber of trials: %d\nNumber of generations: %d\nCrossover rate: %f\nMutation rate: %f\nMutation stdev: %f\nAllocated MPI workers: %d\n", population_size, n_trials, n_generations, crossover_rate, mutation_rate, mutation_stdev, mpi_tasks);
-      	printf("elitism: %d\n", elitism);
-    }
+  population_size = mpi_tasks * int((double)population_size / (double)mpi_tasks + 0.999);
+
+  if (mpi_rank == 0)
+  {
+    printf("Population size: %d\nNumber of trials: %d\nNumber of generations: %d\nCrossover rate: %f\nMutation rate: %f\nMutation stdev: %f\nAllocated MPI workers: %d\n", population_size, n_trials, n_generations, crossover_rate, mutation_rate, mutation_stdev, mpi_tasks);
+    printf("elitism: %d\n", elitism);
+  }
 
   // Define the genome
   GARealAlleleSetArray allele_array;
-  
-  allele_array.add(0, 1.0); // Probability of switching to search
-  allele_array.add(0, 1.0); // Probability of returning to nest
-  allele_array.add(0, 4*M_PI); // Uninformed search variation
-  allele_array.add(0, 20); // Rate of informed search decay
-  allele_array.add(0, 20); // Rate of site fidelity
-  allele_array.add(0, 20); // Rate of laying pheremone
-  allele_array.add(0, 20); // Rate of pheremone decay
-  
-    
+
+  allele_array.add(0, 1.0);      // Probability of switching to search
+  allele_array.add(0, 1.0);      // Probability of returning to nest
+  allele_array.add(0, 4 * M_PI); // Uninformed search variation
+  allele_array.add(0, 20);       // Rate of informed search decay
+  allele_array.add(0, 20);       // Rate of site fidelity
+  allele_array.add(0, 20);       // Rate of laying pheremone
+  allele_array.add(0, 20);       // Rate of pheremone decay
+
   // Create the template genome using the phenotype map we just made.
   GARealGenome genome(allele_array, objective);
   genome.crossover(GARealUniformCrossover);
   genome.mutator(GARealGaussianMutatorStdev); // Specify our version of the Gaussuan mutator
   genome.initializer(CPFAInitializer);
- 
+
   // Now create the GA using the genome and run it.
   GASimpleGA ga(genome);
   GALinearScaling scaling;
-  ga.maximize();		// Maximize the objective
- 
+  ga.maximize(); // Maximize the objective
+
   ga.populationSize(population_size);
   ga.nGenerations(n_generations);
   ga.pMutation(mutation_rate);
@@ -190,7 +189,7 @@ int main(int argc, char **argv)
     ga.elitist(gaTrue);
   else
     ga.elitist(gaFalse);
-  if(mpi_rank == 0)
+  if (mpi_rank == 0)
     ga.scoreFilename("evolution.txt");
   else
     ga.scoreFilename("/dev/null");
@@ -198,338 +197,363 @@ int main(int argc, char **argv)
   ga.scoreFrequency(1);
   ga.flushFrequency(1);
   ga.selectScores(GAStatistics::AllScores);
-  
+
   // Pass MPI data to the GA class
   ga.mpi_rank(mpi_rank);
   ga.mpi_tasks(mpi_tasks);
-  //ga.evolve(seed); // Manual generations
+  // ga.evolve(seed); // Manual generations
 
-// initialize the ga since we are not using the evolve function
+  // initialize the ga since we are not using the evolve function
   ga.initialize(seed); // This is essential for the mpi workers to be sychronized
 
-    // Name the results file with the current time and date
- time_t t = time(0);   // get time now
-    struct tm * now = localtime( & t );
-    stringstream ss;
+  // Name the results file with the current time and date
+  time_t t = time(0); // get time now
+  struct tm *now = localtime(&t);
+  stringstream ss;
 
-    boost::filesystem::path exp_path(experiment_path);
-    
-    ss << "results/CPFA-evolution-"
-       << exp_path.stem().string() << '-'
-       <<GIT_BRANCH<<"-"<<GIT_COMMIT_HASH<<"-"
-       << (now->tm_year) << '-'
-       << (now->tm_mon + 1) << '-'
-       <<  now->tm_mday << '-'
-       <<  now->tm_hour << '-'
-       <<  now->tm_min << '-'
-       <<  now->tm_sec << ".csv";
+  boost::filesystem::path exp_path(experiment_path);
 
-    string results_file_name = ss.str();
+  ss << "results/CPFA-evolution-"
+     << exp_path.stem().string() << '-'
+     << GIT_BRANCH << "-" << GIT_COMMIT_HASH << "-"
+     << (now->tm_year) << '-'
+     << (now->tm_mon + 1) << '-'
+     << now->tm_mday << '-'
+     << now->tm_hour << '-'
+     << now->tm_min << '-'
+     << now->tm_sec << ".csv";
 
-    if (mpi_rank == 0)
-      {
+  string results_file_name = ss.str();
+
+  if (mpi_rank == 0)
+  {
     // Write output file header
     ofstream results_output_stream;
-	results_output_stream.open(results_file_name, ios::app);
-	results_output_stream << "Population size: " << population_size << "\nNumber of trials: " << n_trials << "\nNumber of generations: "<< n_generations<<"\nCrossover rate: "<< crossover_rate<<"\nMutation rate: " << mutation_rate << "\nMutation stdev: "<< mutation_stdev << "Algorithm: CPFA\n" << "Number of searchers: 6\n" << "Number of targets: 256\n" << "Target distribution: power law" << endl;
-	results_output_stream << "Generation" 
-			      << ", " << "Compute Time (s)"
-			      << ", " << "Convergence"
-			      << ", " << "Mean"
-			      << ", " << "Maximum"
-			      << ", " << "Minimum"
-			      << ", " << "Standard Deviation"
-			      << ", " << "Diversity"
-			      << ", " << "ProbabilityOfSwitchingToSearching"
-			      << ", " << "ProbabilityOfReturningToNest"
-			      << ", " << "UninformedSearchVariation"
-			      << ", " << "RateOfInformedSearchDecay"
-			      << ", " << "RateOfSiteFidelity"
-			      << ", " << "RateOfLayingPheromone"
-			      << ", " << "RateOfPheromoneDecay";
+    results_output_stream.open(results_file_name, ios::app);
+    results_output_stream << "Population size: " << population_size << "\nNumber of trials: " << n_trials << "\nNumber of generations: " << n_generations << "\nCrossover rate: " << crossover_rate << "\nMutation rate: " << mutation_rate << "\nMutation stdev: " << mutation_stdev << "Algorithm: CPFA\n"
+                          << "Number of searchers: 6\n"
+                          << "Number of targets: 256\n"
+                          << "Target distribution: power law" << endl;
+    results_output_stream << "Generation"
+                          << ", "
+                          << "Compute Time (s)"
+                          << ", "
+                          << "Convergence"
+                          << ", "
+                          << "Mean"
+                          << ", "
+                          << "Maximum"
+                          << ", "
+                          << "Minimum"
+                          << ", "
+                          << "Standard Deviation"
+                          << ", "
+                          << "Diversity"
+                          << ", "
+                          << "ProbabilityOfSwitchingToSearching"
+                          << ", "
+                          << "ProbabilityOfReturningToNest"
+                          << ", "
+                          << "UninformedSearchVariation"
+                          << ", "
+                          << "RateOfInformedSearchDecay"
+                          << ", "
+                          << "RateOfSiteFidelity"
+                          << ", "
+                          << "RateOfLayingPheromone"
+                          << ", "
+                          << "RateOfPheromoneDecay";
 
-	results_output_stream << endl;
-	results_output_stream.close();
-      }
+    results_output_stream << endl;
+    results_output_stream.close();
+  }
 
-	while(!ga.done())
-	  {
+  while (!ga.done())
+  {
 
-	    std::chrono::time_point<std::chrono::system_clock>generation_start, generation_end;
-	    if (mpi_rank == 0)
-	      {
-		generation_start = std::chrono::system_clock::now();
-	      }
-	    
-      // Calculate the generation
-      ga.step();
+    std::chrono::time_point<std::chrono::system_clock> generation_start, generation_end;
+    if (mpi_rank == 0)
+    {
+      generation_start = std::chrono::system_clock::now();
+    }
 
-    if(mpi_rank == 0)
-      {
-	generation_end = std::chrono::system_clock::now();
-	std::chrono::duration<double> generation_elapsed_seconds = generation_end-generation_start;
-	ofstream results_output_stream;
-	results_output_stream.open(results_file_name, ios::app);
-       results_output_stream << ga.statistics().generation() 
-			     << ", " << generation_elapsed_seconds.count()
-			     << ", " << ga.statistics().convergence()
-			     << ", " << ga.statistics().current(GAStatistics::Mean)
-			     << ", " << ga.statistics().current(GAStatistics::Maximum)
-			     << ", " << ga.statistics().current(GAStatistics::Minimum)
-			     << ", " << ga.statistics().current(GAStatistics::Deviation)
-			     << ", " << ga.statistics().current(GAStatistics::Diversity);
-       
-	  for (int i = 0; i < GENOME_SIZE; i++)
-	    results_output_stream << ", " << dynamic_cast<const GARealGenome&>(ga.population().best()).gene(i);
+    // Calculate the generation
+    ga.step();
 
-	  
-	  const GARealGenome& best_genome = dynamic_cast<const GARealGenome&>(ga.statistics().bestIndividual());
-	  results_output_stream << endl;
-	  
-	  results_output_stream << "The GA found an optimum at: ";
-	  results_output_stream << best_genome.gene(0);
-	  for (int i = 1; i < GENOME_SIZE; i++)
-	    results_output_stream << ", " << best_genome.gene(i);
-	  results_output_stream << " with score: " << best_genome.score();
-	  results_output_stream << endl;
-	  results_output_stream.close();
-      }
-	  }
-	// Display the GA's progress
-	if(mpi_rank == 0)
-	  {
-	    cout << ga.statistics() << " " << ga.parameters() << endl;
-	  }
-	
+    if (mpi_rank == 0)
+    {
+      generation_end = std::chrono::system_clock::now();
+      std::chrono::duration<double> generation_elapsed_seconds = generation_end - generation_start;
+      ofstream results_output_stream;
+      results_output_stream.open(results_file_name, ios::app);
+      results_output_stream << ga.statistics().generation()
+                            << ", " << generation_elapsed_seconds.count()
+                            << ", " << ga.statistics().convergence()
+                            << ", " << ga.statistics().current(GAStatistics::Mean)
+                            << ", " << ga.statistics().current(GAStatistics::Maximum)
+                            << ", " << ga.statistics().current(GAStatistics::Minimum)
+                            << ", " << ga.statistics().current(GAStatistics::Deviation)
+                            << ", " << ga.statistics().current(GAStatistics::Diversity);
+
+      for (int i = 0; i < GENOME_SIZE; i++)
+        results_output_stream << ", " << dynamic_cast<const GARealGenome &>(ga.population().best()).gene(i);
+
+      const GARealGenome &best_genome = dynamic_cast<const GARealGenome &>(ga.statistics().bestIndividual());
+      results_output_stream << endl;
+
+      results_output_stream << "The GA found an optimum at: ";
+      results_output_stream << best_genome.gene(0);
+      for (int i = 1; i < GENOME_SIZE; i++)
+        results_output_stream << ", " << best_genome.gene(i);
+      results_output_stream << " with score: " << best_genome.score();
+      results_output_stream << endl;
+      results_output_stream.close();
+    }
+  }
+  // Display the GA's progress
+  if (mpi_rank == 0)
+  {
+    cout << ga.statistics() << " " << ga.parameters() << endl;
+  }
+
   MPI_Finalize();
 
   program_end = std::chrono::system_clock::now();
- 
-  std::chrono::duration<double> program_elapsed_seconds = program_end-program_start;
 
-  if(mpi_rank == 0)
+  std::chrono::duration<double> program_elapsed_seconds = program_end - program_start;
+
+  if (mpi_rank == 0)
     printf("Run time was %f seconds\n", program_elapsed_seconds.count());
 
   return 0;
-  }
+}
 
-// Initializes the genome according to the Beyond Pheromones paper 
-void CPFAInitializer(GAGenome & c)
+// Initializes the genome according to the Beyond Pheromones paper
+void CPFAInitializer(GAGenome &c)
 {
   // For the exponential PDF needed to initialize some of the genes
-  
+
   std::exponential_distribution<double> exponential_distribution_10(10.0);
   std::exponential_distribution<double> exponential_distribution_5(5.0);
   std::uniform_real_distribution<double> uniform_distribution_0_1(0.0, 1.0);
-  std::uniform_real_distribution<double> uniform_distribution_0_4PI(0.0, 4.0*M_PI);
+  std::uniform_real_distribution<double> uniform_distribution_0_4PI(0.0, 4.0 * M_PI);
   std::uniform_real_distribution<double> uniform_distribution_0_20(0.0, 20.0);
 
-  GA1DArrayAlleleGenome<float> &child= DYN_CAST(GA1DArrayAlleleGenome<float> &, c);
+  GA1DArrayAlleleGenome<float> &child = DYN_CAST(GA1DArrayAlleleGenome<float> &, c);
   child.resize(GAGenome::ANY_SIZE); // let chrom resize if it can
-  
-  child.gene(0, uniform_distribution_0_1(generator)); // Probability of switching to search
-  child.gene(1, uniform_distribution_0_1(generator)); // Probability of returning to nest
-  child.gene(2, uniform_distribution_0_4PI(generator)); // Uninformed search variation
-  child.gene(3, exponential_distribution_5(generator)); // Rate of informed search decay
-  child.gene(4, uniform_distribution_0_20(generator)); // Rate of site fidelity
-  child.gene(5, uniform_distribution_0_20(generator)); // Rate of laying pheremone
+
+  child.gene(0, uniform_distribution_0_1(generator));    // Probability of switching to search
+  child.gene(1, uniform_distribution_0_1(generator));    // Probability of returning to nest
+  child.gene(2, uniform_distribution_0_4PI(generator));  // Uninformed search variation
+  child.gene(3, exponential_distribution_5(generator));  // Rate of informed search decay
+  child.gene(4, uniform_distribution_0_20(generator));   // Rate of site fidelity
+  child.gene(5, uniform_distribution_0_20(generator));   // Rate of laying pheremone
   child.gene(6, exponential_distribution_10(generator)); // Rate of pheremone decay
 }
 
 // The mutation operator based on the original from GALib but adds stdev
 // The Gaussian mutator picks a new value based on a Gaussian distribution
 // around the current value.  We respect the bounds (if any).
-int GARealGaussianMutatorStdev(GAGenome& g, float pmut)
+int GARealGaussianMutatorStdev(GAGenome &g, float pmut)
 {
-  GA1DArrayAlleleGenome<float> &child=
-    DYN_CAST(GA1DArrayAlleleGenome<float> &, g);
-  register int n, i;
-  if(pmut <= 0.0) return(0);
+  GA1DArrayAlleleGenome<float> &child =
+      DYN_CAST(GA1DArrayAlleleGenome<float> &, g);
+  int n, i;
+  if (pmut <= 0.0)
+    return (0);
 
   float nMut = pmut * (float)(child.length());
-  int length = child.length()-1;
-  if(nMut < 1.0){// we have to do a flip test on each element
+  int length = child.length() - 1;
+  if (nMut < 1.0)
+  { // we have to do a flip test on each element
     nMut = 0;
-    for(i=length; i>=0; i--){
+    for (i = length; i >= 0; i--)
+    {
       float value = child.gene(i);
-      if(GAFlipCoin(pmut)){
-	if(child.alleleset(i).type() == GAAllele::ENUMERATED ||
-	   child.alleleset(i).type() == GAAllele::DISCRETIZED)
-	  value = child.alleleset(i).allele();
-	else if(child.alleleset(i).type() == GAAllele::BOUNDED){
-	  value += GAUnitGaussian()*mutation_stdev;//*(child.alleleset(i).upper()-child.alleleset(i).lower()); // since the standard deviation varies proportionally to a constant multiplier 
-	  value = GAMax(child.alleleset(i).lower(), value);
-	  value = GAMin(child.alleleset(i).upper(), value);
-	}
-	child.gene(i, value);
-	nMut++;
+      if (GAFlipCoin(pmut))
+      {
+        if (child.alleleset(i).type() == GAAllele::ENUMERATED ||
+            child.alleleset(i).type() == GAAllele::DISCRETIZED)
+          value = child.alleleset(i).allele();
+        else if (child.alleleset(i).type() == GAAllele::BOUNDED)
+        {
+          value += GAUnitGaussian() * mutation_stdev; //*(child.alleleset(i).upper()-child.alleleset(i).lower()); // since the standard deviation varies proportionally to a constant multiplier
+          value = GAMax(child.alleleset(i).lower(), value);
+          value = GAMin(child.alleleset(i).upper(), value);
+        }
+        child.gene(i, value);
+        nMut++;
       }
     }
   }
-  else{// only mutate the ones we need to
-    for(n=0; n<nMut; n++){
-      int idx = GARandomInt(0,length);
+  else
+  { // only mutate the ones we need to
+    for (n = 0; n < nMut; n++)
+    {
+      int idx = GARandomInt(0, length);
       float value = child.gene(idx);
-      if(child.alleleset(idx).type() == GAAllele::ENUMERATED ||
-	 child.alleleset(idx).type() == GAAllele::DISCRETIZED)
-	value = child.alleleset(idx).allele();
-      else if(child.alleleset(idx).type() == GAAllele::BOUNDED){
-	value += GAUnitGaussian()*mutation_stdev*(child.alleleset(i).upper()-child.alleleset(i).lower()); // since the standard deviation varies proportionally to a constant multiplier 
-	value = GAMax(child.alleleset(idx).lower(), value);
-	value = GAMin(child.alleleset(idx).upper(), value);
+      if (child.alleleset(idx).type() == GAAllele::ENUMERATED ||
+          child.alleleset(idx).type() == GAAllele::DISCRETIZED)
+        value = child.alleleset(idx).allele();
+      else if (child.alleleset(idx).type() == GAAllele::BOUNDED)
+      {
+        value += GAUnitGaussian() * mutation_stdev * (child.alleleset(i).upper() - child.alleleset(i).lower()); // since the standard deviation varies proportionally to a constant multiplier
+        value = GAMax(child.alleleset(idx).lower(), value);
+        value = GAMin(child.alleleset(idx).upper(), value);
       }
       child.gene(idx, value);
     }
   }
-  return((int)nMut);
+  return ((int)nMut);
 }
-
 
 float objective(GAGenome &c)
 {
   float avg = 0;
-  
+
   // For timing
   std::chrono::time_point<std::chrono::system_clock> start, end;
   start = std::chrono::system_clock::now();
 
-  for (int i = 0; i < n_trials; i++) avg += LaunchARGoS(c);
-  
+  for (int i = 0; i < n_trials; i++)
+    avg += LaunchARGoS(c);
+
   avg /= n_trials;
 
-  
   end = std::chrono::system_clock::now();
-  
-  std::chrono::duration<double> elapsed_seconds = end-start;
 
-  MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);     
+  std::chrono::duration<double> elapsed_seconds = end - start;
 
-      char hostname[1024];              
-      hostname[1023] = '\0';                                          
-      gethostname(hostname, 1023);     
- 
-      /*
-      printf("Worker %d on %s evaluated genome [", mpi_rank, hostname);
-      for (int i = 0; i < GENOME_SIZE; i++)
-	printf("%f ",dynamic_cast<const GARealGenome&>(c).gene(i));
-      printf("] in %f seconds. ", elapsed_seconds.count());
-      printf("Fitness: %f.\n", avg );
-      */
+  MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
 
-      return avg;
+  char hostname[1024];
+  hostname[1023] = '\0';
+  gethostname(hostname, 1023);
+
+  /*
+  printf("Worker %d on %s evaluated genome [", mpi_rank, hostname);
+  for (int i = 0; i < GENOME_SIZE; i++)
+printf("%f ",dynamic_cast<const GARealGenome&>(c).gene(i));
+  printf("] in %f seconds. ", elapsed_seconds.count());
+  printf("Fitness: %f.\n", avg );
+  */
+
+  return avg;
 }
 
 /*
  * Launch ARGoS to evaluate a genome.
  */
-float LaunchARGoS(GAGenome& c_genome) 
+float LaunchARGoS(GAGenome &c_genome)
 {
   // Declate the fitness value and the shared memory segment id and address
   float fitness = 0;
-  int    ShmID;
-  float*   ShmPTR;
-  
+  int ShmID;
+  float *ShmPTR;
+
   // Allocate the shared memory to use between this process and the child argos process
   ShmID = shmget(IPC_PRIVATE, sizeof(float), IPC_CREAT | 0666);
-  if (ShmID < 0) {
+  if (ShmID < 0)
+  {
     printf("ERROR: Allocating shared memory segment in main.cpp:LaunchARGoS() failed.\n");
     exit(1);
   }
-  
+
   // Attach to the shared memory segment
-  ShmPTR = (float*) shmat(ShmID, NULL, 0);
-  if ((float*) ShmPTR == (float*)-1) 
-    {
-      printf("ERROR: Attaching to shared memory segment in main.cpp:LaunchARGoS() failed.\n");
-      exit(1);
-    }
+  ShmPTR = (float *)shmat(ShmID, NULL, 0);
+  if ((float *)ShmPTR == (float *)-1)
+  {
+    printf("ERROR: Attaching to shared memory segment in main.cpp:LaunchARGoS() failed.\n");
+    exit(1);
+  }
 
   *ShmPTR = 0; // Initialise
 
   pid_t pid = fork(); // Create the new process with a copy of this memory space
 
   if (pid == 0)
-    {
-      // In child process - run the argos3 simulation
+  {
+    // In child process - run the argos3 simulation
 
-      /* Convert the received genome to the actual genome type */
-      GARealGenome& cRealGenome = dynamic_cast<GARealGenome&>(c_genome);
-  
-      Real* cpfa_genome = new Real[GENOME_SIZE];
+    /* Convert the received genome to the actual genome type */
+    GARealGenome &cRealGenome = dynamic_cast<GARealGenome &>(c_genome);
 
-      // Convert to a convenient format for the argos controller
-      for (int i = 0; i < GENOME_SIZE; i++)
-	cpfa_genome[i] = cRealGenome.gene(i);
-       
-      /*      
-      printf("%s: worker %d started a genome evaluation. (%f, %f, %f, %f, %f, %f, %f)\n", hostname, mpi_rank, 
-	     cpfa_genome[0],
-	     cpfa_genome[1],
-	     cpfa_genome[2],
-	     cpfa_genome[3],
-	     cpfa_genome[4],
-	     cpfa_genome[5],
-	     cpfa_genome[6]);
-      */
+    Real *cpfa_genome = new Real[GENOME_SIZE];
 
-      /* Redirect LOG and LOGERR to dedicated files to prevent clutter on the screen */
-      std::ofstream cLOGFile("argos_logs/ARGoS_LOG_" + ToString(::getpid()), std::ios::out);
-      LOG.DisableColoredOutput();
-      LOG.GetStream().rdbuf(cLOGFile.rdbuf());
-      std::ofstream cLOGERRFile("argos_logs/ARGoS_LOGERR_" + ToString(::getpid()), std::ios::out);
-      LOGERR.DisableColoredOutput();
-      LOGERR.GetStream().rdbuf(cLOGERRFile.rdbuf());
+    // Convert to a convenient format for the argos controller
+    for (int i = 0; i < GENOME_SIZE; i++)
+      cpfa_genome[i] = cRealGenome.gene(i);
 
-      /*
-       * Initialize ARGoS
-       */
-      /* The CSimulator class of ARGoS is a singleton. Therefore, to
-       * manipulate an ARGoS experiment, it is enough to get its instance */
-      argos::CSimulator& cSimulator = argos::CSimulator::GetInstance();
+    /*
+    printf("%s: worker %d started a genome evaluation. (%f, %f, %f, %f, %f, %f, %f)\n", hostname, mpi_rank,
+     cpfa_genome[0],
+     cpfa_genome[1],
+     cpfa_genome[2],
+     cpfa_genome[3],
+     cpfa_genome[4],
+     cpfa_genome[5],
+     cpfa_genome[6]);
+    */
 
-      // Set the .argos configuration file
-      cSimulator.SetExperimentFileName(experiment_path);
-      
-      // Load it to configure ARGoS 
-      cSimulator.LoadExperiment();
+    /* Redirect LOG and LOGERR to dedicated files to prevent clutter on the screen */
+    std::ofstream cLOGFile("argos_logs/ARGoS_LOG_" + ToString(::getpid()), std::ios::out);
+    LOG.DisableColoredOutput();
+    LOG.GetStream().rdbuf(cLOGFile.rdbuf());
+    std::ofstream cLOGERRFile("argos_logs/ARGoS_LOGERR_" + ToString(::getpid()), std::ios::out);
+    LOGERR.DisableColoredOutput();
+    LOGERR.GetStream().rdbuf(cLOGERRFile.rdbuf());
 
-      // Get a reference to the loop functions
-      CPFA_loop_functions& cLoopFunctions = dynamic_cast<CPFA_loop_functions&>(cSimulator.GetLoopFunctions());
+    /*
+     * Initialize ARGoS
+     */
+    /* The CSimulator class of ARGoS is a singleton. Therefore, to
+     * manipulate an ARGoS experiment, it is enough to get its instance */
+    argos::CSimulator &cSimulator = argos::CSimulator::GetInstance();
 
-      // Configure the controller with the genome
-      cLoopFunctions.ConfigureFromGenome(cpfa_genome);
+    // Set the .argos configuration file
+    cSimulator.SetExperimentFileName(experiment_path);
 
-      // Run the experiment
-      cSimulator.Execute();
+    // Load it to configure ARGoS
+    cSimulator.LoadExperiment();
 
-      // Update performance and store in the shared memory segment
-      *ShmPTR = cLoopFunctions.Score();;
+    // Get a reference to the loop functions
+    CPFA_loop_functions &cLoopFunctions = dynamic_cast<CPFA_loop_functions &>(cSimulator.GetLoopFunctions());
 
-      // For testing
-      //float score = 0;
-      //for (int i = 0; i < GENOME_SIZE; i++) score += cpfa_genome[i];
-      //*ShmPTR = score;
+    // Configure the controller with the genome
+    cLoopFunctions.ConfigureFromGenome(cpfa_genome);
 
-      // Clean up the simulation
-      cSimulator.Destroy();
-      
-      // Clean up the temp genome copy
-	delete [] cpfa_genome;
+    // Run the experiment
+    cSimulator.Execute();
 
-	// Make this process exit
-      _Exit(0); 
-    }
-  
+    // Update performance and store in the shared memory segment
+    *ShmPTR = cLoopFunctions.Score();
+    ;
+
+    // For testing
+    // float score = 0;
+    // for (int i = 0; i < GENOME_SIZE; i++) score += cpfa_genome[i];
+    //*ShmPTR = score;
+
+    // Clean up the simulation
+    cSimulator.Destroy();
+
+    // Clean up the temp genome copy
+    delete[] cpfa_genome;
+
+    // Make this process exit
+    _Exit(0);
+  }
+
   // In parent - wait for child to finish
   int status = wait(&status);
 
   // Make a local copy of the shared fitness value
-  fitness = *ShmPTR;  
+  fitness = *ShmPTR;
 
   // Release shared memory
-  shmdt((void *) ShmPTR);
+  shmdt((void *)ShmPTR);
   shmctl(ShmID, IPC_RMID, NULL);
 
-  /* Return the result of the evaluation */  
+  /* Return the result of the evaluation */
   return fitness;
 }

--- a/Ideal_Static_MPFA/source/ga-mpi/GA1DArrayGenome.C
+++ b/Ideal_Static_MPFA/source/ga-mpi/GA1DArrayGenome.C
@@ -18,7 +18,7 @@
 #include <ga-mpi/GA1DArrayGenome.h>
 #include <ga-mpi/GAMask.h>
 
-template <class T> int 
+template <class T> int
 GA1DArrayIsHole(const GA1DArrayGenome<T>&, const GA1DArrayGenome<T>&,
 		int, int, int);
 
@@ -36,15 +36,15 @@ GA1DArrayGenome<T>::classID() const {return GAID::ArrayGenome;}
 // this point - initialization must be done explicitly by the user of the
 // genome (eg when the population is created or reset).  If we called the
 // initializer routine here then we could end up with multiple initializations
-// and/or calls to dummy initializers (for example when the genome is 
+// and/or calls to dummy initializers (for example when the genome is
 // created with a dummy initializer and the initializer is assigned later on).
 // Besides, we default to the no-initialization initializer by calling the
 // default genome constructor.
-template <class T> 
+template <class T>
 GA1DArrayGenome<T>::
 GA1DArrayGenome(unsigned int length, GAGenome::Evaluator f, void * u) :
 GAArray<T>(length),
-GAGenome(DEFAULT_1DARRAY_INITIALIZER, 
+GAGenome(DEFAULT_1DARRAY_INITIALIZER,
 	 DEFAULT_1DARRAY_MUTATOR,
 	 DEFAULT_1DARRAY_COMPARATOR) {
   evaluator(f);
@@ -56,9 +56,9 @@ GAGenome(DEFAULT_1DARRAY_INITIALIZER,
 
 // This is the copy initializer.  We set everything to the default values, then
 // copy the original.  The Array creator takes care of zeroing the data.
-template <class T> 
+template <class T>
 GA1DArrayGenome<T>::
-GA1DArrayGenome(const GA1DArrayGenome<T> & orig) : 
+GA1DArrayGenome(const GA1DArrayGenome<T> & orig) :
 GAArray<T>(orig.sz), GAGenome() {
   GA1DArrayGenome<T>::copy(orig);
 }
@@ -74,7 +74,7 @@ GA1DArrayGenome<T>::~GA1DArrayGenome() { }
 // what we define here - a virtual function).  We should check to be sure that
 // both genomes are the same class and same dimension.  This function tries
 // to be smart about they way it copies.  If we already have data, then we do
-// a memcpy of the one we're supposed to copy.  If we don't or we're not the 
+// a memcpy of the one we're supposed to copy.  If we don't or we're not the
 // same size as the one we're supposed to copy, then we adjust ourselves.
 //   The Array takes care of the resize in its copy method.
 template <class T> void
@@ -92,7 +92,7 @@ GA1DArrayGenome<T>::copy(const GAGenome & orig){
 template <class T> GAGenome *
 GA1DArrayGenome<T>::clone(GAGenome::CloneMethod flag) const {
   GA1DArrayGenome<T> *cpy = new GA1DArrayGenome<T>(nx);
-  if(flag == CONTENTS){ 
+  if(flag == CONTENTS){
     cpy->copy(*this);
   }
   else{
@@ -110,10 +110,10 @@ GA1DArrayGenome<T>::clone(GAGenome::CloneMethod flag) const {
 // length, then we don't do anything.
 //   We pay attention to the values of minX and maxX - they determine what kind
 // of resizing we are allowed to do.  If a resize is requested with a length
-// less than the min length specified by the behaviour, we set the minimum 
+// less than the min length specified by the behaviour, we set the minimum
 // to the length.  If the length is longer than the max length specified by
 // the behaviour, we set the max value to the length.
-//   We return the total size (in bits) of the genome after resize. 
+//   We return the total size (in bits) of the genome after resize.
 //   We don't do anything to the new contents!
 template <class T> int
 GA1DArrayGenome<T>::resize(int len)
@@ -160,7 +160,7 @@ GA1DArrayGenome<T>::write(STD_OSTREAM & os) const {
 //   Set the resize behaviour of the genome.  A genome can be fixed
 // length, resizeable with a max and min limit, or resizeable with no limits
 // (other than an implicit one that we use internally).
-//   A value of 0 means no resize, a value less than zero mean unlimited 
+//   A value of 0 means no resize, a value less than zero mean unlimited
 // resize, and a positive value means resize with that value as the limit.
 template <class T> int
 GA1DArrayGenome<T>::
@@ -183,7 +183,7 @@ GA1DArrayGenome<T>::resizeBehaviour() const {
   return val;
 }
 
-template <class T> int 
+template <class T> int
 GA1DArrayGenome<T>::equal(const GAGenome & c) const {
   const GA1DArrayGenome<T> & b = DYN_CAST(const GA1DArrayGenome<T> &, c);
   return((this == &c) ? 1 : ((nx != b.nx) ? 0 : GAArray<T>::equal(b,0,0,nx)));
@@ -205,7 +205,7 @@ its own, independent allele set.  If we clone a new genome, the new one gets a
 link to our allele set (so we don't end up with zillions of allele sets).  Same
 is true for the copy constructor.
   The array may have a single allele set or an array of allele sets, depending
-on which creator was called.  Either way, the allele set cannot be changed 
+on which creator was called.  Either way, the allele set cannot be changed
 once the array is created.
 ---------------------------------------------------------------------------- */
 template <class T> const char *
@@ -213,7 +213,7 @@ GA1DArrayAlleleGenome<T>::className() const {return "GA1DArrayAlleleGenome";}
 template <class T> int
 GA1DArrayAlleleGenome<T>::classID() const {return GAID::ArrayAlleleGenome;}
 
-template <class T> 
+template <class T>
 GA1DArrayAlleleGenome<T>::
 GA1DArrayAlleleGenome(unsigned int length, const GAAlleleSet<T> & s,
 		      GAGenome::Evaluator f, void * u) :
@@ -228,7 +228,7 @@ GA1DArrayGenome<T>(length, f, u){
   this->crossover(GA1DArrayAlleleGenome<T>::DEFAULT_1DARRAY_ALLELE_CROSSOVER);
 }
 
-template <class T> 
+template <class T>
 GA1DArrayAlleleGenome<T>::
 GA1DArrayAlleleGenome(const GAAlleleSetArray<T> & sa,
 		      GAGenome::Evaluator f, void * u) :
@@ -247,9 +247,9 @@ GA1DArrayGenome<T>(sa.size(), f, u) {
 
 // The copy constructor creates a new genome whose allele set refers to the
 // original's allele set.
-template <class T> 
+template <class T>
 GA1DArrayAlleleGenome<T>::
-GA1DArrayAlleleGenome(const GA1DArrayAlleleGenome<T>& orig) : 
+GA1DArrayAlleleGenome(const GA1DArrayAlleleGenome<T>& orig) :
 GA1DArrayGenome<T>(orig.sz) {
   naset = 0;
   aset = (GAAlleleSet<T>*)0;
@@ -265,7 +265,7 @@ GA1DArrayAlleleGenome<T>::~GA1DArrayAlleleGenome(){
 
 
 // This implementation of clone does not make use of the contents/attributes
-// capability because this whole interface isn't quite right yet...  Just 
+// capability because this whole interface isn't quite right yet...  Just
 // clone the entire thing, contents and all.
 template <class T> GAGenome *
 GA1DArrayAlleleGenome<T>::clone(GAGenome::CloneMethod) const {
@@ -273,10 +273,10 @@ GA1DArrayAlleleGenome<T>::clone(GAGenome::CloneMethod) const {
 }
 
 
-template <class T> void 
+template <class T> void
 GA1DArrayAlleleGenome<T>::copy(const GAGenome& orig){
   if(&orig == this) return;
-  const GA1DArrayAlleleGenome<T> * c = 
+  const GA1DArrayAlleleGenome<T> * c =
     DYN_CAST(const GA1DArrayAlleleGenome<T>*, &orig);
   if(c) {
     GA1DArrayGenome<T>::copy(*c);
@@ -339,7 +339,7 @@ GA1DArrayAlleleGenome<T>::equal(const GAGenome & c) const {
 ---------------------------------------------------------------------------- */
 // The random initializer sets the elements of the array based on the alleles
 // set.  We choose randomly the allele for each element.
-template <class ARRAY_TYPE> void 
+template <class ARRAY_TYPE> void
 GA1DArrayAlleleGenome<ARRAY_TYPE>::UniformInitializer(GAGenome & c)
 {
   GA1DArrayAlleleGenome<ARRAY_TYPE> &child=
@@ -354,7 +354,7 @@ GA1DArrayAlleleGenome<ARRAY_TYPE>::UniformInitializer(GAGenome & c)
 // and assign each element the next allele in the allele set.  Once each
 // element has been initialized, scramble the contents by swapping elements.
 // This assumes that there is only one allele set for the array.
-template <class ARRAY_TYPE> void 
+template <class ARRAY_TYPE> void
 GA1DArrayAlleleGenome<ARRAY_TYPE>::OrderedInitializer(GAGenome & c)
 {
   GA1DArrayAlleleGenome<ARRAY_TYPE> &child=
@@ -372,15 +372,15 @@ GA1DArrayAlleleGenome<ARRAY_TYPE>::OrderedInitializer(GAGenome & c)
 }
 
 
-// Randomly pick elements in the array then set the element to any of the 
+// Randomly pick elements in the array then set the element to any of the
 // alleles in the allele set for this genome.  This will work for any number
 // of allele sets for a given array.
-template <class ARRAY_TYPE> int 
+template <class ARRAY_TYPE> int
 GA1DArrayAlleleGenome<ARRAY_TYPE>::FlipMutator(GAGenome & c, float pmut)
 {
   GA1DArrayAlleleGenome<ARRAY_TYPE> &child=
     DYN_CAST(GA1DArrayAlleleGenome<ARRAY_TYPE> &, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.length());
@@ -404,11 +404,11 @@ GA1DArrayAlleleGenome<ARRAY_TYPE>::FlipMutator(GAGenome & c, float pmut)
 
 
 // Randomly swap elements in the array.
-template <class ARRAY_TYPE> int 
+template <class ARRAY_TYPE> int
 GA1DArrayGenome<ARRAY_TYPE>::SwapMutator(GAGenome & c, float pmut)
 {
   GA1DArrayGenome<ARRAY_TYPE> &child=DYN_CAST(GA1DArrayGenome<ARRAY_TYPE>&, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.length());
@@ -469,7 +469,7 @@ ElementComparator(const GAGenome& a, const GAGenome& b)
 #define SWAP(a,b) {unsigned int tmp=a; a=b; b=tmp;}
 
 // Randomly take bits from each parent.  For each bit we flip a coin to see if
-// that bit should come from the mother or the father.  If strings are 
+// that bit should come from the mother or the father.  If strings are
 // different lengths then we need to use the mask to get things right.
 template <class T> int
 GA1DArrayGenome<T>::
@@ -517,8 +517,8 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
     n = 2;
   }
   else if(c1 || c2){
-    GA1DArrayGenome<T> &sis = (c1 ? 
-			       DYN_CAST(GA1DArrayGenome<T> &, *c1) : 
+    GA1DArrayGenome<T> &sis = (c1 ?
+			       DYN_CAST(GA1DArrayGenome<T> &, *c1) :
 			       DYN_CAST(GA1DArrayGenome<T> &, *c2));
 
     if(mom.length() == dad.length() && sis.length() == mom.length()){
@@ -550,7 +550,7 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
 // we cannot handle that and post an error message.
 template <class T> int
 GA1DArrayGenome<T>::
-OnePointCrossover(const GAGenome& p1, const GAGenome& p2, 
+OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 		  GAGenome* c1, GAGenome* c2){
   const GA1DArrayGenome<T> &mom=DYN_CAST(const GA1DArrayGenome<T> &, p1);
   const GA1DArrayGenome<T> &dad=DYN_CAST(const GA1DArrayGenome<T> &, p2);
@@ -565,7 +565,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour() == GAGenome::FIXED_SIZE){
-      if(mom.length() != dad.length() || 
+      if(mom.length() != dad.length() ||
 	 sis.length() != bro.length() ||
 	 sis.length() != mom.length()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -587,17 +587,17 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sis.resize(momsite+dadlen);
       bro.resize(dadsite+momlen);
     }
-    
+
     sis.copy(mom, 0, 0, momsite);
     sis.copy(dad, momsite, dadsite, dadlen);
     bro.copy(dad, 0, 0, dadsite);
     bro.copy(mom, dadsite, momsite, momlen);
-  
+
     nc = 2;
   }
   else if(c1 || c2){
-    GA1DArrayGenome<T> &sis = (c1 ? 
-			       DYN_CAST(GA1DArrayGenome<T> &, *c1) : 
+    GA1DArrayGenome<T> &sis = (c1 ?
+			       DYN_CAST(GA1DArrayGenome<T> &, *c1) :
 			       DYN_CAST(GA1DArrayGenome<T> &, *c2));
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE){
@@ -615,7 +615,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       dadlen = dad.length() - dadsite;
       sis.resize(momsite+dadlen);
     }
-    
+
     if(GARandomBit()){
       sis.copy(mom, 0, 0, momsite);
       sis.copy(dad, momsite, dadsite, dadlen);
@@ -642,14 +642,14 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
 
 // Two point crossover for the 1D array genome.  Similar to the single point
-// crossover, but here we pick two points then grab the sections based upon 
+// crossover, but here we pick two points then grab the sections based upon
 // those two points.
 //   When we pick the points, it doesn't matter where they fall (one is not
 // dependent upon the other).  Make sure we get the lesser one into the first
 // position of our site array.
 template <class T> int
 GA1DArrayGenome<T>::
-TwoPointCrossover(const GAGenome& p1, const GAGenome& p2, 
+TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
 		  GAGenome* c1, GAGenome* c2){
   const GA1DArrayGenome<T> &mom=DYN_CAST(const GA1DArrayGenome<T> &, p1);
   const GA1DArrayGenome<T> &dad=DYN_CAST(const GA1DArrayGenome<T> &, p2);
@@ -664,7 +664,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour() == GAGenome::FIXED_SIZE){
-      if(mom.length() != dad.length() || 
+      if(mom.length() != dad.length() ||
 	 sis.length() != bro.length() ||
 	 sis.length() != mom.length()){
 	GAErr(GA_LOC, mom.className(), "two-point cross", gaErrSameLengthReqd);
@@ -675,7 +675,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
       if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
-      
+
       dadsite[0] = momsite[0];
       dadsite[1] = momsite[1];
       dadlen[0] = momlen[0];
@@ -691,13 +691,13 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
       if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
-      
+
       dadsite[0] = GARandomInt(0, dad.length());
       dadsite[1] = GARandomInt(0, dad.length());
       if(dadsite[0] > dadsite[1]) SWAP(dadsite[0], dadsite[1]);
       dadlen[0] = dadsite[1] - dadsite[0];
       dadlen[1] = dad.length() - dadsite[1];
-      
+
       sis.resize(momsite[0]+dadlen[0]+momlen[1]);
       bro.resize(dadsite[0]+momlen[0]+dadlen[1]);
     }
@@ -726,7 +726,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
       if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
-      
+
       dadsite[0] = momsite[0];
       dadsite[1] = momsite[1];
       dadlen[0] = momlen[0];
@@ -738,7 +738,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
       if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
-      
+
       dadsite[0] = GARandomInt(0, dad.length());
       dadsite[1] = GARandomInt(0, dad.length());
       if(dadsite[0] > dadsite[1]) SWAP(dadsite[0], dadsite[1]);
@@ -771,13 +771,13 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
 
 
 
-// Even and odd crossover for the array works just like it does for the 
+// Even and odd crossover for the array works just like it does for the
 // binary strings.  For even crossover we take the 0th element and every other
 // one after that from the mother.  The 1st and every other come from the
 // father.  For odd crossover, we do just the opposite.
 template <class T> int
 GA1DArrayGenome<T>::
-EvenOddCrossover(const GAGenome& p1, const GAGenome& p2, 
+EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
 		 GAGenome* c1, GAGenome* c2){
   const GA1DArrayGenome<T> &mom=DYN_CAST(const GA1DArrayGenome<T> &, p1);
   const GA1DArrayGenome<T> &dad=DYN_CAST(const GA1DArrayGenome<T> &, p2);
@@ -816,10 +816,10 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
     nc = 2;
   }
   else if(c1 || c2){
-    GA1DArrayGenome<T> &sis = (c1 ? 
-			       DYN_CAST(GA1DArrayGenome<T> &, *c1) : 
+    GA1DArrayGenome<T> &sis = (c1 ?
+			       DYN_CAST(GA1DArrayGenome<T> &, *c1) :
 			       DYN_CAST(GA1DArrayGenome<T> &, *c2));
-    
+
     if(mom.length() == dad.length() && sis.length() == mom.length()){
       for(i=sis.length()-1; i>=1; i-=2){
 	sis.gene(i, mom.gene(i));
@@ -853,7 +853,7 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
 //   We make sure that b will be greater than a.
 template <class T> int
 GA1DArrayGenome<T>::
-PartialMatchCrossover(const GAGenome& p1, const GAGenome& p2, 
+PartialMatchCrossover(const GAGenome& p1, const GAGenome& p2,
 		      GAGenome* c1, GAGenome* c2){
   const GA1DArrayGenome<T> &mom=DYN_CAST(const GA1DArrayGenome<T> &, p1);
   const GA1DArrayGenome<T> &dad=DYN_CAST(const GA1DArrayGenome<T> &, p2);
@@ -868,7 +868,7 @@ PartialMatchCrossover(const GAGenome& p1, const GAGenome& p2,
     GAErr(GA_LOC, mom.className(), "parial match cross", gaErrBadParentLength);
     return nc;
   }
-  
+
   if(c1 && c2){
     GA1DArrayGenome<T> &sis=DYN_CAST(GA1DArrayGenome<T> &, *c1);
     GA1DArrayGenome<T> &bro=DYN_CAST(GA1DArrayGenome<T> &, *c2);
@@ -887,8 +887,8 @@ PartialMatchCrossover(const GAGenome& p1, const GAGenome& p2,
     nc = 2;
   }
   else if(c1 || c2){
-    GA1DArrayGenome<T> &sis = (c1 ? 
-			       DYN_CAST(GA1DArrayGenome<T> &, *c1) : 
+    GA1DArrayGenome<T> &sis = (c1 ?
+			       DYN_CAST(GA1DArrayGenome<T> &, *c1) :
 			       DYN_CAST(GA1DArrayGenome<T> &, *c2));
 
     const GA1DArrayGenome<T> *parent1, *parent2;
@@ -929,7 +929,7 @@ GA1DArrayIsHole(const GA1DArrayGenome<T> &c, const GA1DArrayGenome<T> &dad,
 //   This implementation isn't terribly smart.  For example, I do a linear
 // search rather than caching and doing binary search or smarter hash tables.
 //   First we copy the mother into the sister.  Then move the 'holes' into the
-// crossover section and maintain the ordering of the non-hole elements.  
+// crossover section and maintain the ordering of the non-hole elements.
 // Finally, put the 'holes' in the proper order within the crossover section.
 // After we have done the sister, we do the brother.
 template <class T> int
@@ -949,7 +949,7 @@ OrderCrossover(const GAGenome& p1, const GAGenome& p2,
     GAErr(GA_LOC, mom.className(), "order cross", gaErrBadParentLength);
     return nc;
   }
-  
+
   if(c1 && c2){
     GA1DArrayGenome<T> &sis=DYN_CAST(GA1DArrayGenome<T> &, *c1);
     GA1DArrayGenome<T> &bro=DYN_CAST(GA1DArrayGenome<T> &, *c2);
@@ -962,7 +962,7 @@ OrderCrossover(const GAGenome& p1, const GAGenome& p2,
       if(index >= sis.size()) index=0;
       if(GA1DArrayIsHole(sis,dad,index,a,b)) break;
     }
-    
+
     for(; i<sis.size()-b+a; i++, index++){
       if(index >= sis.size()) index=0;
       j=index;
@@ -999,7 +999,7 @@ OrderCrossover(const GAGenome& p1, const GAGenome& p2,
       } while(GA1DArrayIsHole(bro,mom,j,a,b));
       bro.swap(index,j);
     }
-    
+
 // Now put the 'holes' in the proper order within the crossover section.
     for(i=a; i<b; i++){
       if(bro.gene(i) != mom.gene(i)){
@@ -1011,8 +1011,8 @@ OrderCrossover(const GAGenome& p1, const GAGenome& p2,
     nc = 2;
   }
   else if(c1 || c2){
-    GA1DArrayGenome<T> &sis = (c1 ? 
-			       DYN_CAST(GA1DArrayGenome<T> &, *c1) : 
+    GA1DArrayGenome<T> &sis = (c1 ?
+			       DYN_CAST(GA1DArrayGenome<T> &, *c1) :
 			       DYN_CAST(GA1DArrayGenome<T> &, *c2));
 
     const GA1DArrayGenome<T> *parent1, *parent2;
@@ -1053,7 +1053,7 @@ OrderCrossover(const GAGenome& p1, const GAGenome& p2,
 
 
 
-// Cycle crossover for the 1D array genome.  This is implemented as described 
+// Cycle crossover for the 1D array genome.  This is implemented as described
 // in goldberg's book.  The first is picked from mom, then cycle using dad.
 // Finally, fill in the gaps with the elements from dad.
 //   We allocate space for a temporary array in this routine.  It never frees
@@ -1063,8 +1063,8 @@ OrderCrossover(const GAGenome& p1, const GAGenome& p2,
 //  Allocate space for an array of flags.  We use this to keep track of whether
 // the child's contents came from the mother or the father.  We don't free the
 // space here, but it is not a memory leak.
-//   The first step is to cycle through mom & dad to get the cyclic part of 
-// the crossover.  Then fill in the rest of the sis with dad's contents that 
+//   The first step is to cycle through mom & dad to get the cyclic part of
+// the crossover.  Then fill in the rest of the sis with dad's contents that
 // we didn't use in the cycle.  Finally, do the same thing for the other child.
 //   Notice that this implementation makes serious use of the operator= for the
 // objects in the array.  It also requires the operator != and == comparators.
@@ -1139,7 +1139,7 @@ CycleCrossover(const GAGenome& p1, const GAGenome& p2,
     GAMask mask;
     mask.size(sis.length());
     mask.clear();
-    
+
     sis.gene(0, parent1->gene(0));
     mask[0] = 1;
     while(parent2->gene(current) != parent1->gene(0)){

--- a/Ideal_Static_MPFA/source/ga-mpi/GA1DBinStrGenome.C
+++ b/Ideal_Static_MPFA/source/ga-mpi/GA1DBinStrGenome.C
@@ -27,13 +27,13 @@
 // this point - initialization must be done explicitly by the user of the
 // genome (eg when the population is created or reset).  If we called the
 // initializer routine here then we could end up with multiple initializations
-// and/or calls to dummy initializers (for example when the genome is 
+// and/or calls to dummy initializers (for example when the genome is
 // created with a dummy initializer and the initializer is assigned later on).
 GA1DBinaryStringGenome::
-GA1DBinaryStringGenome(unsigned int len, 
+GA1DBinaryStringGenome(unsigned int len,
 		       GAGenome::Evaluator f, void * u) :
 GABinaryString(len),
-GAGenome(DEFAULT_1DBINSTR_INITIALIZER, 
+GAGenome(DEFAULT_1DBINSTR_INITIALIZER,
 	 DEFAULT_1DBINSTR_MUTATOR,
 	 DEFAULT_1DBINSTR_COMPARATOR) {
   evaluator(f);
@@ -60,7 +60,7 @@ GA1DBinaryStringGenome::~GA1DBinaryStringGenome() {
 
 
 // The clone member creates a duplicate (exact or just attributes, depending
-// on the flag).  The caller is responsible for freeing the memory that is 
+// on the flag).  The caller is responsible for freeing the memory that is
 // allocated by this method.
 GAGenome*
 GA1DBinaryStringGenome::clone(GAGenome::CloneMethod flag) const {
@@ -81,7 +81,7 @@ GA1DBinaryStringGenome::clone(GAGenome::CloneMethod flag) const {
 // what we define here - a virtual function).  We should check to be sure that
 // both genomes are the same class and same dimension.  This function tries
 // to be smart about they way it copies.  If we already have data, then we do
-// a memcpy of the one we're supposed to copy.  If we don't or we're not the 
+// a memcpy of the one we're supposed to copy.  If we don't or we're not the
 // same size as the one we're supposed to copy, then we adjust ourselves.
 //   The BinaryStringGenome takes care of the resize in its copy method.
 // It also copies the bitstring for us.
@@ -89,7 +89,7 @@ void
 GA1DBinaryStringGenome::copy(const GAGenome & orig)
 {
   if(&orig == this) return;
-  const GA1DBinaryStringGenome* c = 
+  const GA1DBinaryStringGenome* c =
     DYN_CAST(const GA1DBinaryStringGenome*, &orig);
   if(c) {
     GAGenome::copy(*c);
@@ -173,7 +173,7 @@ GA1DBinaryStringGenome::write(STD_OSTREAM & os) const
 //   Set the resize behaviour of the genome.  A genome can be fixed
 // length, resizeable with a max and min limit, or resizeable with no limits
 // (other than an implicit one that we use internally).
-//   A value of 0 means no resize, a value less than zero mean unlimited 
+//   A value of 0 means no resize, a value less than zero mean unlimited
 // resize, and a positive value means resize with that value as the limit.
 //   We return the upper limit of the genome's size.
 int
@@ -190,21 +190,21 @@ resizeBehaviour(unsigned int lower, unsigned int upper)
   return resizeBehaviour();
 }
 
-int 
+int
 GA1DBinaryStringGenome::resizeBehaviour() const {
   int val = maxX;
   if(maxX == minX) val = FIXED_SIZE;
   return val;
 }
 
-int 
+int
 GA1DBinaryStringGenome::
 equal(const GA1DBinaryStringGenome& c,
       unsigned int dest, unsigned int src, unsigned int len) const {
   return GABinaryString::equal(c,dest,src,len);
 }
 
-int 
+int
 GA1DBinaryStringGenome::equal(const GAGenome & c) const {
   if(this == &c) return 1;
   const GA1DBinaryStringGenome* b = DYN_CAST(const GA1DBinaryStringGenome*,&c);
@@ -231,7 +231,7 @@ GA1DBinaryStringGenome::equal(const GAGenome & c) const {
 // random bit function so we don't have to worry about machine-specific stuff.
 //   We also do a resize so the genome can resize itself (randomly) if it
 // is a resizeable genome.
-void 
+void
 GA1DBinaryStringGenome::UniformInitializer(GAGenome & c)
 {
   GA1DBinaryStringGenome &child=DYN_CAST(GA1DBinaryStringGenome &, c);
@@ -242,7 +242,7 @@ GA1DBinaryStringGenome::UniformInitializer(GAGenome & c)
 
 
 //   Unset all of the bits in the genome.
-void 
+void
 GA1DBinaryStringGenome::UnsetInitializer(GAGenome & c)
 {
   GA1DBinaryStringGenome &child=DYN_CAST(GA1DBinaryStringGenome &, c);
@@ -252,7 +252,7 @@ GA1DBinaryStringGenome::UnsetInitializer(GAGenome & c)
 
 
 //   Set all of the bits in the genome.
-void 
+void
 GA1DBinaryStringGenome::SetInitializer(GAGenome & c)
 {
   GA1DBinaryStringGenome &child=DYN_CAST(GA1DBinaryStringGenome &, c);
@@ -271,11 +271,11 @@ GA1DBinaryStringGenome::SetInitializer(GAGenome & c)
 // better the chance that it will match the desired mutation rate.
 //   If nMut is greater than 1, then we round up, so a mutation of 2.2 would
 // be 3 mutations, and 2.9 would be 3 as well.  nMut of 3 would be 3 mutations.
-int 
+int
 GA1DBinaryStringGenome::FlipMutator(GAGenome & c, float pmut)
 {
   GA1DBinaryStringGenome &child=DYN_CAST(GA1DBinaryStringGenome &, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float, child.length());
@@ -298,10 +298,10 @@ GA1DBinaryStringGenome::FlipMutator(GAGenome & c, float pmut)
 }
 
 
-// Return a number from 0 to 1 to indicate how similar two genomes are.  For 
+// Return a number from 0 to 1 to indicate how similar two genomes are.  For
 // the binary strings we compare bits.  We count the number of bits that are
 // the same then divide by the number of bits.  If the genomes are different
-// length then we return a -1 to indicate that we cannot calculate the 
+// length then we return a -1 to indicate that we cannot calculate the
 // similarity.
 //   Normal hamming distance makes use of population information - this is not
 // a hamming measure!  This is a similarity measure of two individuals, not
@@ -334,7 +334,7 @@ GA1DBinaryStringGenome::BitComparator(const GAGenome& a, const GAGenome& b){
 
 
 // Randomly take bits from each parent.  For each bit we flip a coin to see if
-// that bit should come from the mother or the father.  This operator can be 
+// that bit should come from the mother or the father.  This operator can be
 // used on genomes of different lengths, but the crossover is truncated to the
 // shorter of the parents and child.
 int
@@ -385,8 +385,8 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
     n = 2;
   }
   else if(c1 || c2){
-    GA1DBinaryStringGenome &sis = (c1 ? 
-				   DYN_CAST(GA1DBinaryStringGenome&, *c1) : 
+    GA1DBinaryStringGenome &sis = (c1 ?
+				   DYN_CAST(GA1DBinaryStringGenome&, *c1) :
 				   DYN_CAST(GA1DBinaryStringGenome&, *c2));
 
     if(mom.length() == dad.length() && sis.length() == mom.length()){
@@ -434,7 +434,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour() == GAGenome::FIXED_SIZE){
-      if(mom.length() != dad.length() || 
+      if(mom.length() != dad.length() ||
 	 sis.length() != bro.length() ||
 	 sis.length() != mom.length()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -461,12 +461,12 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
     sis.copy(dad, momsite, dadsite, dadlen);
     bro.copy(dad, 0, 0, dadsite);
     bro.copy(mom, dadsite, momsite, momlen);
-  
+
     n = 2;
   }
   else if(c1 || c2){
-    GA1DBinaryStringGenome &sis = (c1 ? 
-				   DYN_CAST(GA1DBinaryStringGenome&, *c1) : 
+    GA1DBinaryStringGenome &sis = (c1 ?
+				   DYN_CAST(GA1DBinaryStringGenome&, *c1) :
 				   DYN_CAST(GA1DBinaryStringGenome&, *c2));
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE){
@@ -530,7 +530,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour() == GAGenome::FIXED_SIZE){
-      if(mom.length() != dad.length() || 
+      if(mom.length() != dad.length() ||
 	 sis.length() != bro.length() ||
 	 sis.length() != mom.length()){
 	GAErr(GA_LOC, mom.className(), "two-point cross", gaErrSameLengthReqd);
@@ -558,7 +558,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
       if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
-      
+
       dadsite[0] = GARandomInt(0, dad.length());
       dadsite[1] = GARandomInt(0, dad.length());
       if(dadsite[0] > dadsite[1]) SWAP(dadsite[0], dadsite[1]);
@@ -579,8 +579,8 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
     n = 2;
   }
   else if(c1 || c2){
-    GA1DBinaryStringGenome &sis = (c1 ? 
-				   DYN_CAST(GA1DBinaryStringGenome&, *c1) : 
+    GA1DBinaryStringGenome &sis = (c1 ?
+				   DYN_CAST(GA1DBinaryStringGenome&, *c1) :
 				   DYN_CAST(GA1DBinaryStringGenome&, *c2));
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE){
@@ -605,7 +605,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
       if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
-      
+
       dadsite[0] = GARandomInt(0, dad.length());
       dadsite[1] = GARandomInt(0, dad.length());
       if(dadsite[0] > dadsite[1]) SWAP(dadsite[0], dadsite[1]);
@@ -639,10 +639,10 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
 //   Even and odd crossovers take alternating bits from the mother and father.
 // For even crossover, we take every even bit from the mother and every odd bit
 // from the father (the first bit is the 0th bit, so it is even).  Odd
-// crossover is just the opposite.  
+// crossover is just the opposite.
 int
 GA1DBinaryStringGenome::
-EvenOddCrossover(const GAGenome& p1, const GAGenome& p2, 
+EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
 		 GAGenome* c1, GAGenome* c2){
   const GA1DBinaryStringGenome &mom=
     DYN_CAST(const GA1DBinaryStringGenome &, p1);
@@ -685,7 +685,7 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
   }
   else if(c1 || c2){
     GA1DBinaryStringGenome &sis = (c1 ?
-				   DYN_CAST(GA1DBinaryStringGenome&, *c1) : 
+				   DYN_CAST(GA1DBinaryStringGenome&, *c1) :
 				   DYN_CAST(GA1DBinaryStringGenome&, *c2));
 
     if(mom.length() == dad.length() && sis.length() == mom.length()){

--- a/Ideal_Static_MPFA/source/ga-mpi/GA2DArrayGenome.C
+++ b/Ideal_Static_MPFA/source/ga-mpi/GA2DArrayGenome.C
@@ -27,13 +27,13 @@ GA2DArrayGenome<T>::className() const {return "GA2DArrayGenome";}
 template <class T> int
 GA2DArrayGenome<T>::classID() const {return GAID::ArrayGenome2D;}
 
-template <class T> 
+template <class T>
 GA2DArrayGenome<T>::
-GA2DArrayGenome(unsigned int width, unsigned int height, 
+GA2DArrayGenome(unsigned int width, unsigned int height,
 		GAGenome::Evaluator f,
 		void * u) :
 GAArray<T>(width*height),
-GAGenome(DEFAULT_2DARRAY_INITIALIZER, 
+GAGenome(DEFAULT_2DARRAY_INITIALIZER,
 	 DEFAULT_2DARRAY_MUTATOR,
 	 DEFAULT_2DARRAY_COMPARATOR)
 {
@@ -44,7 +44,7 @@ GAGenome(DEFAULT_2DARRAY_INITIALIZER,
 }
 
 
-template <class T> 
+template <class T>
 GA2DArrayGenome<T>::
 GA2DArrayGenome(const GA2DArrayGenome<T> & orig) : GAArray<T>(orig.sz){
   GA2DArrayGenome<T>::copy(orig);
@@ -62,10 +62,10 @@ GA2DArrayGenome<T>::copy(const GAGenome & orig){
   if(c) {
     GAGenome::copy(*c);
     GAArray<T>::copy(*c);
-    nx = c->nx; ny = c->ny; 
-    minX = c->minX; minY = c->minY; 
+    nx = c->nx; ny = c->ny;
+    minX = c->minX; minY = c->minY;
     maxX = c->maxX; maxY = c->maxY;
-  } 
+  }
 }
 
 
@@ -77,8 +77,8 @@ GA2DArrayGenome<T>::clone(GAGenome::CloneMethod flag) const {
   }
   else{
     cpy->GAGenome::copy(*this);
-    cpy->minX = minX; cpy->minY = minY; 
-    cpy->maxX = maxX; cpy->maxY = maxY; 
+    cpy->minX = minX; cpy->minY = minY;
+    cpy->maxX = maxX; cpy->maxY = maxY;
   }
   return cpy;
 }
@@ -137,7 +137,7 @@ GA2DArrayGenome<T>::read(STD_ISTREAM &) {
 
 
 template <class T> int
-GA2DArrayGenome<T>::write(STD_OSTREAM & os) const 
+GA2DArrayGenome<T>::write(STD_OSTREAM & os) const
 {
   for(unsigned int j=0; j<ny; j++){
     for(unsigned int i=0; i<nx; i++){
@@ -167,7 +167,7 @@ GA2DArrayGenome<T>::resizeBehaviour(GAGenome::Dimension which) const {
 
 template <class T> int
 GA2DArrayGenome<T>::
-resizeBehaviour(GAGenome::Dimension which, 
+resizeBehaviour(GAGenome::Dimension which,
 		unsigned int lower, unsigned int upper)
 {
   if(upper < lower){
@@ -212,12 +212,12 @@ GA2DArrayGenome<T>::copy(const GA2DArrayGenome<T> & orig,
   for(unsigned int j=0; j<h; j++)
     GAArray<T>::copy(orig, (s+j)*nx+r, (y+j)*orig.nx+x, w);
 
-  _evaluated = gaFalse; 
+  _evaluated = gaFalse;
 }
 
 
 
-template <class T> int 
+template <class T> int
 GA2DArrayGenome<T>::equal(const GAGenome & c) const
 {
   if(this == &c) return 1;
@@ -259,9 +259,9 @@ GA2DArrayAlleleGenome<T>::className() const {return "GA2DArrayAlleleGenome";}
 template <class T> int
 GA2DArrayAlleleGenome<T>::classID() const {return GAID::ArrayAlleleGenome2D;}
 
-template <class T> 
+template <class T>
 GA2DArrayAlleleGenome<T>::
-GA2DArrayAlleleGenome(unsigned int width, unsigned int height, 
+GA2DArrayAlleleGenome(unsigned int width, unsigned int height,
 		      const GAAlleleSet<T> & s,
 		      GAGenome::Evaluator f, void * u) :
 GA2DArrayGenome<T>(width,height,f,u){
@@ -275,9 +275,9 @@ GA2DArrayGenome<T>(width,height,f,u){
   this->crossover(GA2DArrayAlleleGenome<T>::DEFAULT_2DARRAY_ALLELE_CROSSOVER);
 }
 
-template <class T> 
+template <class T>
 GA2DArrayAlleleGenome<T>::
-GA2DArrayAlleleGenome(unsigned int width, unsigned int height, 
+GA2DArrayAlleleGenome(unsigned int width, unsigned int height,
 		      const GAAlleleSetArray<T> & sa,
 		      GAGenome::Evaluator f, void * u) :
 GA2DArrayGenome<T>(width,height, f, u) {
@@ -293,9 +293,9 @@ GA2DArrayGenome<T>(width,height, f, u) {
 }
 
 
-template <class T> 
+template <class T>
 GA2DArrayAlleleGenome<T>::
-GA2DArrayAlleleGenome(const GA2DArrayAlleleGenome<T> & orig) : 
+GA2DArrayAlleleGenome(const GA2DArrayAlleleGenome<T> & orig) :
 GA2DArrayGenome<T>(orig.nx, orig.ny) {
   naset = 0;
   aset = (GAAlleleSet<T>*)0;
@@ -315,10 +315,10 @@ GA2DArrayAlleleGenome<T>::clone(GAGenome::CloneMethod) const {
 }
 
 
-template <class T> void 
+template <class T> void
 GA2DArrayAlleleGenome<T>::copy(const GAGenome& orig){
   if(&orig == this) return;
-  const GA2DArrayAlleleGenome<T>* c = 
+  const GA2DArrayAlleleGenome<T>* c =
     DYN_CAST(const GA2DArrayAlleleGenome<T>*, &orig);
   if(c) {
     GA2DArrayGenome<T>::copy(*c);
@@ -386,24 +386,24 @@ GA2DArrayAlleleGenome<T>::equal(const GAGenome & c) const {
    Operator definitions
 ---------------------------------------------------------------------------- */
 // this does not handle genomes with multiple allele sets!
-template <class ARRAY_TYPE> void 
+template <class ARRAY_TYPE> void
 GA2DArrayAlleleGenome<ARRAY_TYPE>::UniformInitializer(GAGenome & c)
 {
   GA2DArrayAlleleGenome<ARRAY_TYPE> &child=
     DYN_CAST(GA2DArrayAlleleGenome<ARRAY_TYPE> &, c);
-  child.resize(GAGenome::ANY_SIZE,GAGenome::ANY_SIZE); 
+  child.resize(GAGenome::ANY_SIZE,GAGenome::ANY_SIZE);
   for(int i=child.width()-1; i>=0; i--)
     for(int j=child.height()-1; j>=0; j--)
       child.gene(i, j, child.alleleset().allele());
 }
 
 
-template <class ARRAY_TYPE> int 
+template <class ARRAY_TYPE> int
 GA2DArrayAlleleGenome<ARRAY_TYPE>::FlipMutator(GAGenome & c, float pmut)
 {
   GA2DArrayAlleleGenome<ARRAY_TYPE> &child=
     DYN_CAST(GA2DArrayAlleleGenome<ARRAY_TYPE> &, c);
-  register int n, m, i, j;
+  int n, m, i, j;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.size());
@@ -430,11 +430,11 @@ GA2DArrayAlleleGenome<ARRAY_TYPE>::FlipMutator(GAGenome & c, float pmut)
 }
 
 
-template <class ARRAY_TYPE> int 
+template <class ARRAY_TYPE> int
 GA2DArrayGenome<ARRAY_TYPE>::SwapMutator(GAGenome & c, float pmut)
 {
   GA2DArrayGenome<ARRAY_TYPE> &child=DYN_CAST(GA2DArrayGenome<ARRAY_TYPE>&, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.size());
@@ -496,7 +496,7 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
   if(c1 && c2){
     GA2DArrayGenome<T> &sis=DYN_CAST(GA2DArrayGenome<T> &, *c1);
     GA2DArrayGenome<T> &bro=DYN_CAST(GA2DArrayGenome<T> &, *c2);
-    
+
     if(sis.width() == bro.width() && sis.height() == bro.height() &&
        mom.width() == dad.width() && mom.height() == dad.height() &&
        sis.width() == mom.width() && sis.height() == mom.height()){
@@ -567,7 +567,7 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
 
 
 // This crossover does clipping (no padding) for resizables.  Notice that this
-// means that any resizable children of two parents will have identical 
+// means that any resizable children of two parents will have identical
 // dimensions no matter what.
 template <class T> int
 GA2DArrayGenome<T>::
@@ -587,8 +587,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE){
-      if(mom.width() != dad.width() || 
-	 sis.width() != bro.width() || 
+      if(mom.width() != dad.width() ||
+	 sis.width() != bro.width() ||
 	 sis.width() != mom.width()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -612,8 +612,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
-      if(mom.height() != dad.height() || 
-	 sis.height() != bro.height() || 
+      if(mom.height() != dad.height() ||
+	 sis.height() != bro.height() ||
 	 sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -637,12 +637,12 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     sis.resize(sitex+lenx, sitey+leny);
     bro.resize(sitex+lenx, sitey+leny);
-    
+
     sis.copy(mom, 0, 0, momsitex-sitex, momsitey-sitey, sitex, sitey);
     sis.copy(dad, sitex, 0, dadsitex, dadsitey-sitey, lenx, sitey);
     sis.copy(dad, 0, sitey, dadsitex-sitex, dadsitey, sitex, leny);
     sis.copy(mom, sitex, sitey, momsitex, momsitey, lenx, leny);
-    
+
     bro.copy(dad, 0, 0, dadsitex-sitex, dadsitey-sitey, sitex, sitey);
     bro.copy(mom, sitex, 0, momsitex, momsitey-sitey, lenx, sitey);
     bro.copy(mom, 0, sitey, momsitex-sitex, momsitey, sitex, leny);
@@ -652,7 +652,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
   }
   else if(c1){
     GA2DArrayGenome<T> &sis=DYN_CAST(GA2DArrayGenome<T> &, *c1);
-    
+
     if(sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE){
       if(mom.width() != dad.width() || sis.width() != mom.width()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -669,7 +669,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitex = GAMin(momsitex, dadsitex);
       lenx = GAMin(momlenx, dadlenx);
     }
-    
+
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
       if(mom.height() != dad.height() || sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -686,9 +686,9 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitey = GAMin(momsitey, dadsitey);
       leny = GAMin(momleny, dadleny);
     }
-    
+
     sis.resize(sitex+lenx, sitey+leny);
-    
+
     if(GARandomBit()){
       sis.copy(mom, 0, 0, momsitex-sitex, momsitey-sitey, sitex, sitey);
       sis.copy(dad, sitex, 0, dadsitex, dadsitey-sitey, lenx, sitey);
@@ -759,7 +759,7 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
   }
   else if(c1){
     GA2DArrayGenome<T> &sis=DYN_CAST(GA2DArrayGenome<T> &, *c1);
-    
+
     if(mom.width() == dad.width() && mom.height() == dad.height() &&
        sis.width() == mom.width() && sis.height() == mom.height()){
       int count=0;

--- a/Ideal_Static_MPFA/source/ga-mpi/GA2DBinStrGenome.C
+++ b/Ideal_Static_MPFA/source/ga-mpi/GA2DBinStrGenome.C
@@ -21,7 +21,7 @@
    Genome class definition
 ---------------------------------------------------------------------------- */
 GA2DBinaryStringGenome::
-GA2DBinaryStringGenome(unsigned int width, unsigned int height, 
+GA2DBinaryStringGenome(unsigned int width, unsigned int height,
 		       GAGenome::Evaluator f, void * u) :
 GABinaryString(width*height),
 GAGenome(DEFAULT_2DBINSTR_INITIALIZER,
@@ -54,8 +54,8 @@ GA2DBinaryStringGenome::clone(GAGenome::CloneMethod flag) const {
   }
   else{
     cpy->GAGenome::copy(*this);
-    cpy->minX = minX; cpy->minY = minY; 
-    cpy->maxX = maxX; cpy->maxY = maxY; 
+    cpy->minX = minX; cpy->minY = minY;
+    cpy->maxX = maxX; cpy->maxY = maxY;
   }
   return cpy;
 }
@@ -69,10 +69,10 @@ GA2DBinaryStringGenome::copy(const GAGenome & orig)
   if(c) {
     GAGenome::copy(*c);
     GABinaryString::copy(*c);
-    nx = c->nx; ny = c->ny; 
-    minX = c->minX; minY = c->minY; 
+    nx = c->nx; ny = c->ny;
+    minX = c->minX; minY = c->minY;
     maxX = c->maxX; maxY = c->maxY;
-  } 
+  }
 }
 
 
@@ -105,7 +105,7 @@ GA2DBinaryStringGenome::resize(int w, int h)
 
 // Move the bits into the right position.  If we're smaller, then shift to
 // the smaller size before we do the resize (the resize method maintains bit
-// integrety).  If we're larger, do the move after the resize.  If we're the 
+// integrety).  If we're larger, do the move after the resize.  If we're the
 // same size the we don't do anything.  When we're adding more bits, the new
 // bits get set randomly to 0 or 1.
 
@@ -153,7 +153,7 @@ GA2DBinaryStringGenome::read(STD_ISTREAM & is)
 
   _evaluated = gaFalse;
 
-  if(is.eof() && 
+  if(is.eof() &&
      ((j < ny) ||	     // didn't get some lines
       (i < nx && i != 0))){   // stopped early on a row
     GAErr(GA_LOC, className(), "read", gaErrUnexpectedEOF);
@@ -168,7 +168,7 @@ GA2DBinaryStringGenome::read(STD_ISTREAM & is)
 // Dump the digits to the stream with a newline between each row.  No newline
 // at the end of the whole thing.
 int
-GA2DBinaryStringGenome::write(STD_OSTREAM & os) const 
+GA2DBinaryStringGenome::write(STD_OSTREAM & os) const
 {
   for(unsigned int j=0; j<ny; j++){
     for(unsigned int i=0; i<nx; i++)
@@ -180,7 +180,7 @@ GA2DBinaryStringGenome::write(STD_OSTREAM & os) const
 #endif
 
 
-int 
+int
 GA2DBinaryStringGenome::resizeBehaviour(GAGenome::Dimension which) const {
   int val = 0;
   if(which == WIDTH) {
@@ -318,7 +318,7 @@ GA2DBinaryStringGenome::equal(const GA2DBinaryStringGenome& orig,
 }
 
 
-int 
+int
 GA2DBinaryStringGenome::equal(const GAGenome & c) const
 {
   if(this == &c) return 1;
@@ -344,7 +344,7 @@ GA2DBinaryStringGenome::equal(const GAGenome & c) const
   The order for looping through indices is height-then-width (ie height loops
 before a single width increment)
 ---------------------------------------------------------------------------- */
-void 
+void
 GA2DBinaryStringGenome::UniformInitializer(GAGenome & c)
 {
   GA2DBinaryStringGenome &child=DYN_CAST(GA2DBinaryStringGenome &, c);
@@ -355,7 +355,7 @@ GA2DBinaryStringGenome::UniformInitializer(GAGenome & c)
 }
 
 
-void 
+void
 GA2DBinaryStringGenome::UnsetInitializer(GAGenome & c)
 {
   GA2DBinaryStringGenome &child=DYN_CAST(GA2DBinaryStringGenome &, c);
@@ -364,20 +364,20 @@ GA2DBinaryStringGenome::UnsetInitializer(GAGenome & c)
 }
 
 
-void 
+void
 GA2DBinaryStringGenome::SetInitializer(GAGenome & c)
 {
   GA2DBinaryStringGenome &child=DYN_CAST(GA2DBinaryStringGenome &, c);
-  child.resize(GAGenome::ANY_SIZE, GAGenome::ANY_SIZE);	
+  child.resize(GAGenome::ANY_SIZE, GAGenome::ANY_SIZE);
   child.set(0, 0, child.width(), child.height());
 }
 
 
-int 
+int
 GA2DBinaryStringGenome::FlipMutator(GAGenome & c, float pmut)
 {
   GA2DBinaryStringGenome &child=DYN_CAST(GA2DBinaryStringGenome &, c);
-  register int n, m, i, j;
+  int n, m, i, j;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float, child.size());
@@ -431,7 +431,7 @@ GA2DBinaryStringGenome::BitComparator(const GAGenome& a, const GAGenome& b){
 
 int
 GA2DBinaryStringGenome::
-UniformCrossover(const GAGenome& p1, const GAGenome& p2, 
+UniformCrossover(const GAGenome& p1, const GAGenome& p2,
 		 GAGenome* c1, GAGenome* c2){
   const GA2DBinaryStringGenome &mom=
     DYN_CAST(const GA2DBinaryStringGenome &, p1);
@@ -486,8 +486,8 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
     nc = 2;
   }
   else if(c1 || c2){
-    GA2DBinaryStringGenome &sis = (c1 ? 
-				   DYN_CAST(GA2DBinaryStringGenome&, *c1) : 
+    GA2DBinaryStringGenome &sis = (c1 ?
+				   DYN_CAST(GA2DBinaryStringGenome&, *c1) :
 				   DYN_CAST(GA2DBinaryStringGenome&, *c2));
 
     if(mom.width() == dad.width() && mom.height() == dad.height() &&
@@ -515,13 +515,13 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
 
 //   When we do single point crossover on resizable 2D genomes we can either
 // clip or pad to make the mismatching geometries work out.  Either way, both
-// children end up with the same dimensions (the children have the same 
+// children end up with the same dimensions (the children have the same
 // dimensions as each other, not the same as if they were clipped/padded).
 //   When we pad, the extra space is filled with random bits.  This
 // implementation does only clipping, no padding!
 int
 GA2DBinaryStringGenome::
-OnePointCrossover(const GAGenome& p1, const GAGenome& p2, 
+OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 		  GAGenome* c1, GAGenome* c2){
   const GA2DBinaryStringGenome &mom=
     DYN_CAST(const GA2DBinaryStringGenome &, p1);
@@ -539,8 +539,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE){
-      if(mom.width() != dad.width() || 
-	 sis.width() != bro.width() || 
+      if(mom.width() != dad.width() ||
+	 sis.width() != bro.width() ||
 	 sis.width() != mom.width()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -564,8 +564,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
-      if(mom.height() != dad.height() || 
-	 sis.height() != bro.height() || 
+      if(mom.height() != dad.height() ||
+	 sis.height() != bro.height() ||
 	 sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -640,9 +640,9 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitey = GAMin(momsitey, dadsitey);
       leny = GAMin(momleny, dadleny);
     }
-    
+
     sis.resize(sitex+lenx, sitey+leny);
-    
+
     if(GARandomBit()){
       sis.copy(mom, 0, 0, momsitex-sitex, momsitey-sitey, sitex, sitey);
       sis.copy(dad, sitex, 0, dadsitex, dadsitey-sitey, lenx, sitey);
@@ -666,7 +666,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
 int
 GA2DBinaryStringGenome::
-EvenOddCrossover(const GAGenome& p1, const GAGenome& p2, 
+EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
 		 GAGenome* c1, GAGenome* c2){
   const GA2DBinaryStringGenome &mom=
     DYN_CAST(const GA2DBinaryStringGenome &, p1);
@@ -679,7 +679,7 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
   if(c1 && c2){
     GA2DBinaryStringGenome &sis=DYN_CAST(GA2DBinaryStringGenome &, *c1);
     GA2DBinaryStringGenome &bro=DYN_CAST(GA2DBinaryStringGenome &, *c2);
-    
+
     if(sis.width() == bro.width() && sis.height() == bro.height() &&
        mom.width() == dad.width() && mom.height() == dad.height() &&
        sis.width() == mom.width() && sis.height() == mom.height()){
@@ -719,10 +719,10 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
     nc = 2;
   }
   else if(c1 || c2){
-    GA2DBinaryStringGenome &sis = (c1 ? 
+    GA2DBinaryStringGenome &sis = (c1 ?
 				   DYN_CAST(GA2DBinaryStringGenome&, *c1) :
 				   DYN_CAST(GA2DBinaryStringGenome&, *c2));
-    
+
     if(mom.width() == dad.width() && mom.height() == dad.height() &&
        sis.width() == mom.width() && sis.height() == mom.height()){
       int count=0;

--- a/Ideal_Static_MPFA/source/ga-mpi/GA3DArrayGenome.C
+++ b/Ideal_Static_MPFA/source/ga-mpi/GA3DArrayGenome.C
@@ -27,13 +27,13 @@ GA3DArrayGenome<T>::className() const {return "GA3DArrayGenome";}
 template <class T> int
 GA3DArrayGenome<T>::classID() const {return GAID::ArrayGenome3D;}
 
-template <class T> 
+template <class T>
 GA3DArrayGenome<T>::
 GA3DArrayGenome(unsigned int w, unsigned int h, unsigned int d,
 		GAGenome::Evaluator f,
 		void * u) :
 GAArray<T>(w*h*d),
-GAGenome(DEFAULT_3DARRAY_INITIALIZER, 
+GAGenome(DEFAULT_3DARRAY_INITIALIZER,
 	 DEFAULT_3DARRAY_MUTATOR,
 	 DEFAULT_3DARRAY_COMPARATOR)
 {
@@ -44,7 +44,7 @@ GAGenome(DEFAULT_3DARRAY_INITIALIZER,
 }
 
 
-template <class T> 
+template <class T>
 GA3DArrayGenome<T>::
 GA3DArrayGenome(const GA3DArrayGenome<T> & orig) :
 GAArray<T>(orig.sz), GAGenome(){
@@ -78,7 +78,7 @@ GA3DArrayGenome<T>::clone(GAGenome::CloneMethod flag) const {
   }
   else{
     cpy->GAGenome::copy(*this);
-    cpy->minX = minX; cpy->minY = minY; cpy->minZ = minZ; 
+    cpy->minX = minX; cpy->minY = minY; cpy->minZ = minZ;
     cpy->maxX = maxX; cpy->maxY = maxY; cpy->maxZ = maxZ;
   }
   return cpy;
@@ -145,7 +145,7 @@ GA3DArrayGenome<T>::resize(int w, int h, int d)
 
   GAArray<T>::size(w*h*d);
 
-  if(w > STA_CAST(int,nx) && h > STA_CAST(int,ny)){ 
+  if(w > STA_CAST(int,nx) && h > STA_CAST(int,ny)){
     int z=GAMin(STA_CAST(int,nz),d);
     for(int k=z-1; k>=0; k--)
       for(int j=ny-1; j>=0; j--)
@@ -179,7 +179,7 @@ GA3DArrayGenome<T>::read(STD_ISTREAM &) {
 
 
 template <class T> int
-GA3DArrayGenome<T>::write(STD_OSTREAM & os) const 
+GA3DArrayGenome<T>::write(STD_OSTREAM & os) const
 {
   for(unsigned int k=0; k<nz; k++){
     for(unsigned int j=0; j<ny; j++){
@@ -216,7 +216,7 @@ GA3DArrayGenome<T>::resizeBehaviour(GAGenome::Dimension which) const {
 
 template <class T> int
 GA3DArrayGenome<T>::
-resizeBehaviour(GAGenome::Dimension which, 
+resizeBehaviour(GAGenome::Dimension which,
 		unsigned int lower, unsigned int upper)
 {
   if(upper < lower){
@@ -278,7 +278,7 @@ copy(const GA3DArrayGenome<T> & orig,
 }
 
 
-template <class T> int 
+template <class T> int
 GA3DArrayGenome<T>::equal(const GAGenome & c) const
 {
   if(this == &c) return 1;
@@ -312,7 +312,7 @@ GA3DArrayAlleleGenome<T>::className() const {return "GA3DArrayAlleleGenome";}
 template <class T> int
 GA3DArrayAlleleGenome<T>::classID() const {return GAID::ArrayAlleleGenome3D;}
 
-template <class T> 
+template <class T>
 GA3DArrayAlleleGenome<T>::
 GA3DArrayAlleleGenome(unsigned int w, unsigned int h, unsigned int d,
 		      const GAAlleleSet<T> & s,
@@ -328,7 +328,7 @@ GA3DArrayGenome<T>(w,h,d,f,u) {
   this->crossover(GA3DArrayAlleleGenome<T>::DEFAULT_3DARRAY_ALLELE_CROSSOVER);
 }
 
-template <class T> 
+template <class T>
 GA3DArrayAlleleGenome<T>::
 GA3DArrayAlleleGenome(unsigned int w, unsigned int h, unsigned int d,
 		      const GAAlleleSetArray<T> & sa,
@@ -346,9 +346,9 @@ GA3DArrayGenome<T>(w,h,d, f, u) {
 }
 
 
-template <class T> 
+template <class T>
 GA3DArrayAlleleGenome<T>::
-GA3DArrayAlleleGenome(const GA3DArrayAlleleGenome<T> & orig) : 
+GA3DArrayAlleleGenome(const GA3DArrayAlleleGenome<T> & orig) :
 GA3DArrayGenome<T>(orig.nx, orig.ny, orig.nz) {
   naset = 0;
   aset = (GAAlleleSet<T>*)0;
@@ -368,10 +368,10 @@ GA3DArrayAlleleGenome<T>::clone(GAGenome::CloneMethod) const {
 }
 
 
-template <class T> void 
+template <class T> void
 GA3DArrayAlleleGenome<T>::copy(const GAGenome& orig){
   if(&orig == this) return;
-  const GA3DArrayAlleleGenome<T>* c = 
+  const GA3DArrayAlleleGenome<T>* c =
     DYN_CAST(const GA3DArrayAlleleGenome<T>*, &orig);
   if(c) {
     GA3DArrayGenome<T>::copy(*c);
@@ -414,7 +414,7 @@ GA3DArrayAlleleGenome<T>::resize(int w, int h, int d){
     for(int k=z-1; k>=0; k--)
       for(int j=this->ny-1; j>=0; j--)
 	for(unsigned int i=oldx; i<this->nx; i++)
-	  this->a[k*this->ny*this->nx+j*this->nx+i] = 
+	  this->a[k*this->ny*this->nx+j*this->nx+i] =
 	    aset[(k*this->ny*this->nx+j*this->nx+i) % naset].allele();
   }
   else if(this->ny > oldy){
@@ -463,7 +463,7 @@ GA3DArrayAlleleGenome<T>::equal(const GAGenome & c) const {
    Operator definitions
 ---------------------------------------------------------------------------- */
 // this does not handle genomes with multiple allele sets!
-template <class ARRAY_TYPE> void 
+template <class ARRAY_TYPE> void
 GA3DArrayAlleleGenome<ARRAY_TYPE>::UniformInitializer(GAGenome & c)
 {
   GA3DArrayAlleleGenome<ARRAY_TYPE> &child=
@@ -476,12 +476,12 @@ GA3DArrayAlleleGenome<ARRAY_TYPE>::UniformInitializer(GAGenome & c)
 }
 
 
-template <class ARRAY_TYPE> int 
+template <class ARRAY_TYPE> int
 GA3DArrayAlleleGenome<ARRAY_TYPE>::FlipMutator(GAGenome & c, float pmut)
 {
   GA3DArrayAlleleGenome<ARRAY_TYPE> &child=
     DYN_CAST(GA3DArrayAlleleGenome<ARRAY_TYPE> &, c);
-  register int n, m, d, i, j, k;
+  int n, m, d, i, j, k;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.size());
@@ -512,11 +512,11 @@ GA3DArrayAlleleGenome<ARRAY_TYPE>::FlipMutator(GAGenome & c, float pmut)
 }
 
 
-template <class ARRAY_TYPE> int 
+template <class ARRAY_TYPE> int
 GA3DArrayGenome<ARRAY_TYPE>::SwapMutator(GAGenome & c, float pmut)
 {
   GA3DArrayGenome<ARRAY_TYPE> &child=DYN_CAST(GA3DArrayGenome<ARRAY_TYPE>&, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.size());
@@ -568,7 +568,7 @@ ElementComparator(const GAGenome& a, const GAGenome& b)
 
 
 
-// Make sure our bitmask is big enough, generate a mask, then use it to 
+// Make sure our bitmask is big enough, generate a mask, then use it to
 // extract the information from each parent to stuff the two children.
 // We don't deallocate any space for the masks under the assumption that we'll
 // have to use them again in the future.
@@ -680,12 +680,12 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
 //   This is designed only for genomes that are the same length.  If the child
 // is not the same length as the parent, or if the children are not the same
 // size, we don't do the crossover.
-//   In the interest of speed we do not do any checks for size.  Do not use 
+//   In the interest of speed we do not do any checks for size.  Do not use
 // this crossover method when the parents and children may be different sizes.
 // It might break!
 template <class T> int
 GA3DArrayGenome<T>::
-EvenOddCrossover(const GAGenome& p1, const GAGenome& p2, 
+EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
 GAGenome* c1, GAGenome* c2){
   const GA3DArrayGenome<T> &mom=DYN_CAST(const GA3DArrayGenome<T> &, p1);
   const GA3DArrayGenome<T> &dad=DYN_CAST(const GA3DArrayGenome<T> &, p2);
@@ -696,7 +696,7 @@ GAGenome* c1, GAGenome* c2){
   if(c1 && c2){
     GA3DArrayGenome<T> &sis=DYN_CAST(GA3DArrayGenome<T> &, *c1);
     GA3DArrayGenome<T> &bro=DYN_CAST(GA3DArrayGenome<T> &, *c2);
-    
+
     if(sis.width() == bro.width() && sis.height() == bro.height() &&
        sis.depth() == bro.depth() &&
        mom.width() == dad.width() && mom.height() == dad.height() &&
@@ -806,8 +806,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE){
-      if(mom.width() != dad.width() || 
-	 sis.width() != bro.width() || 
+      if(mom.width() != dad.width() ||
+	 sis.width() != bro.width() ||
 	 sis.width() != mom.width()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -828,11 +828,11 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitex = GAMin(momsitex, dadsitex);
       lenx = GAMin(momlenx, dadlenx);
     }
-    
+
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
-      if(mom.height() != dad.height() || 
-	 sis.height() != bro.height() || 
+      if(mom.height() != dad.height() ||
+	 sis.height() != bro.height() ||
 	 sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -856,8 +856,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE){
-      if(mom.depth() != dad.depth() || 
-	 sis.depth() != bro.depth() || 
+      if(mom.depth() != dad.depth() ||
+	 sis.depth() != bro.depth() ||
 	 sis.depth() != mom.depth()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -882,8 +882,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
     sis.resize(sitex+lenx, sitey+leny, sitez+lenz);
     bro.resize(sitex+lenx, sitey+leny, sitez+lenz);
 
-    sis.copy(mom, 
-	     0, 0, 0, 
+    sis.copy(mom,
+	     0, 0, 0,
 	     momsitex-sitex, momsitey-sitey, momsitez-sitez,
 	     sitex, sitey, sitez);
     sis.copy(dad,
@@ -898,8 +898,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	     sitex, sitey, 0,
 	     momsitex, momsitey, momsitez-sitez,
 	     lenx, leny, sitez);
-    sis.copy(dad, 
-	     0, 0, sitez, 
+    sis.copy(dad,
+	     0, 0, sitez,
 	     dadsitex-sitex, dadsitey-sitey, dadsitez,
 	     sitex, sitey, lenz);
     sis.copy(mom,
@@ -914,9 +914,9 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	     sitex, sitey, sitez,
 	     dadsitex, dadsitey, dadsitez,
 	     lenx, leny, lenz);
-    
-    bro.copy(dad, 
-	     0, 0, 0, 
+
+    bro.copy(dad,
+	     0, 0, 0,
 	     dadsitex-sitex, dadsitey-sitey, dadsitez-sitez,
 	     sitex, sitey, sitez);
     bro.copy(mom,
@@ -931,8 +931,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	     sitex, sitey, 0,
 	     dadsitex, dadsitey, dadsitez-sitez,
 	     lenx, leny, sitez);
-    bro.copy(mom, 
-	     0, 0, sitez, 
+    bro.copy(mom,
+	     0, 0, sitez,
 	     momsitex-sitex, momsitey-sitey, momsitez,
 	     sitex, sitey, lenz);
     bro.copy(dad,
@@ -969,7 +969,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitex = GAMin(momsitex, dadsitex);
       lenx = GAMin(momlenx, dadlenx);
     }
-    
+
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
       if(mom.height() != dad.height() || sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -1003,12 +1003,12 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitez = GAMin(momsitez, dadsitez);
       lenz = GAMin(momlenz, dadlenz);
     }
-    
+
     sis.resize(sitex+lenx, sitey+leny, sitez+lenz);
-    
+
     if(GARandomBit()){
-      sis.copy(mom, 
-	       0, 0, 0, 
+      sis.copy(mom,
+	       0, 0, 0,
 	       momsitex-sitex, momsitey-sitey, momsitez-sitez,
 	       sitex, sitey, sitez);
       sis.copy(dad,
@@ -1023,8 +1023,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	       sitex, sitey, 0,
 	       momsitex, momsitey, momsitez-sitez,
 	       lenx, leny, sitez);
-      sis.copy(dad, 
-	       0, 0, sitez, 
+      sis.copy(dad,
+	       0, 0, sitez,
 	       dadsitex-sitex, dadsitey-sitey, dadsitez,
 	       sitex, sitey, lenz);
       sis.copy(mom,
@@ -1041,8 +1041,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	       lenx, leny, lenz);
     }
     else{
-      sis.copy(dad, 
-	       0, 0, 0, 
+      sis.copy(dad,
+	       0, 0, 0,
 	       dadsitex-sitex, dadsitey-sitey, dadsitez-sitez,
 	       sitex, sitey, sitez);
       sis.copy(mom,
@@ -1057,8 +1057,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	       sitex, sitey, 0,
 	       dadsitex, dadsitey, dadsitez-sitez,
 	       lenx, leny, sitez);
-      sis.copy(mom, 
-	       0, 0, sitez, 
+      sis.copy(mom,
+	       0, 0, sitez,
 	       momsitex-sitex, momsitey-sitey, momsitez,
 	       sitex, sitey, lenz);
       sis.copy(dad,

--- a/Ideal_Static_MPFA/source/ga-mpi/GA3DBinStrGenome.C
+++ b/Ideal_Static_MPFA/source/ga-mpi/GA3DBinStrGenome.C
@@ -56,7 +56,7 @@ GA3DBinaryStringGenome::clone(GAGenome::CloneMethod flag) const {
   }
   else{
     cpy->GAGenome::copy(*this);
-    cpy->minX = minX; cpy->minY = minY; cpy->minZ = minZ; 
+    cpy->minX = minX; cpy->minY = minY; cpy->minZ = minZ;
     cpy->maxX = maxX; cpy->maxY = maxY; cpy->maxZ = maxZ;
   }
   return cpy;
@@ -66,7 +66,7 @@ void
 GA3DBinaryStringGenome::copy(const GAGenome & orig)
 {
   if(&orig == this) return;
-  const GA3DBinaryStringGenome* c = 
+  const GA3DBinaryStringGenome* c =
     DYN_CAST(const GA3DBinaryStringGenome*, &orig);
   if(c) {
     GAGenome::copy(*c);
@@ -206,7 +206,7 @@ GA3DBinaryStringGenome::read(STD_ISTREAM & is)
 
   _evaluated = gaFalse;
 
-  if(is.eof() && 
+  if(is.eof() &&
      ((k < nz) ||		// didn't get some lines
       (j < ny && j != 0) ||	// didn't get some lines
       (i < nx && i != 0))){	// didn't get some lines
@@ -219,10 +219,10 @@ GA3DBinaryStringGenome::read(STD_ISTREAM & is)
 }
 
 
-// Dump the bits to the stream with a newline at the end of each row and 
+// Dump the bits to the stream with a newline at the end of each row and
 // another at the end of each layer.  No newline at the end of the block.
 int
-GA3DBinaryStringGenome::write(STD_OSTREAM & os) const 
+GA3DBinaryStringGenome::write(STD_OSTREAM & os) const
 {
   for(unsigned int k=0; k<nz; k++){
     for(unsigned int j=0; j<ny; j++){
@@ -424,13 +424,13 @@ equal(const GA3DBinaryStringGenome& orig,
     for(unsigned int j=0; j<h; j++)
       eq += GABinaryString::equal(orig,
 				  (z+k)*ny*nx + (y+j)*nx + x,
-				  (srcz+k)*ny*nx + (srcy+j)*nx + srcx, 
+				  (srcz+k)*ny*nx + (srcy+j)*nx + srcx,
 				  w);
   return eq==d*h ? 1 : 0;
 }
 
 
-int 
+int
 GA3DBinaryStringGenome::equal(const GAGenome & c) const
 {
   if(this == &c) return 1;
@@ -459,7 +459,7 @@ GA3DBinaryStringGenome::equal(const GAGenome & c) const
 (ie depth loops before a single height increment, height loops before a single
 width increment)
 ---------------------------------------------------------------------------- */
-void 
+void
 GA3DBinaryStringGenome::UniformInitializer(GAGenome & c)
 {
   GA3DBinaryStringGenome &child=DYN_CAST(GA3DBinaryStringGenome &, c);
@@ -471,7 +471,7 @@ GA3DBinaryStringGenome::UniformInitializer(GAGenome & c)
 }
 
 
-void 
+void
 GA3DBinaryStringGenome::UnsetInitializer(GAGenome & c)
 {
   GA3DBinaryStringGenome &child=DYN_CAST(GA3DBinaryStringGenome &, c);
@@ -480,7 +480,7 @@ GA3DBinaryStringGenome::UnsetInitializer(GAGenome & c)
 }
 
 
-void 
+void
 GA3DBinaryStringGenome::SetInitializer(GAGenome & c)
 {
   GA3DBinaryStringGenome &child=DYN_CAST(GA3DBinaryStringGenome &, c);
@@ -489,11 +489,11 @@ GA3DBinaryStringGenome::SetInitializer(GAGenome & c)
 }
 
 
-int 
+int
 GA3DBinaryStringGenome::FlipMutator(GAGenome & c, float pmut)
 {
   GA3DBinaryStringGenome &child=DYN_CAST(GA3DBinaryStringGenome &, c);
-  register int n, m, i, j, k, d;
+  int n, m, i, j, k, d;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.size());
@@ -550,7 +550,7 @@ GA3DBinaryStringGenome::BitComparator(const GAGenome& a, const GAGenome& b){
 
 
 
-// Make sure our bitmask is big enough, generate a mask, then use it to 
+// Make sure our bitmask is big enough, generate a mask, then use it to
 // extract the information from each parent to stuff the two children.
 // We don't deallocate any space for the masks under the assumption that we'll
 // have to use them again in the future.
@@ -626,10 +626,10 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
     nc = 2;
   }
   else if(c1 || c2){
-    GA3DBinaryStringGenome &sis = (c1 ? 
-				   DYN_CAST(GA3DBinaryStringGenome&, *c1) : 
+    GA3DBinaryStringGenome &sis = (c1 ?
+				   DYN_CAST(GA3DBinaryStringGenome&, *c1) :
 				   DYN_CAST(GA3DBinaryStringGenome&, *c2));
-    
+
     if(mom.width() == dad.width() && mom.height() == dad.height() &&
        mom.depth() == dad.depth() &&
        sis.width() == mom.width() && sis.height() == mom.height() &&
@@ -665,7 +665,7 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
 //   This is designed only for genomes that are the same length.  If the child
 // is not the same length as the parent, or if the children are not the same
 // size, we don't do the crossover.
-//   In the interest of speed we do not do any checks for size.  Do not use 
+//   In the interest of speed we do not do any checks for size.  Do not use
 // this crossover method when the parents and children may be different sizes.
 // It might break!
 int
@@ -733,7 +733,7 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
   }
   else if(c1 || c2){
     GA3DBinaryStringGenome &sis = (c1 ?
-				   DYN_CAST(GA3DBinaryStringGenome &, *c1) : 
+				   DYN_CAST(GA3DBinaryStringGenome &, *c1) :
 				   DYN_CAST(GA3DBinaryStringGenome &, *c2));
 
     if(mom.width() == dad.width() && mom.height() == dad.height() &&
@@ -772,7 +772,7 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
 
 
 // Pick a single point in the 3D block and grab alternating quadrants for each
-// child.  If the children are resizable, this crossover does clipping or 
+// child.  If the children are resizable, this crossover does clipping or
 // padding depending on the setting of the clip flag.  If we pad, we fill the
 // additional bits with random contents.
 int
@@ -795,8 +795,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE){
-      if(mom.width() != dad.width() || 
-	 sis.width() != bro.width() || 
+      if(mom.width() != dad.width() ||
+	 sis.width() != bro.width() ||
 	 sis.width() != mom.width()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -817,11 +817,11 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitex = GAMin(momsitex, dadsitex);
       lenx = GAMin(momlenx, dadlenx);
     }
-    
+
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
-      if(mom.height() != dad.height() || 
-	 sis.height() != bro.height() || 
+      if(mom.height() != dad.height() ||
+	 sis.height() != bro.height() ||
 	 sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -842,11 +842,11 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitey = GAMin(momsitey, dadsitey);
       leny = GAMin(momleny, dadleny);
     }
-    
+
     if(sis.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE){
-      if(mom.depth() != dad.depth() || 
-	 sis.depth() != bro.depth() || 
+      if(mom.depth() != dad.depth() ||
+	 sis.depth() != bro.depth() ||
 	 sis.depth() != mom.depth()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -871,8 +871,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
     sis.resize(sitex+lenx, sitey+leny, sitez+lenz);
     bro.resize(sitex+lenx, sitey+leny, sitez+lenz);
 
-    sis.copy(mom, 
-	     0, 0, 0, 
+    sis.copy(mom,
+	     0, 0, 0,
 	     momsitex-sitex, momsitey-sitey, momsitez-sitez,
 	     sitex, sitey, sitez);
     sis.copy(dad,
@@ -887,8 +887,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	     sitex, sitey, 0,
 	     momsitex, momsitey, momsitez-sitez,
 	     lenx, leny, sitez);
-    sis.copy(dad, 
-	     0, 0, sitez, 
+    sis.copy(dad,
+	     0, 0, sitez,
 	     dadsitex-sitex, dadsitey-sitey, dadsitez,
 	     sitex, sitey, lenz);
     sis.copy(mom,
@@ -903,9 +903,9 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	     sitex, sitey, sitez,
 	     dadsitex, dadsitey, dadsitez,
 	     lenx, leny, lenz);
-    
-    bro.copy(dad, 
-	     0, 0, 0, 
+
+    bro.copy(dad,
+	     0, 0, 0,
 	     dadsitex-sitex, dadsitey-sitey, dadsitez-sitez,
 	     sitex, sitey, sitez);
     bro.copy(mom,
@@ -920,8 +920,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	     sitex, sitey, 0,
 	     dadsitex, dadsitey, dadsitez-sitez,
 	     lenx, leny, sitez);
-    bro.copy(mom, 
-	     0, 0, sitez, 
+    bro.copy(mom,
+	     0, 0, sitez,
 	     momsitex-sitex, momsitey-sitey, momsitez,
 	     sitex, sitey, lenz);
     bro.copy(dad,
@@ -936,7 +936,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	     sitex, sitey, sitez,
 	     momsitex, momsitey, momsitez,
 	     lenx, leny, lenz);
-    
+
     nc = 2;
   }
   else if(c1 || c2){
@@ -960,7 +960,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitex = GAMin(momsitex, dadsitex);
       lenx = GAMin(momlenx, dadlenx);
     }
-    
+
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
       if(mom.height() != dad.height() || sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -977,7 +977,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitey = GAMin(momsitey, dadsitey);
       leny = GAMin(momleny, dadleny);
     }
-    
+
     if(sis.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE){
       if(mom.depth() != dad.depth() || sis.depth() != mom.depth()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -998,8 +998,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
     sis.resize(sitex+lenx, sitey+leny, sitez+lenz);
 
     if(GARandomBit()){
-      sis.copy(mom, 
-	       0, 0, 0, 
+      sis.copy(mom,
+	       0, 0, 0,
 	       momsitex-sitex, momsitey-sitey, momsitez-sitez,
 	       sitex, sitey, sitez);
       sis.copy(dad,
@@ -1014,8 +1014,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	       sitex, sitey, 0,
 	       momsitex, momsitey, momsitez-sitez,
 	       lenx, leny, sitez);
-      sis.copy(dad, 
-	       0, 0, sitez, 
+      sis.copy(dad,
+	       0, 0, sitez,
 	       dadsitex-sitex, dadsitey-sitey, dadsitez,
 	       sitex, sitey, lenz);
       sis.copy(mom,
@@ -1032,8 +1032,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	       lenx, leny, lenz);
     }
     else{
-      sis.copy(dad, 
-	       0, 0, 0, 
+      sis.copy(dad,
+	       0, 0, 0,
 	       dadsitex-sitex, dadsitey-sitey, dadsitez-sitez,
 	       sitex, sitey, sitez);
       sis.copy(mom,
@@ -1048,8 +1048,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	       sitex, sitey, 0,
 	       dadsitex, dadsitey, dadsitez-sitez,
 	       lenx, leny, sitez);
-      sis.copy(mom, 
-	       0, 0, sitez, 
+      sis.copy(mom,
+	       0, 0, sitez,
 	       momsitex-sitex, momsitey-sitey, momsitez,
 	       sitex, sitey, lenz);
       sis.copy(dad,

--- a/Ideal_Static_MPFA/source/ga-mpi/GAListGenome.C
+++ b/Ideal_Static_MPFA/source/ga-mpi/GAListGenome.C
@@ -17,7 +17,7 @@
 #include <ga-mpi/GAMask.h>
 #include <ga-mpi/garandom.h>
 
-template <class T> int 
+template <class T> int
 GAListIsHole(const GAListGenome<T>&, const GAListGenome<T>&, int, int, int);
 
 
@@ -30,8 +30,8 @@ GAListGenome<T>::className() const {return "GAListGenome";}
 template <class T> int
 GAListGenome<T>::classID() const {return GAID::ListGenome;}
 
-template <class T> 
-GAListGenome<T>::GAListGenome(GAGenome::Evaluator f, void * u) : 
+template <class T>
+GAListGenome<T>::GAListGenome(GAGenome::Evaluator f, void * u) :
 GAList<T>(),
 GAGenome(DEFAULT_LIST_INITIALIZER,
 	 DEFAULT_LIST_MUTATOR,
@@ -42,8 +42,8 @@ GAGenome(DEFAULT_LIST_INITIALIZER,
 }
 
 
-template <class T> 
-GAListGenome<T>::GAListGenome(const GAListGenome<T> & orig) : 
+template <class T>
+GAListGenome<T>::GAListGenome(const GAListGenome<T> & orig) :
 GAList<T>(),
 GAGenome() {
   GAListGenome<T>::copy(orig);
@@ -76,10 +76,10 @@ GAListGenome<T>::copy(const GAGenome & orig){
 
 #ifdef GALIB_USE_STREAMS
 // Traverse the list (breadth-first) and dump the contents as best we can to
-// the stream.  We don't try to write the contents of the nodes - we simply 
+// the stream.  We don't try to write the contents of the nodes - we simply
 // write a . for each node in the list.
 template <class T> int
-GAListGenome<T>::write(STD_OSTREAM & os) const 
+GAListGenome<T>::write(STD_OSTREAM & os) const
 {
   os << "node       next       prev       contents\n";
   if(!this->hd) return 0;;
@@ -105,7 +105,7 @@ GAListGenome<T>::write(STD_OSTREAM & os) const
 // then you have nothing to worry about.
 //   Neither of these operators affects the internal iterator of either
 // list genome in any way.
-template <class T> int 
+template <class T> int
 GAListGenome<T>::equal(const GAGenome & c) const
 {
   if(this == &c) return 1;
@@ -136,14 +136,14 @@ GAListGenome<T>::equal(const GAGenome & c) const
 ---------------------------------------------------------------------------- */
 // Mutate a list by nuking nodes.  Any node has a pmut chance of getting nuked.
 // This is actually kind of bogus for the second part of the if clause (if nMut
-// is greater than or equal to 1).  Nodes end up having more than pmut 
+// is greater than or equal to 1).  Nodes end up having more than pmut
 // probability of getting nuked.
 //   After the mutation the iterator is left at the head of the list.
 template <class T> int
 GAListGenome<T>::DestructiveMutator(GAGenome & c, float pmut)
 {
   GAListGenome<T> &child=DYN_CAST(GAListGenome<T> &, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return 0;
 
   n = child.size();
@@ -171,14 +171,14 @@ GAListGenome<T>::DestructiveMutator(GAGenome & c, float pmut)
 
 // Mutate a list by swapping two nodes.  Any node has a pmut chance of getting
 // swapped, and the swap could happen to any other node.  And in the case of
-// nMut < 1, the swap may generate a swap partner that is the same node, in 
+// nMut < 1, the swap may generate a swap partner that is the same node, in
 // which case no swap occurs (we don't check).
 //   After the mutation the iterator is left at the head of the list.
 template <class T> int
 GAListGenome<T>::SwapMutator(GAGenome & c, float pmut)
 {
   GAListGenome<T> &child=DYN_CAST(GAListGenome<T> &, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return 0;
 
   n = child.size();
@@ -205,7 +205,7 @@ GAListGenome<T>::SwapMutator(GAGenome & c, float pmut)
 
 // This comparator returns the number of elements that the two lists have
 // in common (both in position and in value).  If they are different lengths
-// then we just say they are completely different.  This is probably barely 
+// then we just say they are completely different.  This is probably barely
 // adequate for most applications - we really should give more credit for
 // nodes that are the same but in different positions.  But that would be
 // pretty nasty to compute.
@@ -213,7 +213,7 @@ GAListGenome<T>::SwapMutator(GAGenome & c, float pmut)
 // which to compare this diversity measure.  Its kind of hard to define this
 // one in a general way...
 template <class T> float
-GAListGenome<T>::NodeComparator(const GAGenome& a, const GAGenome& b) 
+GAListGenome<T>::NodeComparator(const GAGenome& a, const GAGenome& b)
 {
   if(&a == &b) return 0;
   const GAListGenome<T>& sis=DYN_CAST(const GAListGenome<T>&, a);
@@ -244,7 +244,7 @@ GAListGenome<T>::NodeComparator(const GAGenome& a, const GAGenome& b)
 
 #define SWAP(a,b) {unsigned int tmp=a; a=b; b=tmp;}
 
-// This crossover picks a site between nodes in each parent.  It is the same 
+// This crossover picks a site between nodes in each parent.  It is the same
 // as single point crossover on a resizeable binary string genome.  The site
 // in the mother is not necessarily the same as the site in the father!
 //   When we pick a crossover site, it is between nodes of the list (otherwise
@@ -253,7 +253,7 @@ GAListGenome<T>::NodeComparator(const GAGenome& a, const GAGenome& b)
 // whereas the cross site possibilities are numbered from 0 to size, inclusive.
 // This means we have to map the site to the list to determine whether an
 // insertion should occur before or after a node.
-//   We first copy the mother into the child (this deletes whatever contents 
+//   We first copy the mother into the child (this deletes whatever contents
 // were in the child originally).  Then we clone the father from the cross site
 // to the end of the list.  Then we delete the tail of the child from the
 // mother's cross site to the end of the list.  Finally, we insert the clone
@@ -265,7 +265,7 @@ GAListGenome<T>::NodeComparator(const GAGenome& a, const GAGenome& b)
 // do better by copying only what we need of the mother.
 template <class T> int
 GAListGenome<T>::
-OnePointCrossover(const GAGenome& p1, const GAGenome& p2, 
+OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 		  GAGenome* c1, GAGenome* c2){
   const GAListGenome<T> &mom=DYN_CAST(const GAListGenome<T> &, p1);
   const GAListGenome<T> &dad=DYN_CAST(const GAListGenome<T> &, p2);
@@ -330,13 +330,13 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 //   This version of the partial match crossover uses objects that are multiply
 // instantiated - each list genome contains its own objects in its nodes.
 // The operator== method must be defined on the object for this implementation
-// to work!  In this case, the 'object' is an int, so we're OK.  If you are 
+// to work!  In this case, the 'object' is an int, so we're OK.  If you are
 // putting your own objects in the nodes, be sure you have operator== defined
 // for your object.  You must also have operator!= defined for your object.  We
 // do not do any assignments, so operator= and/or copy is not required.
 //   We assume that none of the nodes will return a NULL pointer.  Also assume
 // that the cross site has been selected properly.
-//   First we make a copy of the mother.  Then we loop through the match 
+//   First we make a copy of the mother.  Then we loop through the match
 // section and try to swap each element in the child's match section with its
 // partner (as defined by the current node in the father's match section).
 //   Mirroring will work the same way - just swap mom & dad and you're all set.

--- a/Ideal_Static_MPFA/source/ga-mpi/GARealGenome.C
+++ b/Ideal_Static_MPFA/source/ga-mpi/GARealGenome.C
@@ -13,7 +13,7 @@
 
 // We must also specialize the allele set so that the alleles are handled
 // properly.  Be sure to handle bounds correctly whether we are discretized
-// or continuous.  Handle the case where someone sets stupid bounds that 
+// or continuous.  Handle the case where someone sets stupid bounds that
 // might cause an infinite loop for exclusive bounds.
 template <> float
 GAAlleleSet<float>::allele() const {
@@ -29,8 +29,8 @@ GAAlleleSet<float>::allele() const {
     if(core->lowerb == GAAllele::EXCLUSIVE) value += core->a[2];
   }
   else{
-    if(core->a[0] == core->a[1] && 
-       core->lowerb == GAAllele::EXCLUSIVE && 
+    if(core->a[0] == core->a[1] &&
+       core->lowerb == GAAllele::EXCLUSIVE &&
        core->upperb == GAAllele::EXCLUSIVE) {
       value = core->a[0];
     }
@@ -74,9 +74,9 @@ GAAlleleSet<float>::allele(unsigned int i) const {
 
 // now the specialization of the genome itself.
 
-template <> const char * 
+template <> const char *
 GA1DArrayAlleleGenome<float>::className() const {return "GARealGenome";}
-template <> int 
+template <> int
 GA1DArrayAlleleGenome<float>::classID() const {return GAID::FloatGenome;}
 
 template <> GA1DArrayAlleleGenome<float>::
@@ -108,7 +108,7 @@ GA1DArrayGenome<float>(sa.size(), f, u){
   crossover(DEFAULT_REAL_CROSSOVER);
 }
 
-template <> 
+template <>
 GA1DArrayAlleleGenome<float>::~GA1DArrayAlleleGenome(){
   delete [] aset;
 }
@@ -148,12 +148,12 @@ GA1DArrayAlleleGenome<float>::read(STD_ISTREAM & is) {
 ---------------------------------------------------------------------------- */
 // The Gaussian mutator picks a new value based on a Gaussian distribution
 // around the current value.  We respect the bounds (if any).
-//*** need to figure out a way to make the stdev other than 1.0 
-int 
+//*** need to figure out a way to make the stdev other than 1.0
+int
 GARealGaussianMutator(GAGenome& g, float pmut){
   GA1DArrayAlleleGenome<float> &child=
     DYN_CAST(GA1DArrayAlleleGenome<float> &, g);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * (float)(child.length());
@@ -200,7 +200,7 @@ GARealGaussianMutator(GAGenome& g, float pmut){
 // identical.  If parents are not the same length, the extra elements are not
 // set!  You might want to add some noise to this so that both children are not
 // the same...
-int 
+int
 GARealArithmeticCrossover(const GAGenome& p1, const GAGenome& p2,
 			  GAGenome* c1, GAGenome* c2) {
   const GA1DArrayGenome<float> &mom=
@@ -222,8 +222,8 @@ GARealArithmeticCrossover(const GAGenome& p1, const GAGenome& p2,
     n = 2;
   }
   else if(c1 || c2){
-    GA1DArrayGenome<float> &sis = (c1 ? 
-				   DYN_CAST(GA1DArrayGenome<float> &, *c1) : 
+    GA1DArrayGenome<float> &sis = (c1 ?
+				   DYN_CAST(GA1DArrayGenome<float> &, *c1) :
 				   DYN_CAST(GA1DArrayGenome<float> &, *c2));
 
     int len = GAMax(mom.length(), dad.length());
@@ -240,7 +240,7 @@ GARealArithmeticCrossover(const GAGenome& p1, const GAGenome& p2,
 // Blend crossover generates a new value based on the interval between parents.
 // We generate a uniform distribution based on the distance between parent
 // values, then choose the child value based upon that distribution.
-int 
+int
 GARealBlendCrossover(const GAGenome& p1, const GAGenome& p2,
 		     GAGenome* c1, GAGenome* c2) {
   const GA1DArrayGenome<float> &mom=
@@ -257,9 +257,9 @@ GARealBlendCrossover(const GAGenome& p1, const GAGenome& p2,
     int len = GAMax(mom.length(), dad.length());
     for(int i=0; i<len; i++) {
       float dist = 0;
-      if(mom.gene(i) > dad.gene(i)) 
+      if(mom.gene(i) > dad.gene(i))
 	dist = mom.gene(i) - dad.gene(i);
-      else 
+      else
 	dist = dad.gene(i) - mom.gene(i);
       float lo = (GAMin(mom.gene(i), dad.gene(i))) - 0.5*dist;
       float hi = (GAMax(mom.gene(i), dad.gene(i))) + 0.5*dist;
@@ -276,9 +276,9 @@ GARealBlendCrossover(const GAGenome& p1, const GAGenome& p2,
     int len = GAMax(mom.length(), dad.length());
     for(int i=0; i<len; i++) {
       float dist = 0;
-      if(mom.gene(i) > dad.gene(i)) 
+      if(mom.gene(i) > dad.gene(i))
 	dist = mom.gene(i) - dad.gene(i);
-      else 
+      else
 	dist = dad.gene(i) - mom.gene(i);
       float lo = (GAMin(mom.gene(i), dad.gene(i))) - 0.5*dist;
       float hi = (GAMax(mom.gene(i), dad.gene(i))) + 0.5*dist;
@@ -298,7 +298,7 @@ GARealBlendCrossover(const GAGenome& p1, const GAGenome& p2,
 //
 // These must be included _after_ the specializations because some compilers
 // get all wigged out about the declaration/specialization order.  Note that
-// some compilers require a syntax different than others when forcing the 
+// some compilers require a syntax different than others when forcing the
 // instantiation (i.e. GNU wants the 'template class', borland does not).
 #ifndef GALIB_USE_AUTO_INST
 #include <ga-mpi/GAAllele.C>

--- a/Ideal_Static_MPFA/source/ga-mpi/GATreeGenome.C
+++ b/Ideal_Static_MPFA/source/ga-mpi/GATreeGenome.C
@@ -25,7 +25,7 @@ template <class T> int
 GATreeGenome<T>::classID() const {return GAID::TreeGenome;}
 
 template <class T>
-GATreeGenome<T>::GATreeGenome(GAGenome::Evaluator f, void * u) : 
+GATreeGenome<T>::GATreeGenome(GAGenome::Evaluator f, void * u) :
 GATree<T>(),
 GAGenome(DEFAULT_TREE_INITIALIZER,
 	 DEFAULT_TREE_MUTATOR,
@@ -37,7 +37,7 @@ GAGenome(DEFAULT_TREE_INITIALIZER,
 
 
 template <class T>
-GATreeGenome<T>::GATreeGenome(const GATreeGenome<T> & orig) : 
+GATreeGenome<T>::GATreeGenome(const GATreeGenome<T> & orig) :
 GATree<T>(),
 GAGenome() {
   GATreeGenome<T>::copy(orig);
@@ -70,7 +70,7 @@ GATreeGenome<T>::copy(const GAGenome & orig) {
 
 #ifdef GALIB_USE_STREAMS
 // Traverse the tree (breadth-first) and dump the contents as best we can to
-// the stream.  We don't try to write the contents of the nodes - we simply 
+// the stream.  We don't try to write the contents of the nodes - we simply
 // write a . for each node in the tree.
 //   We allocate space for x,y coord pair for each node in the tree.  Then we
 // do a depth-first traversal of the tree and assign coords to the nodes in the
@@ -102,7 +102,7 @@ _tt(STD_OSTREAM & os, GANode<T> * n)
 }
 
 template <class T> int
-GATreeGenome<T>::write(STD_OSTREAM & os) const 
+GATreeGenome<T>::write(STD_OSTREAM & os) const
 {
   os << "node       parent     child      next       prev       contents\n";
   _tt(os, (GANode<T> *)(this->rt));
@@ -111,7 +111,7 @@ GATreeGenome<T>::write(STD_OSTREAM & os) const
 #endif
 
 
-template <class T> int  
+template <class T> int
 GATreeGenome<T>::equal(const GAGenome & c) const
 {
   if(this == &c) return 1;
@@ -140,7 +140,7 @@ template <class T> int
 GATreeGenome<T>::DestructiveMutator(GAGenome & c, float pmut)
 {
   GATreeGenome<T> &child=DYN_CAST(GATreeGenome<T> &, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return 0;
 
   n = child.size();
@@ -169,14 +169,14 @@ GATreeGenome<T>::DestructiveMutator(GAGenome & c, float pmut)
 // This is a rearranging mutation operator.  It randomly picks two nodes in the
 // tree and swaps them.  Any node has a pmut chance of getting
 // swapped, and the swap could happen to any other node.  And in the case of
-// nMut < 1, the swap may generate a swap partner that is the same node, in 
+// nMut < 1, the swap may generate a swap partner that is the same node, in
 // which case no swap occurs (we don't check).
 //   After the mutation the iterator is left at the root of the tree.
 template <class T> int
 GATreeGenome<T>::SwapNodeMutator(GAGenome & c, float pmut)
 {
   GATreeGenome<T> &child=DYN_CAST(GATreeGenome<T> &, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return 0;
 
   n = child.size();
@@ -214,7 +214,7 @@ template <class T> int
 GATreeGenome<T>::SwapSubtreeMutator(GAGenome & c, float pmut)
 {
   GATreeGenome<T> &child=DYN_CAST(GATreeGenome<T> &, c);
-  register int n, i;
+  int n, i;
   int a, b;
   if(pmut <= 0.0) return 0;
 
@@ -247,7 +247,7 @@ GATreeGenome<T>::SwapSubtreeMutator(GAGenome & c, float pmut)
 // We use the recursive tree function to compare the tree structures.  This
 // does not compare the contents of the nodes.
 template <class T> float
-GATreeGenome<T>::TopologyComparator(const GAGenome& a, const GAGenome& b) 
+GATreeGenome<T>::TopologyComparator(const GAGenome& a, const GAGenome& b)
 {
   if(&a == &b) return 0;
   const GATreeGenome<T>& sis=DYN_CAST(const GATreeGenome<T>&, a);
@@ -277,7 +277,7 @@ GATreeGenome<T>::TopologyComparator(const GAGenome& a, const GAGenome& b)
 //     do the check to see if the crossover site is valid.
 template <class T> int
 GATreeGenome<T>::
-OnePointCrossover(const GAGenome& p1, const GAGenome& p2, 
+OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 		  GAGenome* c1, GAGenome* c2){
   const GATreeGenome<T> &mom=DYN_CAST(const GATreeGenome<T> &, p1);
   const GATreeGenome<T> &dad=DYN_CAST(const GATreeGenome<T> &, p2);

--- a/Ideal_Transportation_MPFA/source/evolver.cpp
+++ b/Ideal_Transportation_MPFA/source/evolver.cpp
@@ -11,7 +11,7 @@
 // For shared memory management
 #include <sys/mman.h>
 
-#include <ctime> // For clock()
+#include <ctime>  // For clock()
 #include <chrono> // For clock()
 #include <mpi.h>
 
@@ -31,12 +31,12 @@
 #include <source/MPFA/MPFA_loop_functions.h>
 
 // For timing
-#include <ctime> // For clock()
+#include <ctime>  // For clock()
 #include <chrono> // For clock()
 
 // For shared variable between child and parent process
-#include  <sys/ipc.h>
-#include  <sys/shm.h>
+#include <sys/ipc.h>
+#include <sys/shm.h>
 
 float objective(GAGenome &);
 float LaunchARGoS(GAGenome &);
@@ -44,11 +44,11 @@ float LaunchARGoS(GAGenome &);
 int mpi_tasks, mpi_rank;
 
 int elitism = 0;
-int n_trials = 20; // used by the objective function
+int n_trials = 20;            // used by the objective function
 double mutation_stdev = 1.00; // Gaussian mutation stdev - will be scaled by possible range
 string experiment_path;
 
-void CPFAInitializer(GAGenome & c);
+void CPFAInitializer(GAGenome &c);
 int GARealGaussianMutatorStdev(GAGenome &, float);
 
 std::default_random_engine generator;
@@ -62,125 +62,124 @@ int main(int argc, char **argv)
   MPI_Init(&argc, &argv);
   MPI_Comm_size(MPI_COMM_WORLD, &mpi_tasks);
   MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
-                         
-  char hostname[1024];                                                                                                       
-  hostname[1023] = '\0';                                          
+
+  char hostname[1024];
+  hostname[1023] = '\0';
   gethostname(hostname, 1023);
-  
+
   double mutation_rate = 0.01;
   double crossover_rate = 0.01;
   int population_size = 10;
   int n_generations = 10;
 
-    char c='h';
+  char c = 'h';
   // Handle command line arguments
-  while ((c = getopt (argc, argv, "t:g:p:c:m:s:h:e:x:")) != -1)
+  while ((c = getopt(argc, argv, "t:g:p:c:m:s:h:e:x:")) != -1)
     switch (c)
-      {
-      case 'x':
-	experiment_path = optarg;
+    {
+    case 'x':
+      experiment_path = optarg;
       break;
-      case 't':
-	n_trials = atoi(optarg);
-	break;
-      case 'g':
-        n_generations = atoi(optarg);
-        break;
-      case 'p':
-        population_size = atoi(optarg);
-        break;
-      case 'm':
-        mutation_rate = strtod(optarg, NULL);
-	break;
-      case 'c':
-	crossover_rate = strtod(optarg, NULL);
-	break;
-      case 's':
-        mutation_stdev = strtod(optarg, NULL);
-	break;
-      case 'e':
-        elitism = atoi(optarg);
-	break;
-      case 'h':
-	printf("Usage: %s -p {population size} -g {number of generations} -t {number of trials} -c {crossover rate} -m {mutation rate} -s {mutation standard deviation} -e {elitism 0 or 1}", argv[0]);
-	break;
-      case '?':
-        if (optopt == 'p')
-          fprintf (stderr, "Option -%c requires an argument specifying the population size.\n", optopt);
-	else if (optopt == 'g')
-	  fprintf (stderr, "Option -%c requires an argument specifying the number of generations.\n", optopt);
-	else if (optopt == 't')
-	  fprintf (stderr, "Option -%c requires an argument specifying the number of trials.\n", optopt);
-	else if (optopt == 'c')
-	  fprintf (stderr, "Option -%c requires an argument specifying the crossover rate.\n", optopt);
-	else if (optopt == 'm')
-	  fprintf (stderr, "Option -%c requires an argument specifying the mutation rate.\n", optopt);
-	else if (optopt == 's')
-	  fprintf (stderr, "Option -%c requires an argument specifying the mutation standard deviation.\n", optopt);
-        else if (isprint (optopt))
-          fprintf (stderr, "Unknown option `-%c'.\n", optopt);
-        else
-          fprintf (stderr,
-                   "Unknown option character `\\x%x'.\n",
-                   optopt);
-        return 1;
-      default:
-	printf("Usage: %s -p {population size} -g {number of generations} -t {number of trials} -c {crossover rate} -m {mutation rate} -s {mutation standard deviation}", argv[0]);
-        abort ();
-      }
+    case 't':
+      n_trials = atoi(optarg);
+      break;
+    case 'g':
+      n_generations = atoi(optarg);
+      break;
+    case 'p':
+      population_size = atoi(optarg);
+      break;
+    case 'm':
+      mutation_rate = strtod(optarg, NULL);
+      break;
+    case 'c':
+      crossover_rate = strtod(optarg, NULL);
+      break;
+    case 's':
+      mutation_stdev = strtod(optarg, NULL);
+      break;
+    case 'e':
+      elitism = atoi(optarg);
+      break;
+    case 'h':
+      printf("Usage: %s -p {population size} -g {number of generations} -t {number of trials} -c {crossover rate} -m {mutation rate} -s {mutation standard deviation} -e {elitism 0 or 1}", argv[0]);
+      break;
+    case '?':
+      if (optopt == 'p')
+        fprintf(stderr, "Option -%c requires an argument specifying the population size.\n", optopt);
+      else if (optopt == 'g')
+        fprintf(stderr, "Option -%c requires an argument specifying the number of generations.\n", optopt);
+      else if (optopt == 't')
+        fprintf(stderr, "Option -%c requires an argument specifying the number of trials.\n", optopt);
+      else if (optopt == 'c')
+        fprintf(stderr, "Option -%c requires an argument specifying the crossover rate.\n", optopt);
+      else if (optopt == 'm')
+        fprintf(stderr, "Option -%c requires an argument specifying the mutation rate.\n", optopt);
+      else if (optopt == 's')
+        fprintf(stderr, "Option -%c requires an argument specifying the mutation standard deviation.\n", optopt);
+      else if (isprint(optopt))
+        fprintf(stderr, "Unknown option `-%c'.\n", optopt);
+      else
+        fprintf(stderr,
+                "Unknown option character `\\x%x'.\n",
+                optopt);
+      return 1;
+    default:
+      printf("Usage: %s -p {population size} -g {number of generations} -t {number of trials} -c {crossover rate} -m {mutation rate} -s {mutation standard deviation}", argv[0]);
+      abort();
+    }
 
   if (experiment_path.empty())
-    {
-      printf("Usage: %s -p {population size} -g {number of generations} -t {number of trials} -c {crossover rate} -m {mutation rate} -s {mutation standard deviation} -x {argos experiment file}\n", argv[0]);
-      exit(1);
-    }
+  {
+    printf("Usage: %s -p {population size} -g {number of generations} -t {number of trials} -c {crossover rate} -m {mutation rate} -s {mutation standard deviation} -x {argos experiment file}\n", argv[0]);
+    exit(1);
+  }
 
   float max_float = std::numeric_limits<float>::max();
 
-    //printf("%s:\tworker %d ready.\n", hostname, mpi_rank);                                          
+  // printf("%s:\tworker %d ready.\n", hostname, mpi_rank);
 
   // See if we've been given a seed to use (for testing purposes).  When you
   // specify a random seed, the evolution will be exactly the same each time
   // you use that seed number
   unsigned int seed = 12345;
-  for(int i=1 ; i<argc ; i++)
-    if(strcmp(argv[i++],"seed") == 0)
+  for (int i = 1; i < argc; i++)
+    if (strcmp(argv[i++], "seed") == 0)
       seed = atoi(argv[i]);
 
   srand(seed);
   generator.seed(seed);
   // popsize / mpi_tasks must be an integer
-  population_size = mpi_tasks * int((double)population_size/(double)mpi_tasks+0.999);
-  
-  if (mpi_rank==0)
-    {
-      printf("Population size: %d\nNumber of trials: %d\nNumber of generations: %d\nCrossover rate: %f\nMutation rate: %f\nMutation stdev: %f\nAllocated MPI workers: %d\n", population_size, n_trials, n_generations, crossover_rate, mutation_rate, mutation_stdev, mpi_tasks);
-      	printf("elitism: %d\n", elitism);
-    }
+  population_size = mpi_tasks * int((double)population_size / (double)mpi_tasks + 0.999);
+
+  if (mpi_rank == 0)
+  {
+    printf("Population size: %d\nNumber of trials: %d\nNumber of generations: %d\nCrossover rate: %f\nMutation rate: %f\nMutation stdev: %f\nAllocated MPI workers: %d\n", population_size, n_trials, n_generations, crossover_rate, mutation_rate, mutation_stdev, mpi_tasks);
+    printf("elitism: %d\n", elitism);
+  }
 
   // Define the genome
   GARealAlleleSetArray allele_array;
-  
-  allele_array.add(0, 1.0); // Probability of switching to search
-  allele_array.add(0, 1.0); // Probability of returning to nest
-  allele_array.add(0, 4*M_PI); // Uninformed search variation
-  allele_array.add(0, 20); // Rate of informed search decay
-  allele_array.add(0, 20); // Rate of site fidelity
-  allele_array.add(0, 20); // Rate of laying pheremone
-  allele_array.add(0, 20); // Rate of pheremone decay
-  
-    
+
+  allele_array.add(0, 1.0);      // Probability of switching to search
+  allele_array.add(0, 1.0);      // Probability of returning to nest
+  allele_array.add(0, 4 * M_PI); // Uninformed search variation
+  allele_array.add(0, 20);       // Rate of informed search decay
+  allele_array.add(0, 20);       // Rate of site fidelity
+  allele_array.add(0, 20);       // Rate of laying pheremone
+  allele_array.add(0, 20);       // Rate of pheremone decay
+
   // Create the template genome using the phenotype map we just made.
   GARealGenome genome(allele_array, objective);
   genome.crossover(GARealUniformCrossover);
   genome.mutator(GARealGaussianMutatorStdev); // Specify our version of the Gaussuan mutator
   genome.initializer(CPFAInitializer);
- 
+
   // Now create the GA using the genome and run it.
   GASimpleGA ga(genome);
   GALinearScaling scaling;
-  ga.maximize();		// Maximize the objective
- 
+  ga.maximize(); // Maximize the objective
+
   ga.populationSize(population_size);
   ga.nGenerations(n_generations);
   ga.pMutation(mutation_rate);
@@ -190,7 +189,7 @@ int main(int argc, char **argv)
     ga.elitist(gaTrue);
   else
     ga.elitist(gaFalse);
-  if(mpi_rank == 0)
+  if (mpi_rank == 0)
     ga.scoreFilename("evolution.txt");
   else
     ga.scoreFilename("/dev/null");
@@ -198,338 +197,363 @@ int main(int argc, char **argv)
   ga.scoreFrequency(1);
   ga.flushFrequency(1);
   ga.selectScores(GAStatistics::AllScores);
-  
+
   // Pass MPI data to the GA class
   ga.mpi_rank(mpi_rank);
   ga.mpi_tasks(mpi_tasks);
-  //ga.evolve(seed); // Manual generations
+  // ga.evolve(seed); // Manual generations
 
-// initialize the ga since we are not using the evolve function
+  // initialize the ga since we are not using the evolve function
   ga.initialize(seed); // This is essential for the mpi workers to be sychronized
 
-    // Name the results file with the current time and date
- time_t t = time(0);   // get time now
-    struct tm * now = localtime( & t );
-    stringstream ss;
+  // Name the results file with the current time and date
+  time_t t = time(0); // get time now
+  struct tm *now = localtime(&t);
+  stringstream ss;
 
-    boost::filesystem::path exp_path(experiment_path);
-    
-    ss << "results/CPFA-evolution-"
-       << exp_path.stem().string() << '-'
-       <<GIT_BRANCH<<"-"<<GIT_COMMIT_HASH<<"-"
-       << (now->tm_year) << '-'
-       << (now->tm_mon + 1) << '-'
-       <<  now->tm_mday << '-'
-       <<  now->tm_hour << '-'
-       <<  now->tm_min << '-'
-       <<  now->tm_sec << ".csv";
+  boost::filesystem::path exp_path(experiment_path);
 
-    string results_file_name = ss.str();
+  ss << "results/CPFA-evolution-"
+     << exp_path.stem().string() << '-'
+     << GIT_BRANCH << "-" << GIT_COMMIT_HASH << "-"
+     << (now->tm_year) << '-'
+     << (now->tm_mon + 1) << '-'
+     << now->tm_mday << '-'
+     << now->tm_hour << '-'
+     << now->tm_min << '-'
+     << now->tm_sec << ".csv";
 
-    if (mpi_rank == 0)
-      {
+  string results_file_name = ss.str();
+
+  if (mpi_rank == 0)
+  {
     // Write output file header
     ofstream results_output_stream;
-	results_output_stream.open(results_file_name, ios::app);
-	results_output_stream << "Population size: " << population_size << "\nNumber of trials: " << n_trials << "\nNumber of generations: "<< n_generations<<"\nCrossover rate: "<< crossover_rate<<"\nMutation rate: " << mutation_rate << "\nMutation stdev: "<< mutation_stdev << "Algorithm: CPFA\n" << "Number of searchers: 6\n" << "Number of targets: 256\n" << "Target distribution: power law" << endl;
-	results_output_stream << "Generation" 
-			      << ", " << "Compute Time (s)"
-			      << ", " << "Convergence"
-			      << ", " << "Mean"
-			      << ", " << "Maximum"
-			      << ", " << "Minimum"
-			      << ", " << "Standard Deviation"
-			      << ", " << "Diversity"
-			      << ", " << "ProbabilityOfSwitchingToSearching"
-			      << ", " << "ProbabilityOfReturningToNest"
-			      << ", " << "UninformedSearchVariation"
-			      << ", " << "RateOfInformedSearchDecay"
-			      << ", " << "RateOfSiteFidelity"
-			      << ", " << "RateOfLayingPheromone"
-			      << ", " << "RateOfPheromoneDecay";
+    results_output_stream.open(results_file_name, ios::app);
+    results_output_stream << "Population size: " << population_size << "\nNumber of trials: " << n_trials << "\nNumber of generations: " << n_generations << "\nCrossover rate: " << crossover_rate << "\nMutation rate: " << mutation_rate << "\nMutation stdev: " << mutation_stdev << "Algorithm: CPFA\n"
+                          << "Number of searchers: 6\n"
+                          << "Number of targets: 256\n"
+                          << "Target distribution: power law" << endl;
+    results_output_stream << "Generation"
+                          << ", "
+                          << "Compute Time (s)"
+                          << ", "
+                          << "Convergence"
+                          << ", "
+                          << "Mean"
+                          << ", "
+                          << "Maximum"
+                          << ", "
+                          << "Minimum"
+                          << ", "
+                          << "Standard Deviation"
+                          << ", "
+                          << "Diversity"
+                          << ", "
+                          << "ProbabilityOfSwitchingToSearching"
+                          << ", "
+                          << "ProbabilityOfReturningToNest"
+                          << ", "
+                          << "UninformedSearchVariation"
+                          << ", "
+                          << "RateOfInformedSearchDecay"
+                          << ", "
+                          << "RateOfSiteFidelity"
+                          << ", "
+                          << "RateOfLayingPheromone"
+                          << ", "
+                          << "RateOfPheromoneDecay";
 
-	results_output_stream << endl;
-	results_output_stream.close();
-      }
+    results_output_stream << endl;
+    results_output_stream.close();
+  }
 
-	while(!ga.done())
-	  {
+  while (!ga.done())
+  {
 
-	    std::chrono::time_point<std::chrono::system_clock>generation_start, generation_end;
-	    if (mpi_rank == 0)
-	      {
-		generation_start = std::chrono::system_clock::now();
-	      }
-	    
-      // Calculate the generation
-      ga.step();
+    std::chrono::time_point<std::chrono::system_clock> generation_start, generation_end;
+    if (mpi_rank == 0)
+    {
+      generation_start = std::chrono::system_clock::now();
+    }
 
-    if(mpi_rank == 0)
-      {
-	generation_end = std::chrono::system_clock::now();
-	std::chrono::duration<double> generation_elapsed_seconds = generation_end-generation_start;
-	ofstream results_output_stream;
-	results_output_stream.open(results_file_name, ios::app);
-       results_output_stream << ga.statistics().generation() 
-			     << ", " << generation_elapsed_seconds.count()
-			     << ", " << ga.statistics().convergence()
-			     << ", " << ga.statistics().current(GAStatistics::Mean)
-			     << ", " << ga.statistics().current(GAStatistics::Maximum)
-			     << ", " << ga.statistics().current(GAStatistics::Minimum)
-			     << ", " << ga.statistics().current(GAStatistics::Deviation)
-			     << ", " << ga.statistics().current(GAStatistics::Diversity);
-       
-	  for (int i = 0; i < GENOME_SIZE; i++)
-	    results_output_stream << ", " << dynamic_cast<const GARealGenome&>(ga.population().best()).gene(i);
+    // Calculate the generation
+    ga.step();
 
-	  
-	  const GARealGenome& best_genome = dynamic_cast<const GARealGenome&>(ga.statistics().bestIndividual());
-	  results_output_stream << endl;
-	  
-	  results_output_stream << "The GA found an optimum at: ";
-	  results_output_stream << best_genome.gene(0);
-	  for (int i = 1; i < GENOME_SIZE; i++)
-	    results_output_stream << ", " << best_genome.gene(i);
-	  results_output_stream << " with score: " << best_genome.score();
-	  results_output_stream << endl;
-	  results_output_stream.close();
-      }
-	  }
-	// Display the GA's progress
-	if(mpi_rank == 0)
-	  {
-	    cout << ga.statistics() << " " << ga.parameters() << endl;
-	  }
-	
+    if (mpi_rank == 0)
+    {
+      generation_end = std::chrono::system_clock::now();
+      std::chrono::duration<double> generation_elapsed_seconds = generation_end - generation_start;
+      ofstream results_output_stream;
+      results_output_stream.open(results_file_name, ios::app);
+      results_output_stream << ga.statistics().generation()
+                            << ", " << generation_elapsed_seconds.count()
+                            << ", " << ga.statistics().convergence()
+                            << ", " << ga.statistics().current(GAStatistics::Mean)
+                            << ", " << ga.statistics().current(GAStatistics::Maximum)
+                            << ", " << ga.statistics().current(GAStatistics::Minimum)
+                            << ", " << ga.statistics().current(GAStatistics::Deviation)
+                            << ", " << ga.statistics().current(GAStatistics::Diversity);
+
+      for (int i = 0; i < GENOME_SIZE; i++)
+        results_output_stream << ", " << dynamic_cast<const GARealGenome &>(ga.population().best()).gene(i);
+
+      const GARealGenome &best_genome = dynamic_cast<const GARealGenome &>(ga.statistics().bestIndividual());
+      results_output_stream << endl;
+
+      results_output_stream << "The GA found an optimum at: ";
+      results_output_stream << best_genome.gene(0);
+      for (int i = 1; i < GENOME_SIZE; i++)
+        results_output_stream << ", " << best_genome.gene(i);
+      results_output_stream << " with score: " << best_genome.score();
+      results_output_stream << endl;
+      results_output_stream.close();
+    }
+  }
+  // Display the GA's progress
+  if (mpi_rank == 0)
+  {
+    cout << ga.statistics() << " " << ga.parameters() << endl;
+  }
+
   MPI_Finalize();
 
   program_end = std::chrono::system_clock::now();
- 
-  std::chrono::duration<double> program_elapsed_seconds = program_end-program_start;
 
-  if(mpi_rank == 0)
+  std::chrono::duration<double> program_elapsed_seconds = program_end - program_start;
+
+  if (mpi_rank == 0)
     printf("Run time was %f seconds\n", program_elapsed_seconds.count());
 
   return 0;
-  }
+}
 
-// Initializes the genome according to the Beyond Pheromones paper 
-void CPFAInitializer(GAGenome & c)
+// Initializes the genome according to the Beyond Pheromones paper
+void CPFAInitializer(GAGenome &c)
 {
   // For the exponential PDF needed to initialize some of the genes
-  
+
   std::exponential_distribution<double> exponential_distribution_10(10.0);
   std::exponential_distribution<double> exponential_distribution_5(5.0);
   std::uniform_real_distribution<double> uniform_distribution_0_1(0.0, 1.0);
-  std::uniform_real_distribution<double> uniform_distribution_0_4PI(0.0, 4.0*M_PI);
+  std::uniform_real_distribution<double> uniform_distribution_0_4PI(0.0, 4.0 * M_PI);
   std::uniform_real_distribution<double> uniform_distribution_0_20(0.0, 20.0);
 
-  GA1DArrayAlleleGenome<float> &child= DYN_CAST(GA1DArrayAlleleGenome<float> &, c);
+  GA1DArrayAlleleGenome<float> &child = DYN_CAST(GA1DArrayAlleleGenome<float> &, c);
   child.resize(GAGenome::ANY_SIZE); // let chrom resize if it can
-  
-  child.gene(0, uniform_distribution_0_1(generator)); // Probability of switching to search
-  child.gene(1, uniform_distribution_0_1(generator)); // Probability of returning to nest
-  child.gene(2, uniform_distribution_0_4PI(generator)); // Uninformed search variation
-  child.gene(3, exponential_distribution_5(generator)); // Rate of informed search decay
-  child.gene(4, uniform_distribution_0_20(generator)); // Rate of site fidelity
-  child.gene(5, uniform_distribution_0_20(generator)); // Rate of laying pheremone
+
+  child.gene(0, uniform_distribution_0_1(generator));    // Probability of switching to search
+  child.gene(1, uniform_distribution_0_1(generator));    // Probability of returning to nest
+  child.gene(2, uniform_distribution_0_4PI(generator));  // Uninformed search variation
+  child.gene(3, exponential_distribution_5(generator));  // Rate of informed search decay
+  child.gene(4, uniform_distribution_0_20(generator));   // Rate of site fidelity
+  child.gene(5, uniform_distribution_0_20(generator));   // Rate of laying pheremone
   child.gene(6, exponential_distribution_10(generator)); // Rate of pheremone decay
 }
 
 // The mutation operator based on the original from GALib but adds stdev
 // The Gaussian mutator picks a new value based on a Gaussian distribution
 // around the current value.  We respect the bounds (if any).
-int GARealGaussianMutatorStdev(GAGenome& g, float pmut)
+int GARealGaussianMutatorStdev(GAGenome &g, float pmut)
 {
-  GA1DArrayAlleleGenome<float> &child=
-    DYN_CAST(GA1DArrayAlleleGenome<float> &, g);
-  register int n, i;
-  if(pmut <= 0.0) return(0);
+  GA1DArrayAlleleGenome<float> &child =
+      DYN_CAST(GA1DArrayAlleleGenome<float> &, g);
+  int n, i;
+  if (pmut <= 0.0)
+    return (0);
 
   float nMut = pmut * (float)(child.length());
-  int length = child.length()-1;
-  if(nMut < 1.0){// we have to do a flip test on each element
+  int length = child.length() - 1;
+  if (nMut < 1.0)
+  { // we have to do a flip test on each element
     nMut = 0;
-    for(i=length; i>=0; i--){
+    for (i = length; i >= 0; i--)
+    {
       float value = child.gene(i);
-      if(GAFlipCoin(pmut)){
-	if(child.alleleset(i).type() == GAAllele::ENUMERATED ||
-	   child.alleleset(i).type() == GAAllele::DISCRETIZED)
-	  value = child.alleleset(i).allele();
-	else if(child.alleleset(i).type() == GAAllele::BOUNDED){
-	  value += GAUnitGaussian()*mutation_stdev;//*(child.alleleset(i).upper()-child.alleleset(i).lower()); // since the standard deviation varies proportionally to a constant multiplier 
-	  value = GAMax(child.alleleset(i).lower(), value);
-	  value = GAMin(child.alleleset(i).upper(), value);
-	}
-	child.gene(i, value);
-	nMut++;
+      if (GAFlipCoin(pmut))
+      {
+        if (child.alleleset(i).type() == GAAllele::ENUMERATED ||
+            child.alleleset(i).type() == GAAllele::DISCRETIZED)
+          value = child.alleleset(i).allele();
+        else if (child.alleleset(i).type() == GAAllele::BOUNDED)
+        {
+          value += GAUnitGaussian() * mutation_stdev; //*(child.alleleset(i).upper()-child.alleleset(i).lower()); // since the standard deviation varies proportionally to a constant multiplier
+          value = GAMax(child.alleleset(i).lower(), value);
+          value = GAMin(child.alleleset(i).upper(), value);
+        }
+        child.gene(i, value);
+        nMut++;
       }
     }
   }
-  else{// only mutate the ones we need to
-    for(n=0; n<nMut; n++){
-      int idx = GARandomInt(0,length);
+  else
+  { // only mutate the ones we need to
+    for (n = 0; n < nMut; n++)
+    {
+      int idx = GARandomInt(0, length);
       float value = child.gene(idx);
-      if(child.alleleset(idx).type() == GAAllele::ENUMERATED ||
-	 child.alleleset(idx).type() == GAAllele::DISCRETIZED)
-	value = child.alleleset(idx).allele();
-      else if(child.alleleset(idx).type() == GAAllele::BOUNDED){
-	value += GAUnitGaussian()*mutation_stdev*(child.alleleset(i).upper()-child.alleleset(i).lower()); // since the standard deviation varies proportionally to a constant multiplier 
-	value = GAMax(child.alleleset(idx).lower(), value);
-	value = GAMin(child.alleleset(idx).upper(), value);
+      if (child.alleleset(idx).type() == GAAllele::ENUMERATED ||
+          child.alleleset(idx).type() == GAAllele::DISCRETIZED)
+        value = child.alleleset(idx).allele();
+      else if (child.alleleset(idx).type() == GAAllele::BOUNDED)
+      {
+        value += GAUnitGaussian() * mutation_stdev * (child.alleleset(i).upper() - child.alleleset(i).lower()); // since the standard deviation varies proportionally to a constant multiplier
+        value = GAMax(child.alleleset(idx).lower(), value);
+        value = GAMin(child.alleleset(idx).upper(), value);
       }
       child.gene(idx, value);
     }
   }
-  return((int)nMut);
+  return ((int)nMut);
 }
-
 
 float objective(GAGenome &c)
 {
   float avg = 0;
-  
+
   // For timing
   std::chrono::time_point<std::chrono::system_clock> start, end;
   start = std::chrono::system_clock::now();
 
-  for (int i = 0; i < n_trials; i++) avg += LaunchARGoS(c);
-  
+  for (int i = 0; i < n_trials; i++)
+    avg += LaunchARGoS(c);
+
   avg /= n_trials;
 
-  
   end = std::chrono::system_clock::now();
-  
-  std::chrono::duration<double> elapsed_seconds = end-start;
 
-  MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);     
+  std::chrono::duration<double> elapsed_seconds = end - start;
 
-      char hostname[1024];              
-      hostname[1023] = '\0';                                          
-      gethostname(hostname, 1023);     
- 
-      /*
-      printf("Worker %d on %s evaluated genome [", mpi_rank, hostname);
-      for (int i = 0; i < GENOME_SIZE; i++)
-	printf("%f ",dynamic_cast<const GARealGenome&>(c).gene(i));
-      printf("] in %f seconds. ", elapsed_seconds.count());
-      printf("Fitness: %f.\n", avg );
-      */
+  MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
 
-      return avg;
+  char hostname[1024];
+  hostname[1023] = '\0';
+  gethostname(hostname, 1023);
+
+  /*
+  printf("Worker %d on %s evaluated genome [", mpi_rank, hostname);
+  for (int i = 0; i < GENOME_SIZE; i++)
+printf("%f ",dynamic_cast<const GARealGenome&>(c).gene(i));
+  printf("] in %f seconds. ", elapsed_seconds.count());
+  printf("Fitness: %f.\n", avg );
+  */
+
+  return avg;
 }
 
 /*
  * Launch ARGoS to evaluate a genome.
  */
-float LaunchARGoS(GAGenome& c_genome) 
+float LaunchARGoS(GAGenome &c_genome)
 {
   // Declate the fitness value and the shared memory segment id and address
   float fitness = 0;
-  int    ShmID;
-  float*   ShmPTR;
-  
+  int ShmID;
+  float *ShmPTR;
+
   // Allocate the shared memory to use between this process and the child argos process
   ShmID = shmget(IPC_PRIVATE, sizeof(float), IPC_CREAT | 0666);
-  if (ShmID < 0) {
+  if (ShmID < 0)
+  {
     printf("ERROR: Allocating shared memory segment in main.cpp:LaunchARGoS() failed.\n");
     exit(1);
   }
-  
+
   // Attach to the shared memory segment
-  ShmPTR = (float*) shmat(ShmID, NULL, 0);
-  if ((float*) ShmPTR == (float*)-1) 
-    {
-      printf("ERROR: Attaching to shared memory segment in main.cpp:LaunchARGoS() failed.\n");
-      exit(1);
-    }
+  ShmPTR = (float *)shmat(ShmID, NULL, 0);
+  if ((float *)ShmPTR == (float *)-1)
+  {
+    printf("ERROR: Attaching to shared memory segment in main.cpp:LaunchARGoS() failed.\n");
+    exit(1);
+  }
 
   *ShmPTR = 0; // Initialise
 
   pid_t pid = fork(); // Create the new process with a copy of this memory space
 
   if (pid == 0)
-    {
-      // In child process - run the argos3 simulation
+  {
+    // In child process - run the argos3 simulation
 
-      /* Convert the received genome to the actual genome type */
-      GARealGenome& cRealGenome = dynamic_cast<GARealGenome&>(c_genome);
-  
-      Real* cpfa_genome = new Real[GENOME_SIZE];
+    /* Convert the received genome to the actual genome type */
+    GARealGenome &cRealGenome = dynamic_cast<GARealGenome &>(c_genome);
 
-      // Convert to a convenient format for the argos controller
-      for (int i = 0; i < GENOME_SIZE; i++)
-	cpfa_genome[i] = cRealGenome.gene(i);
-       
-      /*      
-      printf("%s: worker %d started a genome evaluation. (%f, %f, %f, %f, %f, %f, %f)\n", hostname, mpi_rank, 
-	     cpfa_genome[0],
-	     cpfa_genome[1],
-	     cpfa_genome[2],
-	     cpfa_genome[3],
-	     cpfa_genome[4],
-	     cpfa_genome[5],
-	     cpfa_genome[6]);
-      */
+    Real *cpfa_genome = new Real[GENOME_SIZE];
 
-      /* Redirect LOG and LOGERR to dedicated files to prevent clutter on the screen */
-      std::ofstream cLOGFile("argos_logs/ARGoS_LOG_" + ToString(::getpid()), std::ios::out);
-      LOG.DisableColoredOutput();
-      LOG.GetStream().rdbuf(cLOGFile.rdbuf());
-      std::ofstream cLOGERRFile("argos_logs/ARGoS_LOGERR_" + ToString(::getpid()), std::ios::out);
-      LOGERR.DisableColoredOutput();
-      LOGERR.GetStream().rdbuf(cLOGERRFile.rdbuf());
+    // Convert to a convenient format for the argos controller
+    for (int i = 0; i < GENOME_SIZE; i++)
+      cpfa_genome[i] = cRealGenome.gene(i);
 
-      /*
-       * Initialize ARGoS
-       */
-      /* The CSimulator class of ARGoS is a singleton. Therefore, to
-       * manipulate an ARGoS experiment, it is enough to get its instance */
-      argos::CSimulator& cSimulator = argos::CSimulator::GetInstance();
+    /*
+    printf("%s: worker %d started a genome evaluation. (%f, %f, %f, %f, %f, %f, %f)\n", hostname, mpi_rank,
+     cpfa_genome[0],
+     cpfa_genome[1],
+     cpfa_genome[2],
+     cpfa_genome[3],
+     cpfa_genome[4],
+     cpfa_genome[5],
+     cpfa_genome[6]);
+    */
 
-      // Set the .argos configuration file
-      cSimulator.SetExperimentFileName(experiment_path);
-      
-      // Load it to configure ARGoS 
-      cSimulator.LoadExperiment();
+    /* Redirect LOG and LOGERR to dedicated files to prevent clutter on the screen */
+    std::ofstream cLOGFile("argos_logs/ARGoS_LOG_" + ToString(::getpid()), std::ios::out);
+    LOG.DisableColoredOutput();
+    LOG.GetStream().rdbuf(cLOGFile.rdbuf());
+    std::ofstream cLOGERRFile("argos_logs/ARGoS_LOGERR_" + ToString(::getpid()), std::ios::out);
+    LOGERR.DisableColoredOutput();
+    LOGERR.GetStream().rdbuf(cLOGERRFile.rdbuf());
 
-      // Get a reference to the loop functions
-      MPFA_loop_functions& cLoopFunctions = dynamic_cast<MPFA_loop_functions&>(cSimulator.GetLoopFunctions());
+    /*
+     * Initialize ARGoS
+     */
+    /* The CSimulator class of ARGoS is a singleton. Therefore, to
+     * manipulate an ARGoS experiment, it is enough to get its instance */
+    argos::CSimulator &cSimulator = argos::CSimulator::GetInstance();
 
-      // Configure the controller with the genome
-      cLoopFunctions.ConfigureFromGenome(cpfa_genome);
+    // Set the .argos configuration file
+    cSimulator.SetExperimentFileName(experiment_path);
 
-      // Run the experiment
-      cSimulator.Execute();
+    // Load it to configure ARGoS
+    cSimulator.LoadExperiment();
 
-      // Update performance and store in the shared memory segment
-      *ShmPTR = cLoopFunctions.Score();;
+    // Get a reference to the loop functions
+    MPFA_loop_functions &cLoopFunctions = dynamic_cast<MPFA_loop_functions &>(cSimulator.GetLoopFunctions());
 
-      // For testing
-      //float score = 0;
-      //for (int i = 0; i < GENOME_SIZE; i++) score += cpfa_genome[i];
-      //*ShmPTR = score;
+    // Configure the controller with the genome
+    cLoopFunctions.ConfigureFromGenome(cpfa_genome);
 
-      // Clean up the simulation
-      cSimulator.Destroy();
-      
-      // Clean up the temp genome copy
-	delete [] cpfa_genome;
+    // Run the experiment
+    cSimulator.Execute();
 
-	// Make this process exit
-      _Exit(0); 
-    }
-  
+    // Update performance and store in the shared memory segment
+    *ShmPTR = cLoopFunctions.Score();
+    ;
+
+    // For testing
+    // float score = 0;
+    // for (int i = 0; i < GENOME_SIZE; i++) score += cpfa_genome[i];
+    //*ShmPTR = score;
+
+    // Clean up the simulation
+    cSimulator.Destroy();
+
+    // Clean up the temp genome copy
+    delete[] cpfa_genome;
+
+    // Make this process exit
+    _Exit(0);
+  }
+
   // In parent - wait for child to finish
   int status = wait(&status);
 
   // Make a local copy of the shared fitness value
-  fitness = *ShmPTR;  
+  fitness = *ShmPTR;
 
   // Release shared memory
-  shmdt((void *) ShmPTR);
+  shmdt((void *)ShmPTR);
   shmctl(ShmID, IPC_RMID, NULL);
 
-  /* Return the result of the evaluation */  
+  /* Return the result of the evaluation */
   return fitness;
 }

--- a/Ideal_Transportation_MPFA/source/ga-mpi/GA1DArrayGenome.C
+++ b/Ideal_Transportation_MPFA/source/ga-mpi/GA1DArrayGenome.C
@@ -18,7 +18,7 @@
 #include <ga-mpi/GA1DArrayGenome.h>
 #include <ga-mpi/GAMask.h>
 
-template <class T> int 
+template <class T> int
 GA1DArrayIsHole(const GA1DArrayGenome<T>&, const GA1DArrayGenome<T>&,
 		int, int, int);
 
@@ -36,15 +36,15 @@ GA1DArrayGenome<T>::classID() const {return GAID::ArrayGenome;}
 // this point - initialization must be done explicitly by the user of the
 // genome (eg when the population is created or reset).  If we called the
 // initializer routine here then we could end up with multiple initializations
-// and/or calls to dummy initializers (for example when the genome is 
+// and/or calls to dummy initializers (for example when the genome is
 // created with a dummy initializer and the initializer is assigned later on).
 // Besides, we default to the no-initialization initializer by calling the
 // default genome constructor.
-template <class T> 
+template <class T>
 GA1DArrayGenome<T>::
 GA1DArrayGenome(unsigned int length, GAGenome::Evaluator f, void * u) :
 GAArray<T>(length),
-GAGenome(DEFAULT_1DARRAY_INITIALIZER, 
+GAGenome(DEFAULT_1DARRAY_INITIALIZER,
 	 DEFAULT_1DARRAY_MUTATOR,
 	 DEFAULT_1DARRAY_COMPARATOR) {
   evaluator(f);
@@ -56,9 +56,9 @@ GAGenome(DEFAULT_1DARRAY_INITIALIZER,
 
 // This is the copy initializer.  We set everything to the default values, then
 // copy the original.  The Array creator takes care of zeroing the data.
-template <class T> 
+template <class T>
 GA1DArrayGenome<T>::
-GA1DArrayGenome(const GA1DArrayGenome<T> & orig) : 
+GA1DArrayGenome(const GA1DArrayGenome<T> & orig) :
 GAArray<T>(orig.sz), GAGenome() {
   GA1DArrayGenome<T>::copy(orig);
 }
@@ -74,7 +74,7 @@ GA1DArrayGenome<T>::~GA1DArrayGenome() { }
 // what we define here - a virtual function).  We should check to be sure that
 // both genomes are the same class and same dimension.  This function tries
 // to be smart about they way it copies.  If we already have data, then we do
-// a memcpy of the one we're supposed to copy.  If we don't or we're not the 
+// a memcpy of the one we're supposed to copy.  If we don't or we're not the
 // same size as the one we're supposed to copy, then we adjust ourselves.
 //   The Array takes care of the resize in its copy method.
 template <class T> void
@@ -92,7 +92,7 @@ GA1DArrayGenome<T>::copy(const GAGenome & orig){
 template <class T> GAGenome *
 GA1DArrayGenome<T>::clone(GAGenome::CloneMethod flag) const {
   GA1DArrayGenome<T> *cpy = new GA1DArrayGenome<T>(nx);
-  if(flag == CONTENTS){ 
+  if(flag == CONTENTS){
     cpy->copy(*this);
   }
   else{
@@ -110,10 +110,10 @@ GA1DArrayGenome<T>::clone(GAGenome::CloneMethod flag) const {
 // length, then we don't do anything.
 //   We pay attention to the values of minX and maxX - they determine what kind
 // of resizing we are allowed to do.  If a resize is requested with a length
-// less than the min length specified by the behaviour, we set the minimum 
+// less than the min length specified by the behaviour, we set the minimum
 // to the length.  If the length is longer than the max length specified by
 // the behaviour, we set the max value to the length.
-//   We return the total size (in bits) of the genome after resize. 
+//   We return the total size (in bits) of the genome after resize.
 //   We don't do anything to the new contents!
 template <class T> int
 GA1DArrayGenome<T>::resize(int len)
@@ -160,7 +160,7 @@ GA1DArrayGenome<T>::write(STD_OSTREAM & os) const {
 //   Set the resize behaviour of the genome.  A genome can be fixed
 // length, resizeable with a max and min limit, or resizeable with no limits
 // (other than an implicit one that we use internally).
-//   A value of 0 means no resize, a value less than zero mean unlimited 
+//   A value of 0 means no resize, a value less than zero mean unlimited
 // resize, and a positive value means resize with that value as the limit.
 template <class T> int
 GA1DArrayGenome<T>::
@@ -183,7 +183,7 @@ GA1DArrayGenome<T>::resizeBehaviour() const {
   return val;
 }
 
-template <class T> int 
+template <class T> int
 GA1DArrayGenome<T>::equal(const GAGenome & c) const {
   const GA1DArrayGenome<T> & b = DYN_CAST(const GA1DArrayGenome<T> &, c);
   return((this == &c) ? 1 : ((nx != b.nx) ? 0 : GAArray<T>::equal(b,0,0,nx)));
@@ -205,7 +205,7 @@ its own, independent allele set.  If we clone a new genome, the new one gets a
 link to our allele set (so we don't end up with zillions of allele sets).  Same
 is true for the copy constructor.
   The array may have a single allele set or an array of allele sets, depending
-on which creator was called.  Either way, the allele set cannot be changed 
+on which creator was called.  Either way, the allele set cannot be changed
 once the array is created.
 ---------------------------------------------------------------------------- */
 template <class T> const char *
@@ -213,7 +213,7 @@ GA1DArrayAlleleGenome<T>::className() const {return "GA1DArrayAlleleGenome";}
 template <class T> int
 GA1DArrayAlleleGenome<T>::classID() const {return GAID::ArrayAlleleGenome;}
 
-template <class T> 
+template <class T>
 GA1DArrayAlleleGenome<T>::
 GA1DArrayAlleleGenome(unsigned int length, const GAAlleleSet<T> & s,
 		      GAGenome::Evaluator f, void * u) :
@@ -228,7 +228,7 @@ GA1DArrayGenome<T>(length, f, u){
   this->crossover(GA1DArrayAlleleGenome<T>::DEFAULT_1DARRAY_ALLELE_CROSSOVER);
 }
 
-template <class T> 
+template <class T>
 GA1DArrayAlleleGenome<T>::
 GA1DArrayAlleleGenome(const GAAlleleSetArray<T> & sa,
 		      GAGenome::Evaluator f, void * u) :
@@ -247,9 +247,9 @@ GA1DArrayGenome<T>(sa.size(), f, u) {
 
 // The copy constructor creates a new genome whose allele set refers to the
 // original's allele set.
-template <class T> 
+template <class T>
 GA1DArrayAlleleGenome<T>::
-GA1DArrayAlleleGenome(const GA1DArrayAlleleGenome<T>& orig) : 
+GA1DArrayAlleleGenome(const GA1DArrayAlleleGenome<T>& orig) :
 GA1DArrayGenome<T>(orig.sz) {
   naset = 0;
   aset = (GAAlleleSet<T>*)0;
@@ -265,7 +265,7 @@ GA1DArrayAlleleGenome<T>::~GA1DArrayAlleleGenome(){
 
 
 // This implementation of clone does not make use of the contents/attributes
-// capability because this whole interface isn't quite right yet...  Just 
+// capability because this whole interface isn't quite right yet...  Just
 // clone the entire thing, contents and all.
 template <class T> GAGenome *
 GA1DArrayAlleleGenome<T>::clone(GAGenome::CloneMethod) const {
@@ -273,10 +273,10 @@ GA1DArrayAlleleGenome<T>::clone(GAGenome::CloneMethod) const {
 }
 
 
-template <class T> void 
+template <class T> void
 GA1DArrayAlleleGenome<T>::copy(const GAGenome& orig){
   if(&orig == this) return;
-  const GA1DArrayAlleleGenome<T> * c = 
+  const GA1DArrayAlleleGenome<T> * c =
     DYN_CAST(const GA1DArrayAlleleGenome<T>*, &orig);
   if(c) {
     GA1DArrayGenome<T>::copy(*c);
@@ -339,7 +339,7 @@ GA1DArrayAlleleGenome<T>::equal(const GAGenome & c) const {
 ---------------------------------------------------------------------------- */
 // The random initializer sets the elements of the array based on the alleles
 // set.  We choose randomly the allele for each element.
-template <class ARRAY_TYPE> void 
+template <class ARRAY_TYPE> void
 GA1DArrayAlleleGenome<ARRAY_TYPE>::UniformInitializer(GAGenome & c)
 {
   GA1DArrayAlleleGenome<ARRAY_TYPE> &child=
@@ -354,7 +354,7 @@ GA1DArrayAlleleGenome<ARRAY_TYPE>::UniformInitializer(GAGenome & c)
 // and assign each element the next allele in the allele set.  Once each
 // element has been initialized, scramble the contents by swapping elements.
 // This assumes that there is only one allele set for the array.
-template <class ARRAY_TYPE> void 
+template <class ARRAY_TYPE> void
 GA1DArrayAlleleGenome<ARRAY_TYPE>::OrderedInitializer(GAGenome & c)
 {
   GA1DArrayAlleleGenome<ARRAY_TYPE> &child=
@@ -372,15 +372,15 @@ GA1DArrayAlleleGenome<ARRAY_TYPE>::OrderedInitializer(GAGenome & c)
 }
 
 
-// Randomly pick elements in the array then set the element to any of the 
+// Randomly pick elements in the array then set the element to any of the
 // alleles in the allele set for this genome.  This will work for any number
 // of allele sets for a given array.
-template <class ARRAY_TYPE> int 
+template <class ARRAY_TYPE> int
 GA1DArrayAlleleGenome<ARRAY_TYPE>::FlipMutator(GAGenome & c, float pmut)
 {
   GA1DArrayAlleleGenome<ARRAY_TYPE> &child=
     DYN_CAST(GA1DArrayAlleleGenome<ARRAY_TYPE> &, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.length());
@@ -404,11 +404,11 @@ GA1DArrayAlleleGenome<ARRAY_TYPE>::FlipMutator(GAGenome & c, float pmut)
 
 
 // Randomly swap elements in the array.
-template <class ARRAY_TYPE> int 
+template <class ARRAY_TYPE> int
 GA1DArrayGenome<ARRAY_TYPE>::SwapMutator(GAGenome & c, float pmut)
 {
   GA1DArrayGenome<ARRAY_TYPE> &child=DYN_CAST(GA1DArrayGenome<ARRAY_TYPE>&, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.length());
@@ -469,7 +469,7 @@ ElementComparator(const GAGenome& a, const GAGenome& b)
 #define SWAP(a,b) {unsigned int tmp=a; a=b; b=tmp;}
 
 // Randomly take bits from each parent.  For each bit we flip a coin to see if
-// that bit should come from the mother or the father.  If strings are 
+// that bit should come from the mother or the father.  If strings are
 // different lengths then we need to use the mask to get things right.
 template <class T> int
 GA1DArrayGenome<T>::
@@ -517,8 +517,8 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
     n = 2;
   }
   else if(c1 || c2){
-    GA1DArrayGenome<T> &sis = (c1 ? 
-			       DYN_CAST(GA1DArrayGenome<T> &, *c1) : 
+    GA1DArrayGenome<T> &sis = (c1 ?
+			       DYN_CAST(GA1DArrayGenome<T> &, *c1) :
 			       DYN_CAST(GA1DArrayGenome<T> &, *c2));
 
     if(mom.length() == dad.length() && sis.length() == mom.length()){
@@ -550,7 +550,7 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
 // we cannot handle that and post an error message.
 template <class T> int
 GA1DArrayGenome<T>::
-OnePointCrossover(const GAGenome& p1, const GAGenome& p2, 
+OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 		  GAGenome* c1, GAGenome* c2){
   const GA1DArrayGenome<T> &mom=DYN_CAST(const GA1DArrayGenome<T> &, p1);
   const GA1DArrayGenome<T> &dad=DYN_CAST(const GA1DArrayGenome<T> &, p2);
@@ -565,7 +565,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour() == GAGenome::FIXED_SIZE){
-      if(mom.length() != dad.length() || 
+      if(mom.length() != dad.length() ||
 	 sis.length() != bro.length() ||
 	 sis.length() != mom.length()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -587,17 +587,17 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sis.resize(momsite+dadlen);
       bro.resize(dadsite+momlen);
     }
-    
+
     sis.copy(mom, 0, 0, momsite);
     sis.copy(dad, momsite, dadsite, dadlen);
     bro.copy(dad, 0, 0, dadsite);
     bro.copy(mom, dadsite, momsite, momlen);
-  
+
     nc = 2;
   }
   else if(c1 || c2){
-    GA1DArrayGenome<T> &sis = (c1 ? 
-			       DYN_CAST(GA1DArrayGenome<T> &, *c1) : 
+    GA1DArrayGenome<T> &sis = (c1 ?
+			       DYN_CAST(GA1DArrayGenome<T> &, *c1) :
 			       DYN_CAST(GA1DArrayGenome<T> &, *c2));
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE){
@@ -615,7 +615,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       dadlen = dad.length() - dadsite;
       sis.resize(momsite+dadlen);
     }
-    
+
     if(GARandomBit()){
       sis.copy(mom, 0, 0, momsite);
       sis.copy(dad, momsite, dadsite, dadlen);
@@ -642,14 +642,14 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
 
 // Two point crossover for the 1D array genome.  Similar to the single point
-// crossover, but here we pick two points then grab the sections based upon 
+// crossover, but here we pick two points then grab the sections based upon
 // those two points.
 //   When we pick the points, it doesn't matter where they fall (one is not
 // dependent upon the other).  Make sure we get the lesser one into the first
 // position of our site array.
 template <class T> int
 GA1DArrayGenome<T>::
-TwoPointCrossover(const GAGenome& p1, const GAGenome& p2, 
+TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
 		  GAGenome* c1, GAGenome* c2){
   const GA1DArrayGenome<T> &mom=DYN_CAST(const GA1DArrayGenome<T> &, p1);
   const GA1DArrayGenome<T> &dad=DYN_CAST(const GA1DArrayGenome<T> &, p2);
@@ -664,7 +664,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour() == GAGenome::FIXED_SIZE){
-      if(mom.length() != dad.length() || 
+      if(mom.length() != dad.length() ||
 	 sis.length() != bro.length() ||
 	 sis.length() != mom.length()){
 	GAErr(GA_LOC, mom.className(), "two-point cross", gaErrSameLengthReqd);
@@ -675,7 +675,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
       if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
-      
+
       dadsite[0] = momsite[0];
       dadsite[1] = momsite[1];
       dadlen[0] = momlen[0];
@@ -691,13 +691,13 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
       if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
-      
+
       dadsite[0] = GARandomInt(0, dad.length());
       dadsite[1] = GARandomInt(0, dad.length());
       if(dadsite[0] > dadsite[1]) SWAP(dadsite[0], dadsite[1]);
       dadlen[0] = dadsite[1] - dadsite[0];
       dadlen[1] = dad.length() - dadsite[1];
-      
+
       sis.resize(momsite[0]+dadlen[0]+momlen[1]);
       bro.resize(dadsite[0]+momlen[0]+dadlen[1]);
     }
@@ -726,7 +726,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
       if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
-      
+
       dadsite[0] = momsite[0];
       dadsite[1] = momsite[1];
       dadlen[0] = momlen[0];
@@ -738,7 +738,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
       if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
-      
+
       dadsite[0] = GARandomInt(0, dad.length());
       dadsite[1] = GARandomInt(0, dad.length());
       if(dadsite[0] > dadsite[1]) SWAP(dadsite[0], dadsite[1]);
@@ -771,13 +771,13 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
 
 
 
-// Even and odd crossover for the array works just like it does for the 
+// Even and odd crossover for the array works just like it does for the
 // binary strings.  For even crossover we take the 0th element and every other
 // one after that from the mother.  The 1st and every other come from the
 // father.  For odd crossover, we do just the opposite.
 template <class T> int
 GA1DArrayGenome<T>::
-EvenOddCrossover(const GAGenome& p1, const GAGenome& p2, 
+EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
 		 GAGenome* c1, GAGenome* c2){
   const GA1DArrayGenome<T> &mom=DYN_CAST(const GA1DArrayGenome<T> &, p1);
   const GA1DArrayGenome<T> &dad=DYN_CAST(const GA1DArrayGenome<T> &, p2);
@@ -816,10 +816,10 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
     nc = 2;
   }
   else if(c1 || c2){
-    GA1DArrayGenome<T> &sis = (c1 ? 
-			       DYN_CAST(GA1DArrayGenome<T> &, *c1) : 
+    GA1DArrayGenome<T> &sis = (c1 ?
+			       DYN_CAST(GA1DArrayGenome<T> &, *c1) :
 			       DYN_CAST(GA1DArrayGenome<T> &, *c2));
-    
+
     if(mom.length() == dad.length() && sis.length() == mom.length()){
       for(i=sis.length()-1; i>=1; i-=2){
 	sis.gene(i, mom.gene(i));
@@ -853,7 +853,7 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
 //   We make sure that b will be greater than a.
 template <class T> int
 GA1DArrayGenome<T>::
-PartialMatchCrossover(const GAGenome& p1, const GAGenome& p2, 
+PartialMatchCrossover(const GAGenome& p1, const GAGenome& p2,
 		      GAGenome* c1, GAGenome* c2){
   const GA1DArrayGenome<T> &mom=DYN_CAST(const GA1DArrayGenome<T> &, p1);
   const GA1DArrayGenome<T> &dad=DYN_CAST(const GA1DArrayGenome<T> &, p2);
@@ -868,7 +868,7 @@ PartialMatchCrossover(const GAGenome& p1, const GAGenome& p2,
     GAErr(GA_LOC, mom.className(), "parial match cross", gaErrBadParentLength);
     return nc;
   }
-  
+
   if(c1 && c2){
     GA1DArrayGenome<T> &sis=DYN_CAST(GA1DArrayGenome<T> &, *c1);
     GA1DArrayGenome<T> &bro=DYN_CAST(GA1DArrayGenome<T> &, *c2);
@@ -887,8 +887,8 @@ PartialMatchCrossover(const GAGenome& p1, const GAGenome& p2,
     nc = 2;
   }
   else if(c1 || c2){
-    GA1DArrayGenome<T> &sis = (c1 ? 
-			       DYN_CAST(GA1DArrayGenome<T> &, *c1) : 
+    GA1DArrayGenome<T> &sis = (c1 ?
+			       DYN_CAST(GA1DArrayGenome<T> &, *c1) :
 			       DYN_CAST(GA1DArrayGenome<T> &, *c2));
 
     const GA1DArrayGenome<T> *parent1, *parent2;
@@ -929,7 +929,7 @@ GA1DArrayIsHole(const GA1DArrayGenome<T> &c, const GA1DArrayGenome<T> &dad,
 //   This implementation isn't terribly smart.  For example, I do a linear
 // search rather than caching and doing binary search or smarter hash tables.
 //   First we copy the mother into the sister.  Then move the 'holes' into the
-// crossover section and maintain the ordering of the non-hole elements.  
+// crossover section and maintain the ordering of the non-hole elements.
 // Finally, put the 'holes' in the proper order within the crossover section.
 // After we have done the sister, we do the brother.
 template <class T> int
@@ -949,7 +949,7 @@ OrderCrossover(const GAGenome& p1, const GAGenome& p2,
     GAErr(GA_LOC, mom.className(), "order cross", gaErrBadParentLength);
     return nc;
   }
-  
+
   if(c1 && c2){
     GA1DArrayGenome<T> &sis=DYN_CAST(GA1DArrayGenome<T> &, *c1);
     GA1DArrayGenome<T> &bro=DYN_CAST(GA1DArrayGenome<T> &, *c2);
@@ -962,7 +962,7 @@ OrderCrossover(const GAGenome& p1, const GAGenome& p2,
       if(index >= sis.size()) index=0;
       if(GA1DArrayIsHole(sis,dad,index,a,b)) break;
     }
-    
+
     for(; i<sis.size()-b+a; i++, index++){
       if(index >= sis.size()) index=0;
       j=index;
@@ -999,7 +999,7 @@ OrderCrossover(const GAGenome& p1, const GAGenome& p2,
       } while(GA1DArrayIsHole(bro,mom,j,a,b));
       bro.swap(index,j);
     }
-    
+
 // Now put the 'holes' in the proper order within the crossover section.
     for(i=a; i<b; i++){
       if(bro.gene(i) != mom.gene(i)){
@@ -1011,8 +1011,8 @@ OrderCrossover(const GAGenome& p1, const GAGenome& p2,
     nc = 2;
   }
   else if(c1 || c2){
-    GA1DArrayGenome<T> &sis = (c1 ? 
-			       DYN_CAST(GA1DArrayGenome<T> &, *c1) : 
+    GA1DArrayGenome<T> &sis = (c1 ?
+			       DYN_CAST(GA1DArrayGenome<T> &, *c1) :
 			       DYN_CAST(GA1DArrayGenome<T> &, *c2));
 
     const GA1DArrayGenome<T> *parent1, *parent2;
@@ -1053,7 +1053,7 @@ OrderCrossover(const GAGenome& p1, const GAGenome& p2,
 
 
 
-// Cycle crossover for the 1D array genome.  This is implemented as described 
+// Cycle crossover for the 1D array genome.  This is implemented as described
 // in goldberg's book.  The first is picked from mom, then cycle using dad.
 // Finally, fill in the gaps with the elements from dad.
 //   We allocate space for a temporary array in this routine.  It never frees
@@ -1063,8 +1063,8 @@ OrderCrossover(const GAGenome& p1, const GAGenome& p2,
 //  Allocate space for an array of flags.  We use this to keep track of whether
 // the child's contents came from the mother or the father.  We don't free the
 // space here, but it is not a memory leak.
-//   The first step is to cycle through mom & dad to get the cyclic part of 
-// the crossover.  Then fill in the rest of the sis with dad's contents that 
+//   The first step is to cycle through mom & dad to get the cyclic part of
+// the crossover.  Then fill in the rest of the sis with dad's contents that
 // we didn't use in the cycle.  Finally, do the same thing for the other child.
 //   Notice that this implementation makes serious use of the operator= for the
 // objects in the array.  It also requires the operator != and == comparators.
@@ -1139,7 +1139,7 @@ CycleCrossover(const GAGenome& p1, const GAGenome& p2,
     GAMask mask;
     mask.size(sis.length());
     mask.clear();
-    
+
     sis.gene(0, parent1->gene(0));
     mask[0] = 1;
     while(parent2->gene(current) != parent1->gene(0)){

--- a/Ideal_Transportation_MPFA/source/ga-mpi/GA1DBinStrGenome.C
+++ b/Ideal_Transportation_MPFA/source/ga-mpi/GA1DBinStrGenome.C
@@ -27,13 +27,13 @@
 // this point - initialization must be done explicitly by the user of the
 // genome (eg when the population is created or reset).  If we called the
 // initializer routine here then we could end up with multiple initializations
-// and/or calls to dummy initializers (for example when the genome is 
+// and/or calls to dummy initializers (for example when the genome is
 // created with a dummy initializer and the initializer is assigned later on).
 GA1DBinaryStringGenome::
-GA1DBinaryStringGenome(unsigned int len, 
+GA1DBinaryStringGenome(unsigned int len,
 		       GAGenome::Evaluator f, void * u) :
 GABinaryString(len),
-GAGenome(DEFAULT_1DBINSTR_INITIALIZER, 
+GAGenome(DEFAULT_1DBINSTR_INITIALIZER,
 	 DEFAULT_1DBINSTR_MUTATOR,
 	 DEFAULT_1DBINSTR_COMPARATOR) {
   evaluator(f);
@@ -60,7 +60,7 @@ GA1DBinaryStringGenome::~GA1DBinaryStringGenome() {
 
 
 // The clone member creates a duplicate (exact or just attributes, depending
-// on the flag).  The caller is responsible for freeing the memory that is 
+// on the flag).  The caller is responsible for freeing the memory that is
 // allocated by this method.
 GAGenome*
 GA1DBinaryStringGenome::clone(GAGenome::CloneMethod flag) const {
@@ -81,7 +81,7 @@ GA1DBinaryStringGenome::clone(GAGenome::CloneMethod flag) const {
 // what we define here - a virtual function).  We should check to be sure that
 // both genomes are the same class and same dimension.  This function tries
 // to be smart about they way it copies.  If we already have data, then we do
-// a memcpy of the one we're supposed to copy.  If we don't or we're not the 
+// a memcpy of the one we're supposed to copy.  If we don't or we're not the
 // same size as the one we're supposed to copy, then we adjust ourselves.
 //   The BinaryStringGenome takes care of the resize in its copy method.
 // It also copies the bitstring for us.
@@ -89,7 +89,7 @@ void
 GA1DBinaryStringGenome::copy(const GAGenome & orig)
 {
   if(&orig == this) return;
-  const GA1DBinaryStringGenome* c = 
+  const GA1DBinaryStringGenome* c =
     DYN_CAST(const GA1DBinaryStringGenome*, &orig);
   if(c) {
     GAGenome::copy(*c);
@@ -173,7 +173,7 @@ GA1DBinaryStringGenome::write(STD_OSTREAM & os) const
 //   Set the resize behaviour of the genome.  A genome can be fixed
 // length, resizeable with a max and min limit, or resizeable with no limits
 // (other than an implicit one that we use internally).
-//   A value of 0 means no resize, a value less than zero mean unlimited 
+//   A value of 0 means no resize, a value less than zero mean unlimited
 // resize, and a positive value means resize with that value as the limit.
 //   We return the upper limit of the genome's size.
 int
@@ -190,21 +190,21 @@ resizeBehaviour(unsigned int lower, unsigned int upper)
   return resizeBehaviour();
 }
 
-int 
+int
 GA1DBinaryStringGenome::resizeBehaviour() const {
   int val = maxX;
   if(maxX == minX) val = FIXED_SIZE;
   return val;
 }
 
-int 
+int
 GA1DBinaryStringGenome::
 equal(const GA1DBinaryStringGenome& c,
       unsigned int dest, unsigned int src, unsigned int len) const {
   return GABinaryString::equal(c,dest,src,len);
 }
 
-int 
+int
 GA1DBinaryStringGenome::equal(const GAGenome & c) const {
   if(this == &c) return 1;
   const GA1DBinaryStringGenome* b = DYN_CAST(const GA1DBinaryStringGenome*,&c);
@@ -231,7 +231,7 @@ GA1DBinaryStringGenome::equal(const GAGenome & c) const {
 // random bit function so we don't have to worry about machine-specific stuff.
 //   We also do a resize so the genome can resize itself (randomly) if it
 // is a resizeable genome.
-void 
+void
 GA1DBinaryStringGenome::UniformInitializer(GAGenome & c)
 {
   GA1DBinaryStringGenome &child=DYN_CAST(GA1DBinaryStringGenome &, c);
@@ -242,7 +242,7 @@ GA1DBinaryStringGenome::UniformInitializer(GAGenome & c)
 
 
 //   Unset all of the bits in the genome.
-void 
+void
 GA1DBinaryStringGenome::UnsetInitializer(GAGenome & c)
 {
   GA1DBinaryStringGenome &child=DYN_CAST(GA1DBinaryStringGenome &, c);
@@ -252,7 +252,7 @@ GA1DBinaryStringGenome::UnsetInitializer(GAGenome & c)
 
 
 //   Set all of the bits in the genome.
-void 
+void
 GA1DBinaryStringGenome::SetInitializer(GAGenome & c)
 {
   GA1DBinaryStringGenome &child=DYN_CAST(GA1DBinaryStringGenome &, c);
@@ -271,11 +271,11 @@ GA1DBinaryStringGenome::SetInitializer(GAGenome & c)
 // better the chance that it will match the desired mutation rate.
 //   If nMut is greater than 1, then we round up, so a mutation of 2.2 would
 // be 3 mutations, and 2.9 would be 3 as well.  nMut of 3 would be 3 mutations.
-int 
+int
 GA1DBinaryStringGenome::FlipMutator(GAGenome & c, float pmut)
 {
   GA1DBinaryStringGenome &child=DYN_CAST(GA1DBinaryStringGenome &, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float, child.length());
@@ -298,10 +298,10 @@ GA1DBinaryStringGenome::FlipMutator(GAGenome & c, float pmut)
 }
 
 
-// Return a number from 0 to 1 to indicate how similar two genomes are.  For 
+// Return a number from 0 to 1 to indicate how similar two genomes are.  For
 // the binary strings we compare bits.  We count the number of bits that are
 // the same then divide by the number of bits.  If the genomes are different
-// length then we return a -1 to indicate that we cannot calculate the 
+// length then we return a -1 to indicate that we cannot calculate the
 // similarity.
 //   Normal hamming distance makes use of population information - this is not
 // a hamming measure!  This is a similarity measure of two individuals, not
@@ -334,7 +334,7 @@ GA1DBinaryStringGenome::BitComparator(const GAGenome& a, const GAGenome& b){
 
 
 // Randomly take bits from each parent.  For each bit we flip a coin to see if
-// that bit should come from the mother or the father.  This operator can be 
+// that bit should come from the mother or the father.  This operator can be
 // used on genomes of different lengths, but the crossover is truncated to the
 // shorter of the parents and child.
 int
@@ -385,8 +385,8 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
     n = 2;
   }
   else if(c1 || c2){
-    GA1DBinaryStringGenome &sis = (c1 ? 
-				   DYN_CAST(GA1DBinaryStringGenome&, *c1) : 
+    GA1DBinaryStringGenome &sis = (c1 ?
+				   DYN_CAST(GA1DBinaryStringGenome&, *c1) :
 				   DYN_CAST(GA1DBinaryStringGenome&, *c2));
 
     if(mom.length() == dad.length() && sis.length() == mom.length()){
@@ -434,7 +434,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour() == GAGenome::FIXED_SIZE){
-      if(mom.length() != dad.length() || 
+      if(mom.length() != dad.length() ||
 	 sis.length() != bro.length() ||
 	 sis.length() != mom.length()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -461,12 +461,12 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
     sis.copy(dad, momsite, dadsite, dadlen);
     bro.copy(dad, 0, 0, dadsite);
     bro.copy(mom, dadsite, momsite, momlen);
-  
+
     n = 2;
   }
   else if(c1 || c2){
-    GA1DBinaryStringGenome &sis = (c1 ? 
-				   DYN_CAST(GA1DBinaryStringGenome&, *c1) : 
+    GA1DBinaryStringGenome &sis = (c1 ?
+				   DYN_CAST(GA1DBinaryStringGenome&, *c1) :
 				   DYN_CAST(GA1DBinaryStringGenome&, *c2));
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE){
@@ -530,7 +530,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour() == GAGenome::FIXED_SIZE){
-      if(mom.length() != dad.length() || 
+      if(mom.length() != dad.length() ||
 	 sis.length() != bro.length() ||
 	 sis.length() != mom.length()){
 	GAErr(GA_LOC, mom.className(), "two-point cross", gaErrSameLengthReqd);
@@ -558,7 +558,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
       if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
-      
+
       dadsite[0] = GARandomInt(0, dad.length());
       dadsite[1] = GARandomInt(0, dad.length());
       if(dadsite[0] > dadsite[1]) SWAP(dadsite[0], dadsite[1]);
@@ -579,8 +579,8 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
     n = 2;
   }
   else if(c1 || c2){
-    GA1DBinaryStringGenome &sis = (c1 ? 
-				   DYN_CAST(GA1DBinaryStringGenome&, *c1) : 
+    GA1DBinaryStringGenome &sis = (c1 ?
+				   DYN_CAST(GA1DBinaryStringGenome&, *c1) :
 				   DYN_CAST(GA1DBinaryStringGenome&, *c2));
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE){
@@ -605,7 +605,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
       if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
-      
+
       dadsite[0] = GARandomInt(0, dad.length());
       dadsite[1] = GARandomInt(0, dad.length());
       if(dadsite[0] > dadsite[1]) SWAP(dadsite[0], dadsite[1]);
@@ -639,10 +639,10 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
 //   Even and odd crossovers take alternating bits from the mother and father.
 // For even crossover, we take every even bit from the mother and every odd bit
 // from the father (the first bit is the 0th bit, so it is even).  Odd
-// crossover is just the opposite.  
+// crossover is just the opposite.
 int
 GA1DBinaryStringGenome::
-EvenOddCrossover(const GAGenome& p1, const GAGenome& p2, 
+EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
 		 GAGenome* c1, GAGenome* c2){
   const GA1DBinaryStringGenome &mom=
     DYN_CAST(const GA1DBinaryStringGenome &, p1);
@@ -685,7 +685,7 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
   }
   else if(c1 || c2){
     GA1DBinaryStringGenome &sis = (c1 ?
-				   DYN_CAST(GA1DBinaryStringGenome&, *c1) : 
+				   DYN_CAST(GA1DBinaryStringGenome&, *c1) :
 				   DYN_CAST(GA1DBinaryStringGenome&, *c2));
 
     if(mom.length() == dad.length() && sis.length() == mom.length()){

--- a/Ideal_Transportation_MPFA/source/ga-mpi/GA2DArrayGenome.C
+++ b/Ideal_Transportation_MPFA/source/ga-mpi/GA2DArrayGenome.C
@@ -27,13 +27,13 @@ GA2DArrayGenome<T>::className() const {return "GA2DArrayGenome";}
 template <class T> int
 GA2DArrayGenome<T>::classID() const {return GAID::ArrayGenome2D;}
 
-template <class T> 
+template <class T>
 GA2DArrayGenome<T>::
-GA2DArrayGenome(unsigned int width, unsigned int height, 
+GA2DArrayGenome(unsigned int width, unsigned int height,
 		GAGenome::Evaluator f,
 		void * u) :
 GAArray<T>(width*height),
-GAGenome(DEFAULT_2DARRAY_INITIALIZER, 
+GAGenome(DEFAULT_2DARRAY_INITIALIZER,
 	 DEFAULT_2DARRAY_MUTATOR,
 	 DEFAULT_2DARRAY_COMPARATOR)
 {
@@ -44,7 +44,7 @@ GAGenome(DEFAULT_2DARRAY_INITIALIZER,
 }
 
 
-template <class T> 
+template <class T>
 GA2DArrayGenome<T>::
 GA2DArrayGenome(const GA2DArrayGenome<T> & orig) : GAArray<T>(orig.sz){
   GA2DArrayGenome<T>::copy(orig);
@@ -62,10 +62,10 @@ GA2DArrayGenome<T>::copy(const GAGenome & orig){
   if(c) {
     GAGenome::copy(*c);
     GAArray<T>::copy(*c);
-    nx = c->nx; ny = c->ny; 
-    minX = c->minX; minY = c->minY; 
+    nx = c->nx; ny = c->ny;
+    minX = c->minX; minY = c->minY;
     maxX = c->maxX; maxY = c->maxY;
-  } 
+  }
 }
 
 
@@ -77,8 +77,8 @@ GA2DArrayGenome<T>::clone(GAGenome::CloneMethod flag) const {
   }
   else{
     cpy->GAGenome::copy(*this);
-    cpy->minX = minX; cpy->minY = minY; 
-    cpy->maxX = maxX; cpy->maxY = maxY; 
+    cpy->minX = minX; cpy->minY = minY;
+    cpy->maxX = maxX; cpy->maxY = maxY;
   }
   return cpy;
 }
@@ -137,7 +137,7 @@ GA2DArrayGenome<T>::read(STD_ISTREAM &) {
 
 
 template <class T> int
-GA2DArrayGenome<T>::write(STD_OSTREAM & os) const 
+GA2DArrayGenome<T>::write(STD_OSTREAM & os) const
 {
   for(unsigned int j=0; j<ny; j++){
     for(unsigned int i=0; i<nx; i++){
@@ -167,7 +167,7 @@ GA2DArrayGenome<T>::resizeBehaviour(GAGenome::Dimension which) const {
 
 template <class T> int
 GA2DArrayGenome<T>::
-resizeBehaviour(GAGenome::Dimension which, 
+resizeBehaviour(GAGenome::Dimension which,
 		unsigned int lower, unsigned int upper)
 {
   if(upper < lower){
@@ -212,12 +212,12 @@ GA2DArrayGenome<T>::copy(const GA2DArrayGenome<T> & orig,
   for(unsigned int j=0; j<h; j++)
     GAArray<T>::copy(orig, (s+j)*nx+r, (y+j)*orig.nx+x, w);
 
-  _evaluated = gaFalse; 
+  _evaluated = gaFalse;
 }
 
 
 
-template <class T> int 
+template <class T> int
 GA2DArrayGenome<T>::equal(const GAGenome & c) const
 {
   if(this == &c) return 1;
@@ -259,9 +259,9 @@ GA2DArrayAlleleGenome<T>::className() const {return "GA2DArrayAlleleGenome";}
 template <class T> int
 GA2DArrayAlleleGenome<T>::classID() const {return GAID::ArrayAlleleGenome2D;}
 
-template <class T> 
+template <class T>
 GA2DArrayAlleleGenome<T>::
-GA2DArrayAlleleGenome(unsigned int width, unsigned int height, 
+GA2DArrayAlleleGenome(unsigned int width, unsigned int height,
 		      const GAAlleleSet<T> & s,
 		      GAGenome::Evaluator f, void * u) :
 GA2DArrayGenome<T>(width,height,f,u){
@@ -275,9 +275,9 @@ GA2DArrayGenome<T>(width,height,f,u){
   this->crossover(GA2DArrayAlleleGenome<T>::DEFAULT_2DARRAY_ALLELE_CROSSOVER);
 }
 
-template <class T> 
+template <class T>
 GA2DArrayAlleleGenome<T>::
-GA2DArrayAlleleGenome(unsigned int width, unsigned int height, 
+GA2DArrayAlleleGenome(unsigned int width, unsigned int height,
 		      const GAAlleleSetArray<T> & sa,
 		      GAGenome::Evaluator f, void * u) :
 GA2DArrayGenome<T>(width,height, f, u) {
@@ -293,9 +293,9 @@ GA2DArrayGenome<T>(width,height, f, u) {
 }
 
 
-template <class T> 
+template <class T>
 GA2DArrayAlleleGenome<T>::
-GA2DArrayAlleleGenome(const GA2DArrayAlleleGenome<T> & orig) : 
+GA2DArrayAlleleGenome(const GA2DArrayAlleleGenome<T> & orig) :
 GA2DArrayGenome<T>(orig.nx, orig.ny) {
   naset = 0;
   aset = (GAAlleleSet<T>*)0;
@@ -315,10 +315,10 @@ GA2DArrayAlleleGenome<T>::clone(GAGenome::CloneMethod) const {
 }
 
 
-template <class T> void 
+template <class T> void
 GA2DArrayAlleleGenome<T>::copy(const GAGenome& orig){
   if(&orig == this) return;
-  const GA2DArrayAlleleGenome<T>* c = 
+  const GA2DArrayAlleleGenome<T>* c =
     DYN_CAST(const GA2DArrayAlleleGenome<T>*, &orig);
   if(c) {
     GA2DArrayGenome<T>::copy(*c);
@@ -386,24 +386,24 @@ GA2DArrayAlleleGenome<T>::equal(const GAGenome & c) const {
    Operator definitions
 ---------------------------------------------------------------------------- */
 // this does not handle genomes with multiple allele sets!
-template <class ARRAY_TYPE> void 
+template <class ARRAY_TYPE> void
 GA2DArrayAlleleGenome<ARRAY_TYPE>::UniformInitializer(GAGenome & c)
 {
   GA2DArrayAlleleGenome<ARRAY_TYPE> &child=
     DYN_CAST(GA2DArrayAlleleGenome<ARRAY_TYPE> &, c);
-  child.resize(GAGenome::ANY_SIZE,GAGenome::ANY_SIZE); 
+  child.resize(GAGenome::ANY_SIZE,GAGenome::ANY_SIZE);
   for(int i=child.width()-1; i>=0; i--)
     for(int j=child.height()-1; j>=0; j--)
       child.gene(i, j, child.alleleset().allele());
 }
 
 
-template <class ARRAY_TYPE> int 
+template <class ARRAY_TYPE> int
 GA2DArrayAlleleGenome<ARRAY_TYPE>::FlipMutator(GAGenome & c, float pmut)
 {
   GA2DArrayAlleleGenome<ARRAY_TYPE> &child=
     DYN_CAST(GA2DArrayAlleleGenome<ARRAY_TYPE> &, c);
-  register int n, m, i, j;
+  int n, m, i, j;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.size());
@@ -430,11 +430,11 @@ GA2DArrayAlleleGenome<ARRAY_TYPE>::FlipMutator(GAGenome & c, float pmut)
 }
 
 
-template <class ARRAY_TYPE> int 
+template <class ARRAY_TYPE> int
 GA2DArrayGenome<ARRAY_TYPE>::SwapMutator(GAGenome & c, float pmut)
 {
   GA2DArrayGenome<ARRAY_TYPE> &child=DYN_CAST(GA2DArrayGenome<ARRAY_TYPE>&, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.size());
@@ -496,7 +496,7 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
   if(c1 && c2){
     GA2DArrayGenome<T> &sis=DYN_CAST(GA2DArrayGenome<T> &, *c1);
     GA2DArrayGenome<T> &bro=DYN_CAST(GA2DArrayGenome<T> &, *c2);
-    
+
     if(sis.width() == bro.width() && sis.height() == bro.height() &&
        mom.width() == dad.width() && mom.height() == dad.height() &&
        sis.width() == mom.width() && sis.height() == mom.height()){
@@ -567,7 +567,7 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
 
 
 // This crossover does clipping (no padding) for resizables.  Notice that this
-// means that any resizable children of two parents will have identical 
+// means that any resizable children of two parents will have identical
 // dimensions no matter what.
 template <class T> int
 GA2DArrayGenome<T>::
@@ -587,8 +587,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE){
-      if(mom.width() != dad.width() || 
-	 sis.width() != bro.width() || 
+      if(mom.width() != dad.width() ||
+	 sis.width() != bro.width() ||
 	 sis.width() != mom.width()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -612,8 +612,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
-      if(mom.height() != dad.height() || 
-	 sis.height() != bro.height() || 
+      if(mom.height() != dad.height() ||
+	 sis.height() != bro.height() ||
 	 sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -637,12 +637,12 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     sis.resize(sitex+lenx, sitey+leny);
     bro.resize(sitex+lenx, sitey+leny);
-    
+
     sis.copy(mom, 0, 0, momsitex-sitex, momsitey-sitey, sitex, sitey);
     sis.copy(dad, sitex, 0, dadsitex, dadsitey-sitey, lenx, sitey);
     sis.copy(dad, 0, sitey, dadsitex-sitex, dadsitey, sitex, leny);
     sis.copy(mom, sitex, sitey, momsitex, momsitey, lenx, leny);
-    
+
     bro.copy(dad, 0, 0, dadsitex-sitex, dadsitey-sitey, sitex, sitey);
     bro.copy(mom, sitex, 0, momsitex, momsitey-sitey, lenx, sitey);
     bro.copy(mom, 0, sitey, momsitex-sitex, momsitey, sitex, leny);
@@ -652,7 +652,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
   }
   else if(c1){
     GA2DArrayGenome<T> &sis=DYN_CAST(GA2DArrayGenome<T> &, *c1);
-    
+
     if(sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE){
       if(mom.width() != dad.width() || sis.width() != mom.width()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -669,7 +669,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitex = GAMin(momsitex, dadsitex);
       lenx = GAMin(momlenx, dadlenx);
     }
-    
+
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
       if(mom.height() != dad.height() || sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -686,9 +686,9 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitey = GAMin(momsitey, dadsitey);
       leny = GAMin(momleny, dadleny);
     }
-    
+
     sis.resize(sitex+lenx, sitey+leny);
-    
+
     if(GARandomBit()){
       sis.copy(mom, 0, 0, momsitex-sitex, momsitey-sitey, sitex, sitey);
       sis.copy(dad, sitex, 0, dadsitex, dadsitey-sitey, lenx, sitey);
@@ -759,7 +759,7 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
   }
   else if(c1){
     GA2DArrayGenome<T> &sis=DYN_CAST(GA2DArrayGenome<T> &, *c1);
-    
+
     if(mom.width() == dad.width() && mom.height() == dad.height() &&
        sis.width() == mom.width() && sis.height() == mom.height()){
       int count=0;

--- a/Ideal_Transportation_MPFA/source/ga-mpi/GA2DBinStrGenome.C
+++ b/Ideal_Transportation_MPFA/source/ga-mpi/GA2DBinStrGenome.C
@@ -21,7 +21,7 @@
    Genome class definition
 ---------------------------------------------------------------------------- */
 GA2DBinaryStringGenome::
-GA2DBinaryStringGenome(unsigned int width, unsigned int height, 
+GA2DBinaryStringGenome(unsigned int width, unsigned int height,
 		       GAGenome::Evaluator f, void * u) :
 GABinaryString(width*height),
 GAGenome(DEFAULT_2DBINSTR_INITIALIZER,
@@ -54,8 +54,8 @@ GA2DBinaryStringGenome::clone(GAGenome::CloneMethod flag) const {
   }
   else{
     cpy->GAGenome::copy(*this);
-    cpy->minX = minX; cpy->minY = minY; 
-    cpy->maxX = maxX; cpy->maxY = maxY; 
+    cpy->minX = minX; cpy->minY = minY;
+    cpy->maxX = maxX; cpy->maxY = maxY;
   }
   return cpy;
 }
@@ -69,10 +69,10 @@ GA2DBinaryStringGenome::copy(const GAGenome & orig)
   if(c) {
     GAGenome::copy(*c);
     GABinaryString::copy(*c);
-    nx = c->nx; ny = c->ny; 
-    minX = c->minX; minY = c->minY; 
+    nx = c->nx; ny = c->ny;
+    minX = c->minX; minY = c->minY;
     maxX = c->maxX; maxY = c->maxY;
-  } 
+  }
 }
 
 
@@ -105,7 +105,7 @@ GA2DBinaryStringGenome::resize(int w, int h)
 
 // Move the bits into the right position.  If we're smaller, then shift to
 // the smaller size before we do the resize (the resize method maintains bit
-// integrety).  If we're larger, do the move after the resize.  If we're the 
+// integrety).  If we're larger, do the move after the resize.  If we're the
 // same size the we don't do anything.  When we're adding more bits, the new
 // bits get set randomly to 0 or 1.
 
@@ -153,7 +153,7 @@ GA2DBinaryStringGenome::read(STD_ISTREAM & is)
 
   _evaluated = gaFalse;
 
-  if(is.eof() && 
+  if(is.eof() &&
      ((j < ny) ||	     // didn't get some lines
       (i < nx && i != 0))){   // stopped early on a row
     GAErr(GA_LOC, className(), "read", gaErrUnexpectedEOF);
@@ -168,7 +168,7 @@ GA2DBinaryStringGenome::read(STD_ISTREAM & is)
 // Dump the digits to the stream with a newline between each row.  No newline
 // at the end of the whole thing.
 int
-GA2DBinaryStringGenome::write(STD_OSTREAM & os) const 
+GA2DBinaryStringGenome::write(STD_OSTREAM & os) const
 {
   for(unsigned int j=0; j<ny; j++){
     for(unsigned int i=0; i<nx; i++)
@@ -180,7 +180,7 @@ GA2DBinaryStringGenome::write(STD_OSTREAM & os) const
 #endif
 
 
-int 
+int
 GA2DBinaryStringGenome::resizeBehaviour(GAGenome::Dimension which) const {
   int val = 0;
   if(which == WIDTH) {
@@ -318,7 +318,7 @@ GA2DBinaryStringGenome::equal(const GA2DBinaryStringGenome& orig,
 }
 
 
-int 
+int
 GA2DBinaryStringGenome::equal(const GAGenome & c) const
 {
   if(this == &c) return 1;
@@ -344,7 +344,7 @@ GA2DBinaryStringGenome::equal(const GAGenome & c) const
   The order for looping through indices is height-then-width (ie height loops
 before a single width increment)
 ---------------------------------------------------------------------------- */
-void 
+void
 GA2DBinaryStringGenome::UniformInitializer(GAGenome & c)
 {
   GA2DBinaryStringGenome &child=DYN_CAST(GA2DBinaryStringGenome &, c);
@@ -355,7 +355,7 @@ GA2DBinaryStringGenome::UniformInitializer(GAGenome & c)
 }
 
 
-void 
+void
 GA2DBinaryStringGenome::UnsetInitializer(GAGenome & c)
 {
   GA2DBinaryStringGenome &child=DYN_CAST(GA2DBinaryStringGenome &, c);
@@ -364,20 +364,20 @@ GA2DBinaryStringGenome::UnsetInitializer(GAGenome & c)
 }
 
 
-void 
+void
 GA2DBinaryStringGenome::SetInitializer(GAGenome & c)
 {
   GA2DBinaryStringGenome &child=DYN_CAST(GA2DBinaryStringGenome &, c);
-  child.resize(GAGenome::ANY_SIZE, GAGenome::ANY_SIZE);	
+  child.resize(GAGenome::ANY_SIZE, GAGenome::ANY_SIZE);
   child.set(0, 0, child.width(), child.height());
 }
 
 
-int 
+int
 GA2DBinaryStringGenome::FlipMutator(GAGenome & c, float pmut)
 {
   GA2DBinaryStringGenome &child=DYN_CAST(GA2DBinaryStringGenome &, c);
-  register int n, m, i, j;
+  int n, m, i, j;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float, child.size());
@@ -431,7 +431,7 @@ GA2DBinaryStringGenome::BitComparator(const GAGenome& a, const GAGenome& b){
 
 int
 GA2DBinaryStringGenome::
-UniformCrossover(const GAGenome& p1, const GAGenome& p2, 
+UniformCrossover(const GAGenome& p1, const GAGenome& p2,
 		 GAGenome* c1, GAGenome* c2){
   const GA2DBinaryStringGenome &mom=
     DYN_CAST(const GA2DBinaryStringGenome &, p1);
@@ -486,8 +486,8 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
     nc = 2;
   }
   else if(c1 || c2){
-    GA2DBinaryStringGenome &sis = (c1 ? 
-				   DYN_CAST(GA2DBinaryStringGenome&, *c1) : 
+    GA2DBinaryStringGenome &sis = (c1 ?
+				   DYN_CAST(GA2DBinaryStringGenome&, *c1) :
 				   DYN_CAST(GA2DBinaryStringGenome&, *c2));
 
     if(mom.width() == dad.width() && mom.height() == dad.height() &&
@@ -515,13 +515,13 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
 
 //   When we do single point crossover on resizable 2D genomes we can either
 // clip or pad to make the mismatching geometries work out.  Either way, both
-// children end up with the same dimensions (the children have the same 
+// children end up with the same dimensions (the children have the same
 // dimensions as each other, not the same as if they were clipped/padded).
 //   When we pad, the extra space is filled with random bits.  This
 // implementation does only clipping, no padding!
 int
 GA2DBinaryStringGenome::
-OnePointCrossover(const GAGenome& p1, const GAGenome& p2, 
+OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 		  GAGenome* c1, GAGenome* c2){
   const GA2DBinaryStringGenome &mom=
     DYN_CAST(const GA2DBinaryStringGenome &, p1);
@@ -539,8 +539,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE){
-      if(mom.width() != dad.width() || 
-	 sis.width() != bro.width() || 
+      if(mom.width() != dad.width() ||
+	 sis.width() != bro.width() ||
 	 sis.width() != mom.width()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -564,8 +564,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
-      if(mom.height() != dad.height() || 
-	 sis.height() != bro.height() || 
+      if(mom.height() != dad.height() ||
+	 sis.height() != bro.height() ||
 	 sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -640,9 +640,9 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitey = GAMin(momsitey, dadsitey);
       leny = GAMin(momleny, dadleny);
     }
-    
+
     sis.resize(sitex+lenx, sitey+leny);
-    
+
     if(GARandomBit()){
       sis.copy(mom, 0, 0, momsitex-sitex, momsitey-sitey, sitex, sitey);
       sis.copy(dad, sitex, 0, dadsitex, dadsitey-sitey, lenx, sitey);
@@ -666,7 +666,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
 int
 GA2DBinaryStringGenome::
-EvenOddCrossover(const GAGenome& p1, const GAGenome& p2, 
+EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
 		 GAGenome* c1, GAGenome* c2){
   const GA2DBinaryStringGenome &mom=
     DYN_CAST(const GA2DBinaryStringGenome &, p1);
@@ -679,7 +679,7 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
   if(c1 && c2){
     GA2DBinaryStringGenome &sis=DYN_CAST(GA2DBinaryStringGenome &, *c1);
     GA2DBinaryStringGenome &bro=DYN_CAST(GA2DBinaryStringGenome &, *c2);
-    
+
     if(sis.width() == bro.width() && sis.height() == bro.height() &&
        mom.width() == dad.width() && mom.height() == dad.height() &&
        sis.width() == mom.width() && sis.height() == mom.height()){
@@ -719,10 +719,10 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
     nc = 2;
   }
   else if(c1 || c2){
-    GA2DBinaryStringGenome &sis = (c1 ? 
+    GA2DBinaryStringGenome &sis = (c1 ?
 				   DYN_CAST(GA2DBinaryStringGenome&, *c1) :
 				   DYN_CAST(GA2DBinaryStringGenome&, *c2));
-    
+
     if(mom.width() == dad.width() && mom.height() == dad.height() &&
        sis.width() == mom.width() && sis.height() == mom.height()){
       int count=0;

--- a/Ideal_Transportation_MPFA/source/ga-mpi/GA3DArrayGenome.C
+++ b/Ideal_Transportation_MPFA/source/ga-mpi/GA3DArrayGenome.C
@@ -27,13 +27,13 @@ GA3DArrayGenome<T>::className() const {return "GA3DArrayGenome";}
 template <class T> int
 GA3DArrayGenome<T>::classID() const {return GAID::ArrayGenome3D;}
 
-template <class T> 
+template <class T>
 GA3DArrayGenome<T>::
 GA3DArrayGenome(unsigned int w, unsigned int h, unsigned int d,
 		GAGenome::Evaluator f,
 		void * u) :
 GAArray<T>(w*h*d),
-GAGenome(DEFAULT_3DARRAY_INITIALIZER, 
+GAGenome(DEFAULT_3DARRAY_INITIALIZER,
 	 DEFAULT_3DARRAY_MUTATOR,
 	 DEFAULT_3DARRAY_COMPARATOR)
 {
@@ -44,7 +44,7 @@ GAGenome(DEFAULT_3DARRAY_INITIALIZER,
 }
 
 
-template <class T> 
+template <class T>
 GA3DArrayGenome<T>::
 GA3DArrayGenome(const GA3DArrayGenome<T> & orig) :
 GAArray<T>(orig.sz), GAGenome(){
@@ -78,7 +78,7 @@ GA3DArrayGenome<T>::clone(GAGenome::CloneMethod flag) const {
   }
   else{
     cpy->GAGenome::copy(*this);
-    cpy->minX = minX; cpy->minY = minY; cpy->minZ = minZ; 
+    cpy->minX = minX; cpy->minY = minY; cpy->minZ = minZ;
     cpy->maxX = maxX; cpy->maxY = maxY; cpy->maxZ = maxZ;
   }
   return cpy;
@@ -145,7 +145,7 @@ GA3DArrayGenome<T>::resize(int w, int h, int d)
 
   GAArray<T>::size(w*h*d);
 
-  if(w > STA_CAST(int,nx) && h > STA_CAST(int,ny)){ 
+  if(w > STA_CAST(int,nx) && h > STA_CAST(int,ny)){
     int z=GAMin(STA_CAST(int,nz),d);
     for(int k=z-1; k>=0; k--)
       for(int j=ny-1; j>=0; j--)
@@ -179,7 +179,7 @@ GA3DArrayGenome<T>::read(STD_ISTREAM &) {
 
 
 template <class T> int
-GA3DArrayGenome<T>::write(STD_OSTREAM & os) const 
+GA3DArrayGenome<T>::write(STD_OSTREAM & os) const
 {
   for(unsigned int k=0; k<nz; k++){
     for(unsigned int j=0; j<ny; j++){
@@ -216,7 +216,7 @@ GA3DArrayGenome<T>::resizeBehaviour(GAGenome::Dimension which) const {
 
 template <class T> int
 GA3DArrayGenome<T>::
-resizeBehaviour(GAGenome::Dimension which, 
+resizeBehaviour(GAGenome::Dimension which,
 		unsigned int lower, unsigned int upper)
 {
   if(upper < lower){
@@ -278,7 +278,7 @@ copy(const GA3DArrayGenome<T> & orig,
 }
 
 
-template <class T> int 
+template <class T> int
 GA3DArrayGenome<T>::equal(const GAGenome & c) const
 {
   if(this == &c) return 1;
@@ -312,7 +312,7 @@ GA3DArrayAlleleGenome<T>::className() const {return "GA3DArrayAlleleGenome";}
 template <class T> int
 GA3DArrayAlleleGenome<T>::classID() const {return GAID::ArrayAlleleGenome3D;}
 
-template <class T> 
+template <class T>
 GA3DArrayAlleleGenome<T>::
 GA3DArrayAlleleGenome(unsigned int w, unsigned int h, unsigned int d,
 		      const GAAlleleSet<T> & s,
@@ -328,7 +328,7 @@ GA3DArrayGenome<T>(w,h,d,f,u) {
   this->crossover(GA3DArrayAlleleGenome<T>::DEFAULT_3DARRAY_ALLELE_CROSSOVER);
 }
 
-template <class T> 
+template <class T>
 GA3DArrayAlleleGenome<T>::
 GA3DArrayAlleleGenome(unsigned int w, unsigned int h, unsigned int d,
 		      const GAAlleleSetArray<T> & sa,
@@ -346,9 +346,9 @@ GA3DArrayGenome<T>(w,h,d, f, u) {
 }
 
 
-template <class T> 
+template <class T>
 GA3DArrayAlleleGenome<T>::
-GA3DArrayAlleleGenome(const GA3DArrayAlleleGenome<T> & orig) : 
+GA3DArrayAlleleGenome(const GA3DArrayAlleleGenome<T> & orig) :
 GA3DArrayGenome<T>(orig.nx, orig.ny, orig.nz) {
   naset = 0;
   aset = (GAAlleleSet<T>*)0;
@@ -368,10 +368,10 @@ GA3DArrayAlleleGenome<T>::clone(GAGenome::CloneMethod) const {
 }
 
 
-template <class T> void 
+template <class T> void
 GA3DArrayAlleleGenome<T>::copy(const GAGenome& orig){
   if(&orig == this) return;
-  const GA3DArrayAlleleGenome<T>* c = 
+  const GA3DArrayAlleleGenome<T>* c =
     DYN_CAST(const GA3DArrayAlleleGenome<T>*, &orig);
   if(c) {
     GA3DArrayGenome<T>::copy(*c);
@@ -414,7 +414,7 @@ GA3DArrayAlleleGenome<T>::resize(int w, int h, int d){
     for(int k=z-1; k>=0; k--)
       for(int j=this->ny-1; j>=0; j--)
 	for(unsigned int i=oldx; i<this->nx; i++)
-	  this->a[k*this->ny*this->nx+j*this->nx+i] = 
+	  this->a[k*this->ny*this->nx+j*this->nx+i] =
 	    aset[(k*this->ny*this->nx+j*this->nx+i) % naset].allele();
   }
   else if(this->ny > oldy){
@@ -463,7 +463,7 @@ GA3DArrayAlleleGenome<T>::equal(const GAGenome & c) const {
    Operator definitions
 ---------------------------------------------------------------------------- */
 // this does not handle genomes with multiple allele sets!
-template <class ARRAY_TYPE> void 
+template <class ARRAY_TYPE> void
 GA3DArrayAlleleGenome<ARRAY_TYPE>::UniformInitializer(GAGenome & c)
 {
   GA3DArrayAlleleGenome<ARRAY_TYPE> &child=
@@ -476,12 +476,12 @@ GA3DArrayAlleleGenome<ARRAY_TYPE>::UniformInitializer(GAGenome & c)
 }
 
 
-template <class ARRAY_TYPE> int 
+template <class ARRAY_TYPE> int
 GA3DArrayAlleleGenome<ARRAY_TYPE>::FlipMutator(GAGenome & c, float pmut)
 {
   GA3DArrayAlleleGenome<ARRAY_TYPE> &child=
     DYN_CAST(GA3DArrayAlleleGenome<ARRAY_TYPE> &, c);
-  register int n, m, d, i, j, k;
+  int n, m, d, i, j, k;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.size());
@@ -512,11 +512,11 @@ GA3DArrayAlleleGenome<ARRAY_TYPE>::FlipMutator(GAGenome & c, float pmut)
 }
 
 
-template <class ARRAY_TYPE> int 
+template <class ARRAY_TYPE> int
 GA3DArrayGenome<ARRAY_TYPE>::SwapMutator(GAGenome & c, float pmut)
 {
   GA3DArrayGenome<ARRAY_TYPE> &child=DYN_CAST(GA3DArrayGenome<ARRAY_TYPE>&, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.size());
@@ -568,7 +568,7 @@ ElementComparator(const GAGenome& a, const GAGenome& b)
 
 
 
-// Make sure our bitmask is big enough, generate a mask, then use it to 
+// Make sure our bitmask is big enough, generate a mask, then use it to
 // extract the information from each parent to stuff the two children.
 // We don't deallocate any space for the masks under the assumption that we'll
 // have to use them again in the future.
@@ -680,12 +680,12 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
 //   This is designed only for genomes that are the same length.  If the child
 // is not the same length as the parent, or if the children are not the same
 // size, we don't do the crossover.
-//   In the interest of speed we do not do any checks for size.  Do not use 
+//   In the interest of speed we do not do any checks for size.  Do not use
 // this crossover method when the parents and children may be different sizes.
 // It might break!
 template <class T> int
 GA3DArrayGenome<T>::
-EvenOddCrossover(const GAGenome& p1, const GAGenome& p2, 
+EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
 GAGenome* c1, GAGenome* c2){
   const GA3DArrayGenome<T> &mom=DYN_CAST(const GA3DArrayGenome<T> &, p1);
   const GA3DArrayGenome<T> &dad=DYN_CAST(const GA3DArrayGenome<T> &, p2);
@@ -696,7 +696,7 @@ GAGenome* c1, GAGenome* c2){
   if(c1 && c2){
     GA3DArrayGenome<T> &sis=DYN_CAST(GA3DArrayGenome<T> &, *c1);
     GA3DArrayGenome<T> &bro=DYN_CAST(GA3DArrayGenome<T> &, *c2);
-    
+
     if(sis.width() == bro.width() && sis.height() == bro.height() &&
        sis.depth() == bro.depth() &&
        mom.width() == dad.width() && mom.height() == dad.height() &&
@@ -806,8 +806,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE){
-      if(mom.width() != dad.width() || 
-	 sis.width() != bro.width() || 
+      if(mom.width() != dad.width() ||
+	 sis.width() != bro.width() ||
 	 sis.width() != mom.width()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -828,11 +828,11 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitex = GAMin(momsitex, dadsitex);
       lenx = GAMin(momlenx, dadlenx);
     }
-    
+
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
-      if(mom.height() != dad.height() || 
-	 sis.height() != bro.height() || 
+      if(mom.height() != dad.height() ||
+	 sis.height() != bro.height() ||
 	 sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -856,8 +856,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE){
-      if(mom.depth() != dad.depth() || 
-	 sis.depth() != bro.depth() || 
+      if(mom.depth() != dad.depth() ||
+	 sis.depth() != bro.depth() ||
 	 sis.depth() != mom.depth()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -882,8 +882,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
     sis.resize(sitex+lenx, sitey+leny, sitez+lenz);
     bro.resize(sitex+lenx, sitey+leny, sitez+lenz);
 
-    sis.copy(mom, 
-	     0, 0, 0, 
+    sis.copy(mom,
+	     0, 0, 0,
 	     momsitex-sitex, momsitey-sitey, momsitez-sitez,
 	     sitex, sitey, sitez);
     sis.copy(dad,
@@ -898,8 +898,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	     sitex, sitey, 0,
 	     momsitex, momsitey, momsitez-sitez,
 	     lenx, leny, sitez);
-    sis.copy(dad, 
-	     0, 0, sitez, 
+    sis.copy(dad,
+	     0, 0, sitez,
 	     dadsitex-sitex, dadsitey-sitey, dadsitez,
 	     sitex, sitey, lenz);
     sis.copy(mom,
@@ -914,9 +914,9 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	     sitex, sitey, sitez,
 	     dadsitex, dadsitey, dadsitez,
 	     lenx, leny, lenz);
-    
-    bro.copy(dad, 
-	     0, 0, 0, 
+
+    bro.copy(dad,
+	     0, 0, 0,
 	     dadsitex-sitex, dadsitey-sitey, dadsitez-sitez,
 	     sitex, sitey, sitez);
     bro.copy(mom,
@@ -931,8 +931,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	     sitex, sitey, 0,
 	     dadsitex, dadsitey, dadsitez-sitez,
 	     lenx, leny, sitez);
-    bro.copy(mom, 
-	     0, 0, sitez, 
+    bro.copy(mom,
+	     0, 0, sitez,
 	     momsitex-sitex, momsitey-sitey, momsitez,
 	     sitex, sitey, lenz);
     bro.copy(dad,
@@ -969,7 +969,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitex = GAMin(momsitex, dadsitex);
       lenx = GAMin(momlenx, dadlenx);
     }
-    
+
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
       if(mom.height() != dad.height() || sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -1003,12 +1003,12 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitez = GAMin(momsitez, dadsitez);
       lenz = GAMin(momlenz, dadlenz);
     }
-    
+
     sis.resize(sitex+lenx, sitey+leny, sitez+lenz);
-    
+
     if(GARandomBit()){
-      sis.copy(mom, 
-	       0, 0, 0, 
+      sis.copy(mom,
+	       0, 0, 0,
 	       momsitex-sitex, momsitey-sitey, momsitez-sitez,
 	       sitex, sitey, sitez);
       sis.copy(dad,
@@ -1023,8 +1023,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	       sitex, sitey, 0,
 	       momsitex, momsitey, momsitez-sitez,
 	       lenx, leny, sitez);
-      sis.copy(dad, 
-	       0, 0, sitez, 
+      sis.copy(dad,
+	       0, 0, sitez,
 	       dadsitex-sitex, dadsitey-sitey, dadsitez,
 	       sitex, sitey, lenz);
       sis.copy(mom,
@@ -1041,8 +1041,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	       lenx, leny, lenz);
     }
     else{
-      sis.copy(dad, 
-	       0, 0, 0, 
+      sis.copy(dad,
+	       0, 0, 0,
 	       dadsitex-sitex, dadsitey-sitey, dadsitez-sitez,
 	       sitex, sitey, sitez);
       sis.copy(mom,
@@ -1057,8 +1057,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	       sitex, sitey, 0,
 	       dadsitex, dadsitey, dadsitez-sitez,
 	       lenx, leny, sitez);
-      sis.copy(mom, 
-	       0, 0, sitez, 
+      sis.copy(mom,
+	       0, 0, sitez,
 	       momsitex-sitex, momsitey-sitey, momsitez,
 	       sitex, sitey, lenz);
       sis.copy(dad,

--- a/Ideal_Transportation_MPFA/source/ga-mpi/GA3DBinStrGenome.C
+++ b/Ideal_Transportation_MPFA/source/ga-mpi/GA3DBinStrGenome.C
@@ -56,7 +56,7 @@ GA3DBinaryStringGenome::clone(GAGenome::CloneMethod flag) const {
   }
   else{
     cpy->GAGenome::copy(*this);
-    cpy->minX = minX; cpy->minY = minY; cpy->minZ = minZ; 
+    cpy->minX = minX; cpy->minY = minY; cpy->minZ = minZ;
     cpy->maxX = maxX; cpy->maxY = maxY; cpy->maxZ = maxZ;
   }
   return cpy;
@@ -66,7 +66,7 @@ void
 GA3DBinaryStringGenome::copy(const GAGenome & orig)
 {
   if(&orig == this) return;
-  const GA3DBinaryStringGenome* c = 
+  const GA3DBinaryStringGenome* c =
     DYN_CAST(const GA3DBinaryStringGenome*, &orig);
   if(c) {
     GAGenome::copy(*c);
@@ -206,7 +206,7 @@ GA3DBinaryStringGenome::read(STD_ISTREAM & is)
 
   _evaluated = gaFalse;
 
-  if(is.eof() && 
+  if(is.eof() &&
      ((k < nz) ||		// didn't get some lines
       (j < ny && j != 0) ||	// didn't get some lines
       (i < nx && i != 0))){	// didn't get some lines
@@ -219,10 +219,10 @@ GA3DBinaryStringGenome::read(STD_ISTREAM & is)
 }
 
 
-// Dump the bits to the stream with a newline at the end of each row and 
+// Dump the bits to the stream with a newline at the end of each row and
 // another at the end of each layer.  No newline at the end of the block.
 int
-GA3DBinaryStringGenome::write(STD_OSTREAM & os) const 
+GA3DBinaryStringGenome::write(STD_OSTREAM & os) const
 {
   for(unsigned int k=0; k<nz; k++){
     for(unsigned int j=0; j<ny; j++){
@@ -424,13 +424,13 @@ equal(const GA3DBinaryStringGenome& orig,
     for(unsigned int j=0; j<h; j++)
       eq += GABinaryString::equal(orig,
 				  (z+k)*ny*nx + (y+j)*nx + x,
-				  (srcz+k)*ny*nx + (srcy+j)*nx + srcx, 
+				  (srcz+k)*ny*nx + (srcy+j)*nx + srcx,
 				  w);
   return eq==d*h ? 1 : 0;
 }
 
 
-int 
+int
 GA3DBinaryStringGenome::equal(const GAGenome & c) const
 {
   if(this == &c) return 1;
@@ -459,7 +459,7 @@ GA3DBinaryStringGenome::equal(const GAGenome & c) const
 (ie depth loops before a single height increment, height loops before a single
 width increment)
 ---------------------------------------------------------------------------- */
-void 
+void
 GA3DBinaryStringGenome::UniformInitializer(GAGenome & c)
 {
   GA3DBinaryStringGenome &child=DYN_CAST(GA3DBinaryStringGenome &, c);
@@ -471,7 +471,7 @@ GA3DBinaryStringGenome::UniformInitializer(GAGenome & c)
 }
 
 
-void 
+void
 GA3DBinaryStringGenome::UnsetInitializer(GAGenome & c)
 {
   GA3DBinaryStringGenome &child=DYN_CAST(GA3DBinaryStringGenome &, c);
@@ -480,7 +480,7 @@ GA3DBinaryStringGenome::UnsetInitializer(GAGenome & c)
 }
 
 
-void 
+void
 GA3DBinaryStringGenome::SetInitializer(GAGenome & c)
 {
   GA3DBinaryStringGenome &child=DYN_CAST(GA3DBinaryStringGenome &, c);
@@ -489,11 +489,11 @@ GA3DBinaryStringGenome::SetInitializer(GAGenome & c)
 }
 
 
-int 
+int
 GA3DBinaryStringGenome::FlipMutator(GAGenome & c, float pmut)
 {
   GA3DBinaryStringGenome &child=DYN_CAST(GA3DBinaryStringGenome &, c);
-  register int n, m, i, j, k, d;
+  int n, m, i, j, k, d;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.size());
@@ -550,7 +550,7 @@ GA3DBinaryStringGenome::BitComparator(const GAGenome& a, const GAGenome& b){
 
 
 
-// Make sure our bitmask is big enough, generate a mask, then use it to 
+// Make sure our bitmask is big enough, generate a mask, then use it to
 // extract the information from each parent to stuff the two children.
 // We don't deallocate any space for the masks under the assumption that we'll
 // have to use them again in the future.
@@ -626,10 +626,10 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
     nc = 2;
   }
   else if(c1 || c2){
-    GA3DBinaryStringGenome &sis = (c1 ? 
-				   DYN_CAST(GA3DBinaryStringGenome&, *c1) : 
+    GA3DBinaryStringGenome &sis = (c1 ?
+				   DYN_CAST(GA3DBinaryStringGenome&, *c1) :
 				   DYN_CAST(GA3DBinaryStringGenome&, *c2));
-    
+
     if(mom.width() == dad.width() && mom.height() == dad.height() &&
        mom.depth() == dad.depth() &&
        sis.width() == mom.width() && sis.height() == mom.height() &&
@@ -665,7 +665,7 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
 //   This is designed only for genomes that are the same length.  If the child
 // is not the same length as the parent, or if the children are not the same
 // size, we don't do the crossover.
-//   In the interest of speed we do not do any checks for size.  Do not use 
+//   In the interest of speed we do not do any checks for size.  Do not use
 // this crossover method when the parents and children may be different sizes.
 // It might break!
 int
@@ -733,7 +733,7 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
   }
   else if(c1 || c2){
     GA3DBinaryStringGenome &sis = (c1 ?
-				   DYN_CAST(GA3DBinaryStringGenome &, *c1) : 
+				   DYN_CAST(GA3DBinaryStringGenome &, *c1) :
 				   DYN_CAST(GA3DBinaryStringGenome &, *c2));
 
     if(mom.width() == dad.width() && mom.height() == dad.height() &&
@@ -772,7 +772,7 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
 
 
 // Pick a single point in the 3D block and grab alternating quadrants for each
-// child.  If the children are resizable, this crossover does clipping or 
+// child.  If the children are resizable, this crossover does clipping or
 // padding depending on the setting of the clip flag.  If we pad, we fill the
 // additional bits with random contents.
 int
@@ -795,8 +795,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE){
-      if(mom.width() != dad.width() || 
-	 sis.width() != bro.width() || 
+      if(mom.width() != dad.width() ||
+	 sis.width() != bro.width() ||
 	 sis.width() != mom.width()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -817,11 +817,11 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitex = GAMin(momsitex, dadsitex);
       lenx = GAMin(momlenx, dadlenx);
     }
-    
+
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
-      if(mom.height() != dad.height() || 
-	 sis.height() != bro.height() || 
+      if(mom.height() != dad.height() ||
+	 sis.height() != bro.height() ||
 	 sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -842,11 +842,11 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitey = GAMin(momsitey, dadsitey);
       leny = GAMin(momleny, dadleny);
     }
-    
+
     if(sis.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE){
-      if(mom.depth() != dad.depth() || 
-	 sis.depth() != bro.depth() || 
+      if(mom.depth() != dad.depth() ||
+	 sis.depth() != bro.depth() ||
 	 sis.depth() != mom.depth()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -871,8 +871,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
     sis.resize(sitex+lenx, sitey+leny, sitez+lenz);
     bro.resize(sitex+lenx, sitey+leny, sitez+lenz);
 
-    sis.copy(mom, 
-	     0, 0, 0, 
+    sis.copy(mom,
+	     0, 0, 0,
 	     momsitex-sitex, momsitey-sitey, momsitez-sitez,
 	     sitex, sitey, sitez);
     sis.copy(dad,
@@ -887,8 +887,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	     sitex, sitey, 0,
 	     momsitex, momsitey, momsitez-sitez,
 	     lenx, leny, sitez);
-    sis.copy(dad, 
-	     0, 0, sitez, 
+    sis.copy(dad,
+	     0, 0, sitez,
 	     dadsitex-sitex, dadsitey-sitey, dadsitez,
 	     sitex, sitey, lenz);
     sis.copy(mom,
@@ -903,9 +903,9 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	     sitex, sitey, sitez,
 	     dadsitex, dadsitey, dadsitez,
 	     lenx, leny, lenz);
-    
-    bro.copy(dad, 
-	     0, 0, 0, 
+
+    bro.copy(dad,
+	     0, 0, 0,
 	     dadsitex-sitex, dadsitey-sitey, dadsitez-sitez,
 	     sitex, sitey, sitez);
     bro.copy(mom,
@@ -920,8 +920,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	     sitex, sitey, 0,
 	     dadsitex, dadsitey, dadsitez-sitez,
 	     lenx, leny, sitez);
-    bro.copy(mom, 
-	     0, 0, sitez, 
+    bro.copy(mom,
+	     0, 0, sitez,
 	     momsitex-sitex, momsitey-sitey, momsitez,
 	     sitex, sitey, lenz);
     bro.copy(dad,
@@ -936,7 +936,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	     sitex, sitey, sitez,
 	     momsitex, momsitey, momsitez,
 	     lenx, leny, lenz);
-    
+
     nc = 2;
   }
   else if(c1 || c2){
@@ -960,7 +960,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitex = GAMin(momsitex, dadsitex);
       lenx = GAMin(momlenx, dadlenx);
     }
-    
+
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
       if(mom.height() != dad.height() || sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -977,7 +977,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitey = GAMin(momsitey, dadsitey);
       leny = GAMin(momleny, dadleny);
     }
-    
+
     if(sis.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE){
       if(mom.depth() != dad.depth() || sis.depth() != mom.depth()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -998,8 +998,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
     sis.resize(sitex+lenx, sitey+leny, sitez+lenz);
 
     if(GARandomBit()){
-      sis.copy(mom, 
-	       0, 0, 0, 
+      sis.copy(mom,
+	       0, 0, 0,
 	       momsitex-sitex, momsitey-sitey, momsitez-sitez,
 	       sitex, sitey, sitez);
       sis.copy(dad,
@@ -1014,8 +1014,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	       sitex, sitey, 0,
 	       momsitex, momsitey, momsitez-sitez,
 	       lenx, leny, sitez);
-      sis.copy(dad, 
-	       0, 0, sitez, 
+      sis.copy(dad,
+	       0, 0, sitez,
 	       dadsitex-sitex, dadsitey-sitey, dadsitez,
 	       sitex, sitey, lenz);
       sis.copy(mom,
@@ -1032,8 +1032,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	       lenx, leny, lenz);
     }
     else{
-      sis.copy(dad, 
-	       0, 0, 0, 
+      sis.copy(dad,
+	       0, 0, 0,
 	       dadsitex-sitex, dadsitey-sitey, dadsitez-sitez,
 	       sitex, sitey, sitez);
       sis.copy(mom,
@@ -1048,8 +1048,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	       sitex, sitey, 0,
 	       dadsitex, dadsitey, dadsitez-sitez,
 	       lenx, leny, sitez);
-      sis.copy(mom, 
-	       0, 0, sitez, 
+      sis.copy(mom,
+	       0, 0, sitez,
 	       momsitex-sitex, momsitey-sitey, momsitez,
 	       sitex, sitey, lenz);
       sis.copy(dad,

--- a/Ideal_Transportation_MPFA/source/ga-mpi/GAListGenome.C
+++ b/Ideal_Transportation_MPFA/source/ga-mpi/GAListGenome.C
@@ -17,7 +17,7 @@
 #include <ga-mpi/GAMask.h>
 #include <ga-mpi/garandom.h>
 
-template <class T> int 
+template <class T> int
 GAListIsHole(const GAListGenome<T>&, const GAListGenome<T>&, int, int, int);
 
 
@@ -30,8 +30,8 @@ GAListGenome<T>::className() const {return "GAListGenome";}
 template <class T> int
 GAListGenome<T>::classID() const {return GAID::ListGenome;}
 
-template <class T> 
-GAListGenome<T>::GAListGenome(GAGenome::Evaluator f, void * u) : 
+template <class T>
+GAListGenome<T>::GAListGenome(GAGenome::Evaluator f, void * u) :
 GAList<T>(),
 GAGenome(DEFAULT_LIST_INITIALIZER,
 	 DEFAULT_LIST_MUTATOR,
@@ -42,8 +42,8 @@ GAGenome(DEFAULT_LIST_INITIALIZER,
 }
 
 
-template <class T> 
-GAListGenome<T>::GAListGenome(const GAListGenome<T> & orig) : 
+template <class T>
+GAListGenome<T>::GAListGenome(const GAListGenome<T> & orig) :
 GAList<T>(),
 GAGenome() {
   GAListGenome<T>::copy(orig);
@@ -76,10 +76,10 @@ GAListGenome<T>::copy(const GAGenome & orig){
 
 #ifdef GALIB_USE_STREAMS
 // Traverse the list (breadth-first) and dump the contents as best we can to
-// the stream.  We don't try to write the contents of the nodes - we simply 
+// the stream.  We don't try to write the contents of the nodes - we simply
 // write a . for each node in the list.
 template <class T> int
-GAListGenome<T>::write(STD_OSTREAM & os) const 
+GAListGenome<T>::write(STD_OSTREAM & os) const
 {
   os << "node       next       prev       contents\n";
   if(!this->hd) return 0;;
@@ -105,7 +105,7 @@ GAListGenome<T>::write(STD_OSTREAM & os) const
 // then you have nothing to worry about.
 //   Neither of these operators affects the internal iterator of either
 // list genome in any way.
-template <class T> int 
+template <class T> int
 GAListGenome<T>::equal(const GAGenome & c) const
 {
   if(this == &c) return 1;
@@ -136,14 +136,14 @@ GAListGenome<T>::equal(const GAGenome & c) const
 ---------------------------------------------------------------------------- */
 // Mutate a list by nuking nodes.  Any node has a pmut chance of getting nuked.
 // This is actually kind of bogus for the second part of the if clause (if nMut
-// is greater than or equal to 1).  Nodes end up having more than pmut 
+// is greater than or equal to 1).  Nodes end up having more than pmut
 // probability of getting nuked.
 //   After the mutation the iterator is left at the head of the list.
 template <class T> int
 GAListGenome<T>::DestructiveMutator(GAGenome & c, float pmut)
 {
   GAListGenome<T> &child=DYN_CAST(GAListGenome<T> &, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return 0;
 
   n = child.size();
@@ -171,14 +171,14 @@ GAListGenome<T>::DestructiveMutator(GAGenome & c, float pmut)
 
 // Mutate a list by swapping two nodes.  Any node has a pmut chance of getting
 // swapped, and the swap could happen to any other node.  And in the case of
-// nMut < 1, the swap may generate a swap partner that is the same node, in 
+// nMut < 1, the swap may generate a swap partner that is the same node, in
 // which case no swap occurs (we don't check).
 //   After the mutation the iterator is left at the head of the list.
 template <class T> int
 GAListGenome<T>::SwapMutator(GAGenome & c, float pmut)
 {
   GAListGenome<T> &child=DYN_CAST(GAListGenome<T> &, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return 0;
 
   n = child.size();
@@ -205,7 +205,7 @@ GAListGenome<T>::SwapMutator(GAGenome & c, float pmut)
 
 // This comparator returns the number of elements that the two lists have
 // in common (both in position and in value).  If they are different lengths
-// then we just say they are completely different.  This is probably barely 
+// then we just say they are completely different.  This is probably barely
 // adequate for most applications - we really should give more credit for
 // nodes that are the same but in different positions.  But that would be
 // pretty nasty to compute.
@@ -213,7 +213,7 @@ GAListGenome<T>::SwapMutator(GAGenome & c, float pmut)
 // which to compare this diversity measure.  Its kind of hard to define this
 // one in a general way...
 template <class T> float
-GAListGenome<T>::NodeComparator(const GAGenome& a, const GAGenome& b) 
+GAListGenome<T>::NodeComparator(const GAGenome& a, const GAGenome& b)
 {
   if(&a == &b) return 0;
   const GAListGenome<T>& sis=DYN_CAST(const GAListGenome<T>&, a);
@@ -244,7 +244,7 @@ GAListGenome<T>::NodeComparator(const GAGenome& a, const GAGenome& b)
 
 #define SWAP(a,b) {unsigned int tmp=a; a=b; b=tmp;}
 
-// This crossover picks a site between nodes in each parent.  It is the same 
+// This crossover picks a site between nodes in each parent.  It is the same
 // as single point crossover on a resizeable binary string genome.  The site
 // in the mother is not necessarily the same as the site in the father!
 //   When we pick a crossover site, it is between nodes of the list (otherwise
@@ -253,7 +253,7 @@ GAListGenome<T>::NodeComparator(const GAGenome& a, const GAGenome& b)
 // whereas the cross site possibilities are numbered from 0 to size, inclusive.
 // This means we have to map the site to the list to determine whether an
 // insertion should occur before or after a node.
-//   We first copy the mother into the child (this deletes whatever contents 
+//   We first copy the mother into the child (this deletes whatever contents
 // were in the child originally).  Then we clone the father from the cross site
 // to the end of the list.  Then we delete the tail of the child from the
 // mother's cross site to the end of the list.  Finally, we insert the clone
@@ -265,7 +265,7 @@ GAListGenome<T>::NodeComparator(const GAGenome& a, const GAGenome& b)
 // do better by copying only what we need of the mother.
 template <class T> int
 GAListGenome<T>::
-OnePointCrossover(const GAGenome& p1, const GAGenome& p2, 
+OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 		  GAGenome* c1, GAGenome* c2){
   const GAListGenome<T> &mom=DYN_CAST(const GAListGenome<T> &, p1);
   const GAListGenome<T> &dad=DYN_CAST(const GAListGenome<T> &, p2);
@@ -330,13 +330,13 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 //   This version of the partial match crossover uses objects that are multiply
 // instantiated - each list genome contains its own objects in its nodes.
 // The operator== method must be defined on the object for this implementation
-// to work!  In this case, the 'object' is an int, so we're OK.  If you are 
+// to work!  In this case, the 'object' is an int, so we're OK.  If you are
 // putting your own objects in the nodes, be sure you have operator== defined
 // for your object.  You must also have operator!= defined for your object.  We
 // do not do any assignments, so operator= and/or copy is not required.
 //   We assume that none of the nodes will return a NULL pointer.  Also assume
 // that the cross site has been selected properly.
-//   First we make a copy of the mother.  Then we loop through the match 
+//   First we make a copy of the mother.  Then we loop through the match
 // section and try to swap each element in the child's match section with its
 // partner (as defined by the current node in the father's match section).
 //   Mirroring will work the same way - just swap mom & dad and you're all set.

--- a/Ideal_Transportation_MPFA/source/ga-mpi/GARealGenome.C
+++ b/Ideal_Transportation_MPFA/source/ga-mpi/GARealGenome.C
@@ -13,7 +13,7 @@
 
 // We must also specialize the allele set so that the alleles are handled
 // properly.  Be sure to handle bounds correctly whether we are discretized
-// or continuous.  Handle the case where someone sets stupid bounds that 
+// or continuous.  Handle the case where someone sets stupid bounds that
 // might cause an infinite loop for exclusive bounds.
 template <> float
 GAAlleleSet<float>::allele() const {
@@ -29,8 +29,8 @@ GAAlleleSet<float>::allele() const {
     if(core->lowerb == GAAllele::EXCLUSIVE) value += core->a[2];
   }
   else{
-    if(core->a[0] == core->a[1] && 
-       core->lowerb == GAAllele::EXCLUSIVE && 
+    if(core->a[0] == core->a[1] &&
+       core->lowerb == GAAllele::EXCLUSIVE &&
        core->upperb == GAAllele::EXCLUSIVE) {
       value = core->a[0];
     }
@@ -74,9 +74,9 @@ GAAlleleSet<float>::allele(unsigned int i) const {
 
 // now the specialization of the genome itself.
 
-template <> const char * 
+template <> const char *
 GA1DArrayAlleleGenome<float>::className() const {return "GARealGenome";}
-template <> int 
+template <> int
 GA1DArrayAlleleGenome<float>::classID() const {return GAID::FloatGenome;}
 
 template <> GA1DArrayAlleleGenome<float>::
@@ -108,7 +108,7 @@ GA1DArrayGenome<float>(sa.size(), f, u){
   crossover(DEFAULT_REAL_CROSSOVER);
 }
 
-template <> 
+template <>
 GA1DArrayAlleleGenome<float>::~GA1DArrayAlleleGenome(){
   delete [] aset;
 }
@@ -148,12 +148,12 @@ GA1DArrayAlleleGenome<float>::read(STD_ISTREAM & is) {
 ---------------------------------------------------------------------------- */
 // The Gaussian mutator picks a new value based on a Gaussian distribution
 // around the current value.  We respect the bounds (if any).
-//*** need to figure out a way to make the stdev other than 1.0 
-int 
+//*** need to figure out a way to make the stdev other than 1.0
+int
 GARealGaussianMutator(GAGenome& g, float pmut){
   GA1DArrayAlleleGenome<float> &child=
     DYN_CAST(GA1DArrayAlleleGenome<float> &, g);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * (float)(child.length());
@@ -200,7 +200,7 @@ GARealGaussianMutator(GAGenome& g, float pmut){
 // identical.  If parents are not the same length, the extra elements are not
 // set!  You might want to add some noise to this so that both children are not
 // the same...
-int 
+int
 GARealArithmeticCrossover(const GAGenome& p1, const GAGenome& p2,
 			  GAGenome* c1, GAGenome* c2) {
   const GA1DArrayGenome<float> &mom=
@@ -222,8 +222,8 @@ GARealArithmeticCrossover(const GAGenome& p1, const GAGenome& p2,
     n = 2;
   }
   else if(c1 || c2){
-    GA1DArrayGenome<float> &sis = (c1 ? 
-				   DYN_CAST(GA1DArrayGenome<float> &, *c1) : 
+    GA1DArrayGenome<float> &sis = (c1 ?
+				   DYN_CAST(GA1DArrayGenome<float> &, *c1) :
 				   DYN_CAST(GA1DArrayGenome<float> &, *c2));
 
     int len = GAMax(mom.length(), dad.length());
@@ -240,7 +240,7 @@ GARealArithmeticCrossover(const GAGenome& p1, const GAGenome& p2,
 // Blend crossover generates a new value based on the interval between parents.
 // We generate a uniform distribution based on the distance between parent
 // values, then choose the child value based upon that distribution.
-int 
+int
 GARealBlendCrossover(const GAGenome& p1, const GAGenome& p2,
 		     GAGenome* c1, GAGenome* c2) {
   const GA1DArrayGenome<float> &mom=
@@ -257,9 +257,9 @@ GARealBlendCrossover(const GAGenome& p1, const GAGenome& p2,
     int len = GAMax(mom.length(), dad.length());
     for(int i=0; i<len; i++) {
       float dist = 0;
-      if(mom.gene(i) > dad.gene(i)) 
+      if(mom.gene(i) > dad.gene(i))
 	dist = mom.gene(i) - dad.gene(i);
-      else 
+      else
 	dist = dad.gene(i) - mom.gene(i);
       float lo = (GAMin(mom.gene(i), dad.gene(i))) - 0.5*dist;
       float hi = (GAMax(mom.gene(i), dad.gene(i))) + 0.5*dist;
@@ -276,9 +276,9 @@ GARealBlendCrossover(const GAGenome& p1, const GAGenome& p2,
     int len = GAMax(mom.length(), dad.length());
     for(int i=0; i<len; i++) {
       float dist = 0;
-      if(mom.gene(i) > dad.gene(i)) 
+      if(mom.gene(i) > dad.gene(i))
 	dist = mom.gene(i) - dad.gene(i);
-      else 
+      else
 	dist = dad.gene(i) - mom.gene(i);
       float lo = (GAMin(mom.gene(i), dad.gene(i))) - 0.5*dist;
       float hi = (GAMax(mom.gene(i), dad.gene(i))) + 0.5*dist;
@@ -298,7 +298,7 @@ GARealBlendCrossover(const GAGenome& p1, const GAGenome& p2,
 //
 // These must be included _after_ the specializations because some compilers
 // get all wigged out about the declaration/specialization order.  Note that
-// some compilers require a syntax different than others when forcing the 
+// some compilers require a syntax different than others when forcing the
 // instantiation (i.e. GNU wants the 'template class', borland does not).
 #ifndef GALIB_USE_AUTO_INST
 #include <ga-mpi/GAAllele.C>

--- a/Ideal_Transportation_MPFA/source/ga-mpi/GATreeGenome.C
+++ b/Ideal_Transportation_MPFA/source/ga-mpi/GATreeGenome.C
@@ -25,7 +25,7 @@ template <class T> int
 GATreeGenome<T>::classID() const {return GAID::TreeGenome;}
 
 template <class T>
-GATreeGenome<T>::GATreeGenome(GAGenome::Evaluator f, void * u) : 
+GATreeGenome<T>::GATreeGenome(GAGenome::Evaluator f, void * u) :
 GATree<T>(),
 GAGenome(DEFAULT_TREE_INITIALIZER,
 	 DEFAULT_TREE_MUTATOR,
@@ -37,7 +37,7 @@ GAGenome(DEFAULT_TREE_INITIALIZER,
 
 
 template <class T>
-GATreeGenome<T>::GATreeGenome(const GATreeGenome<T> & orig) : 
+GATreeGenome<T>::GATreeGenome(const GATreeGenome<T> & orig) :
 GATree<T>(),
 GAGenome() {
   GATreeGenome<T>::copy(orig);
@@ -70,7 +70,7 @@ GATreeGenome<T>::copy(const GAGenome & orig) {
 
 #ifdef GALIB_USE_STREAMS
 // Traverse the tree (breadth-first) and dump the contents as best we can to
-// the stream.  We don't try to write the contents of the nodes - we simply 
+// the stream.  We don't try to write the contents of the nodes - we simply
 // write a . for each node in the tree.
 //   We allocate space for x,y coord pair for each node in the tree.  Then we
 // do a depth-first traversal of the tree and assign coords to the nodes in the
@@ -102,7 +102,7 @@ _tt(STD_OSTREAM & os, GANode<T> * n)
 }
 
 template <class T> int
-GATreeGenome<T>::write(STD_OSTREAM & os) const 
+GATreeGenome<T>::write(STD_OSTREAM & os) const
 {
   os << "node       parent     child      next       prev       contents\n";
   _tt(os, (GANode<T> *)(this->rt));
@@ -111,7 +111,7 @@ GATreeGenome<T>::write(STD_OSTREAM & os) const
 #endif
 
 
-template <class T> int  
+template <class T> int
 GATreeGenome<T>::equal(const GAGenome & c) const
 {
   if(this == &c) return 1;
@@ -140,7 +140,7 @@ template <class T> int
 GATreeGenome<T>::DestructiveMutator(GAGenome & c, float pmut)
 {
   GATreeGenome<T> &child=DYN_CAST(GATreeGenome<T> &, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return 0;
 
   n = child.size();
@@ -169,14 +169,14 @@ GATreeGenome<T>::DestructiveMutator(GAGenome & c, float pmut)
 // This is a rearranging mutation operator.  It randomly picks two nodes in the
 // tree and swaps them.  Any node has a pmut chance of getting
 // swapped, and the swap could happen to any other node.  And in the case of
-// nMut < 1, the swap may generate a swap partner that is the same node, in 
+// nMut < 1, the swap may generate a swap partner that is the same node, in
 // which case no swap occurs (we don't check).
 //   After the mutation the iterator is left at the root of the tree.
 template <class T> int
 GATreeGenome<T>::SwapNodeMutator(GAGenome & c, float pmut)
 {
   GATreeGenome<T> &child=DYN_CAST(GATreeGenome<T> &, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return 0;
 
   n = child.size();
@@ -214,7 +214,7 @@ template <class T> int
 GATreeGenome<T>::SwapSubtreeMutator(GAGenome & c, float pmut)
 {
   GATreeGenome<T> &child=DYN_CAST(GATreeGenome<T> &, c);
-  register int n, i;
+  int n, i;
   int a, b;
   if(pmut <= 0.0) return 0;
 
@@ -247,7 +247,7 @@ GATreeGenome<T>::SwapSubtreeMutator(GAGenome & c, float pmut)
 // We use the recursive tree function to compare the tree structures.  This
 // does not compare the contents of the nodes.
 template <class T> float
-GATreeGenome<T>::TopologyComparator(const GAGenome& a, const GAGenome& b) 
+GATreeGenome<T>::TopologyComparator(const GAGenome& a, const GAGenome& b)
 {
   if(&a == &b) return 0;
   const GATreeGenome<T>& sis=DYN_CAST(const GATreeGenome<T>&, a);
@@ -277,7 +277,7 @@ GATreeGenome<T>::TopologyComparator(const GAGenome& a, const GAGenome& b)
 //     do the check to see if the crossover site is valid.
 template <class T> int
 GATreeGenome<T>::
-OnePointCrossover(const GAGenome& p1, const GAGenome& p2, 
+OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 		  GAGenome* c1, GAGenome* c2){
   const GATreeGenome<T> &mom=DYN_CAST(const GATreeGenome<T> &, p1);
   const GATreeGenome<T> &dad=DYN_CAST(const GATreeGenome<T> &, p2);

--- a/Static_MPFA/source/evolver.cpp
+++ b/Static_MPFA/source/evolver.cpp
@@ -11,7 +11,7 @@
 // For shared memory management
 #include <sys/mman.h>
 
-#include <ctime> // For clock()
+#include <ctime>  // For clock()
 #include <chrono> // For clock()
 #include <mpi.h>
 
@@ -31,12 +31,12 @@
 #include <source/CPFA/CPFA_loop_functions.h>
 
 // For timing
-#include <ctime> // For clock()
+#include <ctime>  // For clock()
 #include <chrono> // For clock()
 
 // For shared variable between child and parent process
-#include  <sys/ipc.h>
-#include  <sys/shm.h>
+#include <sys/ipc.h>
+#include <sys/shm.h>
 
 float objective(GAGenome &);
 float LaunchARGoS(GAGenome &);
@@ -44,11 +44,11 @@ float LaunchARGoS(GAGenome &);
 int mpi_tasks, mpi_rank;
 
 int elitism = 0;
-int n_trials = 20; // used by the objective function
+int n_trials = 20;            // used by the objective function
 double mutation_stdev = 1.00; // Gaussian mutation stdev - will be scaled by possible range
 string experiment_path;
 
-void CPFAInitializer(GAGenome & c);
+void CPFAInitializer(GAGenome &c);
 int GARealGaussianMutatorStdev(GAGenome &, float);
 
 std::default_random_engine generator;
@@ -62,125 +62,124 @@ int main(int argc, char **argv)
   MPI_Init(&argc, &argv);
   MPI_Comm_size(MPI_COMM_WORLD, &mpi_tasks);
   MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
-                         
-  char hostname[1024];                                                                                                       
-  hostname[1023] = '\0';                                          
+
+  char hostname[1024];
+  hostname[1023] = '\0';
   gethostname(hostname, 1023);
-  
+
   double mutation_rate = 0.01;
   double crossover_rate = 0.01;
   int population_size = 10;
   int n_generations = 10;
 
-    char c='h';
+  char c = 'h';
   // Handle command line arguments
-  while ((c = getopt (argc, argv, "t:g:p:c:m:s:h:e:x:")) != -1)
+  while ((c = getopt(argc, argv, "t:g:p:c:m:s:h:e:x:")) != -1)
     switch (c)
-      {
-      case 'x':
-	experiment_path = optarg;
+    {
+    case 'x':
+      experiment_path = optarg;
       break;
-      case 't':
-	n_trials = atoi(optarg);
-	break;
-      case 'g':
-        n_generations = atoi(optarg);
-        break;
-      case 'p':
-        population_size = atoi(optarg);
-        break;
-      case 'm':
-        mutation_rate = strtod(optarg, NULL);
-	break;
-      case 'c':
-	crossover_rate = strtod(optarg, NULL);
-	break;
-      case 's':
-        mutation_stdev = strtod(optarg, NULL);
-	break;
-      case 'e':
-        elitism = atoi(optarg);
-	break;
-      case 'h':
-	printf("Usage: %s -p {population size} -g {number of generations} -t {number of trials} -c {crossover rate} -m {mutation rate} -s {mutation standard deviation} -e {elitism 0 or 1}", argv[0]);
-	break;
-      case '?':
-        if (optopt == 'p')
-          fprintf (stderr, "Option -%c requires an argument specifying the population size.\n", optopt);
-	else if (optopt == 'g')
-	  fprintf (stderr, "Option -%c requires an argument specifying the number of generations.\n", optopt);
-	else if (optopt == 't')
-	  fprintf (stderr, "Option -%c requires an argument specifying the number of trials.\n", optopt);
-	else if (optopt == 'c')
-	  fprintf (stderr, "Option -%c requires an argument specifying the crossover rate.\n", optopt);
-	else if (optopt == 'm')
-	  fprintf (stderr, "Option -%c requires an argument specifying the mutation rate.\n", optopt);
-	else if (optopt == 's')
-	  fprintf (stderr, "Option -%c requires an argument specifying the mutation standard deviation.\n", optopt);
-        else if (isprint (optopt))
-          fprintf (stderr, "Unknown option `-%c'.\n", optopt);
-        else
-          fprintf (stderr,
-                   "Unknown option character `\\x%x'.\n",
-                   optopt);
-        return 1;
-      default:
-	printf("Usage: %s -p {population size} -g {number of generations} -t {number of trials} -c {crossover rate} -m {mutation rate} -s {mutation standard deviation}", argv[0]);
-        abort ();
-      }
+    case 't':
+      n_trials = atoi(optarg);
+      break;
+    case 'g':
+      n_generations = atoi(optarg);
+      break;
+    case 'p':
+      population_size = atoi(optarg);
+      break;
+    case 'm':
+      mutation_rate = strtod(optarg, NULL);
+      break;
+    case 'c':
+      crossover_rate = strtod(optarg, NULL);
+      break;
+    case 's':
+      mutation_stdev = strtod(optarg, NULL);
+      break;
+    case 'e':
+      elitism = atoi(optarg);
+      break;
+    case 'h':
+      printf("Usage: %s -p {population size} -g {number of generations} -t {number of trials} -c {crossover rate} -m {mutation rate} -s {mutation standard deviation} -e {elitism 0 or 1}", argv[0]);
+      break;
+    case '?':
+      if (optopt == 'p')
+        fprintf(stderr, "Option -%c requires an argument specifying the population size.\n", optopt);
+      else if (optopt == 'g')
+        fprintf(stderr, "Option -%c requires an argument specifying the number of generations.\n", optopt);
+      else if (optopt == 't')
+        fprintf(stderr, "Option -%c requires an argument specifying the number of trials.\n", optopt);
+      else if (optopt == 'c')
+        fprintf(stderr, "Option -%c requires an argument specifying the crossover rate.\n", optopt);
+      else if (optopt == 'm')
+        fprintf(stderr, "Option -%c requires an argument specifying the mutation rate.\n", optopt);
+      else if (optopt == 's')
+        fprintf(stderr, "Option -%c requires an argument specifying the mutation standard deviation.\n", optopt);
+      else if (isprint(optopt))
+        fprintf(stderr, "Unknown option `-%c'.\n", optopt);
+      else
+        fprintf(stderr,
+                "Unknown option character `\\x%x'.\n",
+                optopt);
+      return 1;
+    default:
+      printf("Usage: %s -p {population size} -g {number of generations} -t {number of trials} -c {crossover rate} -m {mutation rate} -s {mutation standard deviation}", argv[0]);
+      abort();
+    }
 
   if (experiment_path.empty())
-    {
-      printf("Usage: %s -p {population size} -g {number of generations} -t {number of trials} -c {crossover rate} -m {mutation rate} -s {mutation standard deviation} -x {argos experiment file}\n", argv[0]);
-      exit(1);
-    }
+  {
+    printf("Usage: %s -p {population size} -g {number of generations} -t {number of trials} -c {crossover rate} -m {mutation rate} -s {mutation standard deviation} -x {argos experiment file}\n", argv[0]);
+    exit(1);
+  }
 
   float max_float = std::numeric_limits<float>::max();
 
-    //printf("%s:\tworker %d ready.\n", hostname, mpi_rank);                                          
+  // printf("%s:\tworker %d ready.\n", hostname, mpi_rank);
 
   // See if we've been given a seed to use (for testing purposes).  When you
   // specify a random seed, the evolution will be exactly the same each time
   // you use that seed number
   unsigned int seed = 12345;
-  for(int i=1 ; i<argc ; i++)
-    if(strcmp(argv[i++],"seed") == 0)
+  for (int i = 1; i < argc; i++)
+    if (strcmp(argv[i++], "seed") == 0)
       seed = atoi(argv[i]);
 
   srand(seed);
   generator.seed(seed);
   // popsize / mpi_tasks must be an integer
-  population_size = mpi_tasks * int((double)population_size/(double)mpi_tasks+0.999);
-  
-  if (mpi_rank==0)
-    {
-      printf("Population size: %d\nNumber of trials: %d\nNumber of generations: %d\nCrossover rate: %f\nMutation rate: %f\nMutation stdev: %f\nAllocated MPI workers: %d\n", population_size, n_trials, n_generations, crossover_rate, mutation_rate, mutation_stdev, mpi_tasks);
-      	printf("elitism: %d\n", elitism);
-    }
+  population_size = mpi_tasks * int((double)population_size / (double)mpi_tasks + 0.999);
+
+  if (mpi_rank == 0)
+  {
+    printf("Population size: %d\nNumber of trials: %d\nNumber of generations: %d\nCrossover rate: %f\nMutation rate: %f\nMutation stdev: %f\nAllocated MPI workers: %d\n", population_size, n_trials, n_generations, crossover_rate, mutation_rate, mutation_stdev, mpi_tasks);
+    printf("elitism: %d\n", elitism);
+  }
 
   // Define the genome
   GARealAlleleSetArray allele_array;
-  
-  allele_array.add(0, 1.0); // Probability of switching to search
-  allele_array.add(0, 1.0); // Probability of returning to nest
-  allele_array.add(0, 4*M_PI); // Uninformed search variation
-  allele_array.add(0, 20); // Rate of informed search decay
-  allele_array.add(0, 20); // Rate of site fidelity
-  allele_array.add(0, 20); // Rate of laying pheremone
-  allele_array.add(0, 20); // Rate of pheremone decay
-  
-    
+
+  allele_array.add(0, 1.0);      // Probability of switching to search
+  allele_array.add(0, 1.0);      // Probability of returning to nest
+  allele_array.add(0, 4 * M_PI); // Uninformed search variation
+  allele_array.add(0, 20);       // Rate of informed search decay
+  allele_array.add(0, 20);       // Rate of site fidelity
+  allele_array.add(0, 20);       // Rate of laying pheremone
+  allele_array.add(0, 20);       // Rate of pheremone decay
+
   // Create the template genome using the phenotype map we just made.
   GARealGenome genome(allele_array, objective);
   genome.crossover(GARealUniformCrossover);
   genome.mutator(GARealGaussianMutatorStdev); // Specify our version of the Gaussuan mutator
   genome.initializer(CPFAInitializer);
- 
+
   // Now create the GA using the genome and run it.
   GASimpleGA ga(genome);
   GALinearScaling scaling;
-  ga.maximize();		// Maximize the objective
- 
+  ga.maximize(); // Maximize the objective
+
   ga.populationSize(population_size);
   ga.nGenerations(n_generations);
   ga.pMutation(mutation_rate);
@@ -190,7 +189,7 @@ int main(int argc, char **argv)
     ga.elitist(gaTrue);
   else
     ga.elitist(gaFalse);
-  if(mpi_rank == 0)
+  if (mpi_rank == 0)
     ga.scoreFilename("evolution.txt");
   else
     ga.scoreFilename("/dev/null");
@@ -198,338 +197,363 @@ int main(int argc, char **argv)
   ga.scoreFrequency(1);
   ga.flushFrequency(1);
   ga.selectScores(GAStatistics::AllScores);
-  
+
   // Pass MPI data to the GA class
   ga.mpi_rank(mpi_rank);
   ga.mpi_tasks(mpi_tasks);
-  //ga.evolve(seed); // Manual generations
+  // ga.evolve(seed); // Manual generations
 
-// initialize the ga since we are not using the evolve function
+  // initialize the ga since we are not using the evolve function
   ga.initialize(seed); // This is essential for the mpi workers to be sychronized
 
-    // Name the results file with the current time and date
- time_t t = time(0);   // get time now
-    struct tm * now = localtime( & t );
-    stringstream ss;
+  // Name the results file with the current time and date
+  time_t t = time(0); // get time now
+  struct tm *now = localtime(&t);
+  stringstream ss;
 
-    boost::filesystem::path exp_path(experiment_path);
-    
-    ss << "results/CPFA-evolution-"
-       << exp_path.stem().string() << '-'
-       <<GIT_BRANCH<<"-"<<GIT_COMMIT_HASH<<"-"
-       << (now->tm_year) << '-'
-       << (now->tm_mon + 1) << '-'
-       <<  now->tm_mday << '-'
-       <<  now->tm_hour << '-'
-       <<  now->tm_min << '-'
-       <<  now->tm_sec << ".csv";
+  boost::filesystem::path exp_path(experiment_path);
 
-    string results_file_name = ss.str();
+  ss << "results/CPFA-evolution-"
+     << exp_path.stem().string() << '-'
+     << GIT_BRANCH << "-" << GIT_COMMIT_HASH << "-"
+     << (now->tm_year) << '-'
+     << (now->tm_mon + 1) << '-'
+     << now->tm_mday << '-'
+     << now->tm_hour << '-'
+     << now->tm_min << '-'
+     << now->tm_sec << ".csv";
 
-    if (mpi_rank == 0)
-      {
+  string results_file_name = ss.str();
+
+  if (mpi_rank == 0)
+  {
     // Write output file header
     ofstream results_output_stream;
-	results_output_stream.open(results_file_name, ios::app);
-	results_output_stream << "Population size: " << population_size << "\nNumber of trials: " << n_trials << "\nNumber of generations: "<< n_generations<<"\nCrossover rate: "<< crossover_rate<<"\nMutation rate: " << mutation_rate << "\nMutation stdev: "<< mutation_stdev << "Algorithm: CPFA\n" << "Number of searchers: 6\n" << "Number of targets: 256\n" << "Target distribution: power law" << endl;
-	results_output_stream << "Generation" 
-			      << ", " << "Compute Time (s)"
-			      << ", " << "Convergence"
-			      << ", " << "Mean"
-			      << ", " << "Maximum"
-			      << ", " << "Minimum"
-			      << ", " << "Standard Deviation"
-			      << ", " << "Diversity"
-			      << ", " << "ProbabilityOfSwitchingToSearching"
-			      << ", " << "ProbabilityOfReturningToNest"
-			      << ", " << "UninformedSearchVariation"
-			      << ", " << "RateOfInformedSearchDecay"
-			      << ", " << "RateOfSiteFidelity"
-			      << ", " << "RateOfLayingPheromone"
-			      << ", " << "RateOfPheromoneDecay";
+    results_output_stream.open(results_file_name, ios::app);
+    results_output_stream << "Population size: " << population_size << "\nNumber of trials: " << n_trials << "\nNumber of generations: " << n_generations << "\nCrossover rate: " << crossover_rate << "\nMutation rate: " << mutation_rate << "\nMutation stdev: " << mutation_stdev << "Algorithm: CPFA\n"
+                          << "Number of searchers: 6\n"
+                          << "Number of targets: 256\n"
+                          << "Target distribution: power law" << endl;
+    results_output_stream << "Generation"
+                          << ", "
+                          << "Compute Time (s)"
+                          << ", "
+                          << "Convergence"
+                          << ", "
+                          << "Mean"
+                          << ", "
+                          << "Maximum"
+                          << ", "
+                          << "Minimum"
+                          << ", "
+                          << "Standard Deviation"
+                          << ", "
+                          << "Diversity"
+                          << ", "
+                          << "ProbabilityOfSwitchingToSearching"
+                          << ", "
+                          << "ProbabilityOfReturningToNest"
+                          << ", "
+                          << "UninformedSearchVariation"
+                          << ", "
+                          << "RateOfInformedSearchDecay"
+                          << ", "
+                          << "RateOfSiteFidelity"
+                          << ", "
+                          << "RateOfLayingPheromone"
+                          << ", "
+                          << "RateOfPheromoneDecay";
 
-	results_output_stream << endl;
-	results_output_stream.close();
-      }
+    results_output_stream << endl;
+    results_output_stream.close();
+  }
 
-	while(!ga.done())
-	  {
+  while (!ga.done())
+  {
 
-	    std::chrono::time_point<std::chrono::system_clock>generation_start, generation_end;
-	    if (mpi_rank == 0)
-	      {
-		generation_start = std::chrono::system_clock::now();
-	      }
-	    
-      // Calculate the generation
-      ga.step();
+    std::chrono::time_point<std::chrono::system_clock> generation_start, generation_end;
+    if (mpi_rank == 0)
+    {
+      generation_start = std::chrono::system_clock::now();
+    }
 
-    if(mpi_rank == 0)
-      {
-	generation_end = std::chrono::system_clock::now();
-	std::chrono::duration<double> generation_elapsed_seconds = generation_end-generation_start;
-	ofstream results_output_stream;
-	results_output_stream.open(results_file_name, ios::app);
-       results_output_stream << ga.statistics().generation() 
-			     << ", " << generation_elapsed_seconds.count()
-			     << ", " << ga.statistics().convergence()
-			     << ", " << ga.statistics().current(GAStatistics::Mean)
-			     << ", " << ga.statistics().current(GAStatistics::Maximum)
-			     << ", " << ga.statistics().current(GAStatistics::Minimum)
-			     << ", " << ga.statistics().current(GAStatistics::Deviation)
-			     << ", " << ga.statistics().current(GAStatistics::Diversity);
-       
-	  for (int i = 0; i < GENOME_SIZE; i++)
-	    results_output_stream << ", " << dynamic_cast<const GARealGenome&>(ga.population().best()).gene(i);
+    // Calculate the generation
+    ga.step();
 
-	  
-	  const GARealGenome& best_genome = dynamic_cast<const GARealGenome&>(ga.statistics().bestIndividual());
-	  results_output_stream << endl;
-	  
-	  results_output_stream << "The GA found an optimum at: ";
-	  results_output_stream << best_genome.gene(0);
-	  for (int i = 1; i < GENOME_SIZE; i++)
-	    results_output_stream << ", " << best_genome.gene(i);
-	  results_output_stream << " with score: " << best_genome.score();
-	  results_output_stream << endl;
-	  results_output_stream.close();
-      }
-	  }
-	// Display the GA's progress
-	if(mpi_rank == 0)
-	  {
-	    cout << ga.statistics() << " " << ga.parameters() << endl;
-	  }
-	
+    if (mpi_rank == 0)
+    {
+      generation_end = std::chrono::system_clock::now();
+      std::chrono::duration<double> generation_elapsed_seconds = generation_end - generation_start;
+      ofstream results_output_stream;
+      results_output_stream.open(results_file_name, ios::app);
+      results_output_stream << ga.statistics().generation()
+                            << ", " << generation_elapsed_seconds.count()
+                            << ", " << ga.statistics().convergence()
+                            << ", " << ga.statistics().current(GAStatistics::Mean)
+                            << ", " << ga.statistics().current(GAStatistics::Maximum)
+                            << ", " << ga.statistics().current(GAStatistics::Minimum)
+                            << ", " << ga.statistics().current(GAStatistics::Deviation)
+                            << ", " << ga.statistics().current(GAStatistics::Diversity);
+
+      for (int i = 0; i < GENOME_SIZE; i++)
+        results_output_stream << ", " << dynamic_cast<const GARealGenome &>(ga.population().best()).gene(i);
+
+      const GARealGenome &best_genome = dynamic_cast<const GARealGenome &>(ga.statistics().bestIndividual());
+      results_output_stream << endl;
+
+      results_output_stream << "The GA found an optimum at: ";
+      results_output_stream << best_genome.gene(0);
+      for (int i = 1; i < GENOME_SIZE; i++)
+        results_output_stream << ", " << best_genome.gene(i);
+      results_output_stream << " with score: " << best_genome.score();
+      results_output_stream << endl;
+      results_output_stream.close();
+    }
+  }
+  // Display the GA's progress
+  if (mpi_rank == 0)
+  {
+    cout << ga.statistics() << " " << ga.parameters() << endl;
+  }
+
   MPI_Finalize();
 
   program_end = std::chrono::system_clock::now();
- 
-  std::chrono::duration<double> program_elapsed_seconds = program_end-program_start;
 
-  if(mpi_rank == 0)
+  std::chrono::duration<double> program_elapsed_seconds = program_end - program_start;
+
+  if (mpi_rank == 0)
     printf("Run time was %f seconds\n", program_elapsed_seconds.count());
 
   return 0;
-  }
+}
 
-// Initializes the genome according to the Beyond Pheromones paper 
-void CPFAInitializer(GAGenome & c)
+// Initializes the genome according to the Beyond Pheromones paper
+void CPFAInitializer(GAGenome &c)
 {
   // For the exponential PDF needed to initialize some of the genes
-  
+
   std::exponential_distribution<double> exponential_distribution_10(10.0);
   std::exponential_distribution<double> exponential_distribution_5(5.0);
   std::uniform_real_distribution<double> uniform_distribution_0_1(0.0, 1.0);
-  std::uniform_real_distribution<double> uniform_distribution_0_4PI(0.0, 4.0*M_PI);
+  std::uniform_real_distribution<double> uniform_distribution_0_4PI(0.0, 4.0 * M_PI);
   std::uniform_real_distribution<double> uniform_distribution_0_20(0.0, 20.0);
 
-  GA1DArrayAlleleGenome<float> &child= DYN_CAST(GA1DArrayAlleleGenome<float> &, c);
+  GA1DArrayAlleleGenome<float> &child = DYN_CAST(GA1DArrayAlleleGenome<float> &, c);
   child.resize(GAGenome::ANY_SIZE); // let chrom resize if it can
-  
-  child.gene(0, uniform_distribution_0_1(generator)); // Probability of switching to search
-  child.gene(1, uniform_distribution_0_1(generator)); // Probability of returning to nest
-  child.gene(2, uniform_distribution_0_4PI(generator)); // Uninformed search variation
-  child.gene(3, exponential_distribution_5(generator)); // Rate of informed search decay
-  child.gene(4, uniform_distribution_0_20(generator)); // Rate of site fidelity
-  child.gene(5, uniform_distribution_0_20(generator)); // Rate of laying pheremone
+
+  child.gene(0, uniform_distribution_0_1(generator));    // Probability of switching to search
+  child.gene(1, uniform_distribution_0_1(generator));    // Probability of returning to nest
+  child.gene(2, uniform_distribution_0_4PI(generator));  // Uninformed search variation
+  child.gene(3, exponential_distribution_5(generator));  // Rate of informed search decay
+  child.gene(4, uniform_distribution_0_20(generator));   // Rate of site fidelity
+  child.gene(5, uniform_distribution_0_20(generator));   // Rate of laying pheremone
   child.gene(6, exponential_distribution_10(generator)); // Rate of pheremone decay
 }
 
 // The mutation operator based on the original from GALib but adds stdev
 // The Gaussian mutator picks a new value based on a Gaussian distribution
 // around the current value.  We respect the bounds (if any).
-int GARealGaussianMutatorStdev(GAGenome& g, float pmut)
+int GARealGaussianMutatorStdev(GAGenome &g, float pmut)
 {
-  GA1DArrayAlleleGenome<float> &child=
-    DYN_CAST(GA1DArrayAlleleGenome<float> &, g);
-  register int n, i;
-  if(pmut <= 0.0) return(0);
+  GA1DArrayAlleleGenome<float> &child =
+      DYN_CAST(GA1DArrayAlleleGenome<float> &, g);
+  int n, i;
+  if (pmut <= 0.0)
+    return (0);
 
   float nMut = pmut * (float)(child.length());
-  int length = child.length()-1;
-  if(nMut < 1.0){// we have to do a flip test on each element
+  int length = child.length() - 1;
+  if (nMut < 1.0)
+  { // we have to do a flip test on each element
     nMut = 0;
-    for(i=length; i>=0; i--){
+    for (i = length; i >= 0; i--)
+    {
       float value = child.gene(i);
-      if(GAFlipCoin(pmut)){
-	if(child.alleleset(i).type() == GAAllele::ENUMERATED ||
-	   child.alleleset(i).type() == GAAllele::DISCRETIZED)
-	  value = child.alleleset(i).allele();
-	else if(child.alleleset(i).type() == GAAllele::BOUNDED){
-	  value += GAUnitGaussian()*mutation_stdev;//*(child.alleleset(i).upper()-child.alleleset(i).lower()); // since the standard deviation varies proportionally to a constant multiplier 
-	  value = GAMax(child.alleleset(i).lower(), value);
-	  value = GAMin(child.alleleset(i).upper(), value);
-	}
-	child.gene(i, value);
-	nMut++;
+      if (GAFlipCoin(pmut))
+      {
+        if (child.alleleset(i).type() == GAAllele::ENUMERATED ||
+            child.alleleset(i).type() == GAAllele::DISCRETIZED)
+          value = child.alleleset(i).allele();
+        else if (child.alleleset(i).type() == GAAllele::BOUNDED)
+        {
+          value += GAUnitGaussian() * mutation_stdev; //*(child.alleleset(i).upper()-child.alleleset(i).lower()); // since the standard deviation varies proportionally to a constant multiplier
+          value = GAMax(child.alleleset(i).lower(), value);
+          value = GAMin(child.alleleset(i).upper(), value);
+        }
+        child.gene(i, value);
+        nMut++;
       }
     }
   }
-  else{// only mutate the ones we need to
-    for(n=0; n<nMut; n++){
-      int idx = GARandomInt(0,length);
+  else
+  { // only mutate the ones we need to
+    for (n = 0; n < nMut; n++)
+    {
+      int idx = GARandomInt(0, length);
       float value = child.gene(idx);
-      if(child.alleleset(idx).type() == GAAllele::ENUMERATED ||
-	 child.alleleset(idx).type() == GAAllele::DISCRETIZED)
-	value = child.alleleset(idx).allele();
-      else if(child.alleleset(idx).type() == GAAllele::BOUNDED){
-	value += GAUnitGaussian()*mutation_stdev*(child.alleleset(i).upper()-child.alleleset(i).lower()); // since the standard deviation varies proportionally to a constant multiplier 
-	value = GAMax(child.alleleset(idx).lower(), value);
-	value = GAMin(child.alleleset(idx).upper(), value);
+      if (child.alleleset(idx).type() == GAAllele::ENUMERATED ||
+          child.alleleset(idx).type() == GAAllele::DISCRETIZED)
+        value = child.alleleset(idx).allele();
+      else if (child.alleleset(idx).type() == GAAllele::BOUNDED)
+      {
+        value += GAUnitGaussian() * mutation_stdev * (child.alleleset(i).upper() - child.alleleset(i).lower()); // since the standard deviation varies proportionally to a constant multiplier
+        value = GAMax(child.alleleset(idx).lower(), value);
+        value = GAMin(child.alleleset(idx).upper(), value);
       }
       child.gene(idx, value);
     }
   }
-  return((int)nMut);
+  return ((int)nMut);
 }
-
 
 float objective(GAGenome &c)
 {
   float avg = 0;
-  
+
   // For timing
   std::chrono::time_point<std::chrono::system_clock> start, end;
   start = std::chrono::system_clock::now();
 
-  for (int i = 0; i < n_trials; i++) avg += LaunchARGoS(c);
-  
+  for (int i = 0; i < n_trials; i++)
+    avg += LaunchARGoS(c);
+
   avg /= n_trials;
 
-  
   end = std::chrono::system_clock::now();
-  
-  std::chrono::duration<double> elapsed_seconds = end-start;
 
-  MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);     
+  std::chrono::duration<double> elapsed_seconds = end - start;
 
-      char hostname[1024];              
-      hostname[1023] = '\0';                                          
-      gethostname(hostname, 1023);     
- 
-      /*
-      printf("Worker %d on %s evaluated genome [", mpi_rank, hostname);
-      for (int i = 0; i < GENOME_SIZE; i++)
-	printf("%f ",dynamic_cast<const GARealGenome&>(c).gene(i));
-      printf("] in %f seconds. ", elapsed_seconds.count());
-      printf("Fitness: %f.\n", avg );
-      */
+  MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
 
-      return avg;
+  char hostname[1024];
+  hostname[1023] = '\0';
+  gethostname(hostname, 1023);
+
+  /*
+  printf("Worker %d on %s evaluated genome [", mpi_rank, hostname);
+  for (int i = 0; i < GENOME_SIZE; i++)
+printf("%f ",dynamic_cast<const GARealGenome&>(c).gene(i));
+  printf("] in %f seconds. ", elapsed_seconds.count());
+  printf("Fitness: %f.\n", avg );
+  */
+
+  return avg;
 }
 
 /*
  * Launch ARGoS to evaluate a genome.
  */
-float LaunchARGoS(GAGenome& c_genome) 
+float LaunchARGoS(GAGenome &c_genome)
 {
   // Declate the fitness value and the shared memory segment id and address
   float fitness = 0;
-  int    ShmID;
-  float*   ShmPTR;
-  
+  int ShmID;
+  float *ShmPTR;
+
   // Allocate the shared memory to use between this process and the child argos process
   ShmID = shmget(IPC_PRIVATE, sizeof(float), IPC_CREAT | 0666);
-  if (ShmID < 0) {
+  if (ShmID < 0)
+  {
     printf("ERROR: Allocating shared memory segment in main.cpp:LaunchARGoS() failed.\n");
     exit(1);
   }
-  
+
   // Attach to the shared memory segment
-  ShmPTR = (float*) shmat(ShmID, NULL, 0);
-  if ((float*) ShmPTR == (float*)-1) 
-    {
-      printf("ERROR: Attaching to shared memory segment in main.cpp:LaunchARGoS() failed.\n");
-      exit(1);
-    }
+  ShmPTR = (float *)shmat(ShmID, NULL, 0);
+  if ((float *)ShmPTR == (float *)-1)
+  {
+    printf("ERROR: Attaching to shared memory segment in main.cpp:LaunchARGoS() failed.\n");
+    exit(1);
+  }
 
   *ShmPTR = 0; // Initialise
 
   pid_t pid = fork(); // Create the new process with a copy of this memory space
 
   if (pid == 0)
-    {
-      // In child process - run the argos3 simulation
+  {
+    // In child process - run the argos3 simulation
 
-      /* Convert the received genome to the actual genome type */
-      GARealGenome& cRealGenome = dynamic_cast<GARealGenome&>(c_genome);
-  
-      Real* cpfa_genome = new Real[GENOME_SIZE];
+    /* Convert the received genome to the actual genome type */
+    GARealGenome &cRealGenome = dynamic_cast<GARealGenome &>(c_genome);
 
-      // Convert to a convenient format for the argos controller
-      for (int i = 0; i < GENOME_SIZE; i++)
-	cpfa_genome[i] = cRealGenome.gene(i);
-       
-      /*      
-      printf("%s: worker %d started a genome evaluation. (%f, %f, %f, %f, %f, %f, %f)\n", hostname, mpi_rank, 
-	     cpfa_genome[0],
-	     cpfa_genome[1],
-	     cpfa_genome[2],
-	     cpfa_genome[3],
-	     cpfa_genome[4],
-	     cpfa_genome[5],
-	     cpfa_genome[6]);
-      */
+    Real *cpfa_genome = new Real[GENOME_SIZE];
 
-      /* Redirect LOG and LOGERR to dedicated files to prevent clutter on the screen */
-      std::ofstream cLOGFile("argos_logs/ARGoS_LOG_" + ToString(::getpid()), std::ios::out);
-      LOG.DisableColoredOutput();
-      LOG.GetStream().rdbuf(cLOGFile.rdbuf());
-      std::ofstream cLOGERRFile("argos_logs/ARGoS_LOGERR_" + ToString(::getpid()), std::ios::out);
-      LOGERR.DisableColoredOutput();
-      LOGERR.GetStream().rdbuf(cLOGERRFile.rdbuf());
+    // Convert to a convenient format for the argos controller
+    for (int i = 0; i < GENOME_SIZE; i++)
+      cpfa_genome[i] = cRealGenome.gene(i);
 
-      /*
-       * Initialize ARGoS
-       */
-      /* The CSimulator class of ARGoS is a singleton. Therefore, to
-       * manipulate an ARGoS experiment, it is enough to get its instance */
-      argos::CSimulator& cSimulator = argos::CSimulator::GetInstance();
+    /*
+    printf("%s: worker %d started a genome evaluation. (%f, %f, %f, %f, %f, %f, %f)\n", hostname, mpi_rank,
+     cpfa_genome[0],
+     cpfa_genome[1],
+     cpfa_genome[2],
+     cpfa_genome[3],
+     cpfa_genome[4],
+     cpfa_genome[5],
+     cpfa_genome[6]);
+    */
 
-      // Set the .argos configuration file
-      cSimulator.SetExperimentFileName(experiment_path);
-      
-      // Load it to configure ARGoS 
-      cSimulator.LoadExperiment();
+    /* Redirect LOG and LOGERR to dedicated files to prevent clutter on the screen */
+    std::ofstream cLOGFile("argos_logs/ARGoS_LOG_" + ToString(::getpid()), std::ios::out);
+    LOG.DisableColoredOutput();
+    LOG.GetStream().rdbuf(cLOGFile.rdbuf());
+    std::ofstream cLOGERRFile("argos_logs/ARGoS_LOGERR_" + ToString(::getpid()), std::ios::out);
+    LOGERR.DisableColoredOutput();
+    LOGERR.GetStream().rdbuf(cLOGERRFile.rdbuf());
 
-      // Get a reference to the loop functions
-      CPFA_loop_functions& cLoopFunctions = dynamic_cast<CPFA_loop_functions&>(cSimulator.GetLoopFunctions());
+    /*
+     * Initialize ARGoS
+     */
+    /* The CSimulator class of ARGoS is a singleton. Therefore, to
+     * manipulate an ARGoS experiment, it is enough to get its instance */
+    argos::CSimulator &cSimulator = argos::CSimulator::GetInstance();
 
-      // Configure the controller with the genome
-      cLoopFunctions.ConfigureFromGenome(cpfa_genome);
+    // Set the .argos configuration file
+    cSimulator.SetExperimentFileName(experiment_path);
 
-      // Run the experiment
-      cSimulator.Execute();
+    // Load it to configure ARGoS
+    cSimulator.LoadExperiment();
 
-      // Update performance and store in the shared memory segment
-      *ShmPTR = cLoopFunctions.Score();;
+    // Get a reference to the loop functions
+    CPFA_loop_functions &cLoopFunctions = dynamic_cast<CPFA_loop_functions &>(cSimulator.GetLoopFunctions());
 
-      // For testing
-      //float score = 0;
-      //for (int i = 0; i < GENOME_SIZE; i++) score += cpfa_genome[i];
-      //*ShmPTR = score;
+    // Configure the controller with the genome
+    cLoopFunctions.ConfigureFromGenome(cpfa_genome);
 
-      // Clean up the simulation
-      cSimulator.Destroy();
-      
-      // Clean up the temp genome copy
-	delete [] cpfa_genome;
+    // Run the experiment
+    cSimulator.Execute();
 
-	// Make this process exit
-      _Exit(0); 
-    }
-  
+    // Update performance and store in the shared memory segment
+    *ShmPTR = cLoopFunctions.Score();
+    ;
+
+    // For testing
+    // float score = 0;
+    // for (int i = 0; i < GENOME_SIZE; i++) score += cpfa_genome[i];
+    //*ShmPTR = score;
+
+    // Clean up the simulation
+    cSimulator.Destroy();
+
+    // Clean up the temp genome copy
+    delete[] cpfa_genome;
+
+    // Make this process exit
+    _Exit(0);
+  }
+
   // In parent - wait for child to finish
   int status = wait(&status);
 
   // Make a local copy of the shared fitness value
-  fitness = *ShmPTR;  
+  fitness = *ShmPTR;
 
   // Release shared memory
-  shmdt((void *) ShmPTR);
+  shmdt((void *)ShmPTR);
   shmctl(ShmID, IPC_RMID, NULL);
 
-  /* Return the result of the evaluation */  
+  /* Return the result of the evaluation */
   return fitness;
 }

--- a/Static_MPFA/source/ga-mpi/GA1DArrayGenome.C
+++ b/Static_MPFA/source/ga-mpi/GA1DArrayGenome.C
@@ -18,7 +18,7 @@
 #include <ga-mpi/GA1DArrayGenome.h>
 #include <ga-mpi/GAMask.h>
 
-template <class T> int 
+template <class T> int
 GA1DArrayIsHole(const GA1DArrayGenome<T>&, const GA1DArrayGenome<T>&,
 		int, int, int);
 
@@ -36,15 +36,15 @@ GA1DArrayGenome<T>::classID() const {return GAID::ArrayGenome;}
 // this point - initialization must be done explicitly by the user of the
 // genome (eg when the population is created or reset).  If we called the
 // initializer routine here then we could end up with multiple initializations
-// and/or calls to dummy initializers (for example when the genome is 
+// and/or calls to dummy initializers (for example when the genome is
 // created with a dummy initializer and the initializer is assigned later on).
 // Besides, we default to the no-initialization initializer by calling the
 // default genome constructor.
-template <class T> 
+template <class T>
 GA1DArrayGenome<T>::
 GA1DArrayGenome(unsigned int length, GAGenome::Evaluator f, void * u) :
 GAArray<T>(length),
-GAGenome(DEFAULT_1DARRAY_INITIALIZER, 
+GAGenome(DEFAULT_1DARRAY_INITIALIZER,
 	 DEFAULT_1DARRAY_MUTATOR,
 	 DEFAULT_1DARRAY_COMPARATOR) {
   evaluator(f);
@@ -56,9 +56,9 @@ GAGenome(DEFAULT_1DARRAY_INITIALIZER,
 
 // This is the copy initializer.  We set everything to the default values, then
 // copy the original.  The Array creator takes care of zeroing the data.
-template <class T> 
+template <class T>
 GA1DArrayGenome<T>::
-GA1DArrayGenome(const GA1DArrayGenome<T> & orig) : 
+GA1DArrayGenome(const GA1DArrayGenome<T> & orig) :
 GAArray<T>(orig.sz), GAGenome() {
   GA1DArrayGenome<T>::copy(orig);
 }
@@ -74,7 +74,7 @@ GA1DArrayGenome<T>::~GA1DArrayGenome() { }
 // what we define here - a virtual function).  We should check to be sure that
 // both genomes are the same class and same dimension.  This function tries
 // to be smart about they way it copies.  If we already have data, then we do
-// a memcpy of the one we're supposed to copy.  If we don't or we're not the 
+// a memcpy of the one we're supposed to copy.  If we don't or we're not the
 // same size as the one we're supposed to copy, then we adjust ourselves.
 //   The Array takes care of the resize in its copy method.
 template <class T> void
@@ -92,7 +92,7 @@ GA1DArrayGenome<T>::copy(const GAGenome & orig){
 template <class T> GAGenome *
 GA1DArrayGenome<T>::clone(GAGenome::CloneMethod flag) const {
   GA1DArrayGenome<T> *cpy = new GA1DArrayGenome<T>(nx);
-  if(flag == CONTENTS){ 
+  if(flag == CONTENTS){
     cpy->copy(*this);
   }
   else{
@@ -110,10 +110,10 @@ GA1DArrayGenome<T>::clone(GAGenome::CloneMethod flag) const {
 // length, then we don't do anything.
 //   We pay attention to the values of minX and maxX - they determine what kind
 // of resizing we are allowed to do.  If a resize is requested with a length
-// less than the min length specified by the behaviour, we set the minimum 
+// less than the min length specified by the behaviour, we set the minimum
 // to the length.  If the length is longer than the max length specified by
 // the behaviour, we set the max value to the length.
-//   We return the total size (in bits) of the genome after resize. 
+//   We return the total size (in bits) of the genome after resize.
 //   We don't do anything to the new contents!
 template <class T> int
 GA1DArrayGenome<T>::resize(int len)
@@ -160,7 +160,7 @@ GA1DArrayGenome<T>::write(STD_OSTREAM & os) const {
 //   Set the resize behaviour of the genome.  A genome can be fixed
 // length, resizeable with a max and min limit, or resizeable with no limits
 // (other than an implicit one that we use internally).
-//   A value of 0 means no resize, a value less than zero mean unlimited 
+//   A value of 0 means no resize, a value less than zero mean unlimited
 // resize, and a positive value means resize with that value as the limit.
 template <class T> int
 GA1DArrayGenome<T>::
@@ -183,7 +183,7 @@ GA1DArrayGenome<T>::resizeBehaviour() const {
   return val;
 }
 
-template <class T> int 
+template <class T> int
 GA1DArrayGenome<T>::equal(const GAGenome & c) const {
   const GA1DArrayGenome<T> & b = DYN_CAST(const GA1DArrayGenome<T> &, c);
   return((this == &c) ? 1 : ((nx != b.nx) ? 0 : GAArray<T>::equal(b,0,0,nx)));
@@ -205,7 +205,7 @@ its own, independent allele set.  If we clone a new genome, the new one gets a
 link to our allele set (so we don't end up with zillions of allele sets).  Same
 is true for the copy constructor.
   The array may have a single allele set or an array of allele sets, depending
-on which creator was called.  Either way, the allele set cannot be changed 
+on which creator was called.  Either way, the allele set cannot be changed
 once the array is created.
 ---------------------------------------------------------------------------- */
 template <class T> const char *
@@ -213,7 +213,7 @@ GA1DArrayAlleleGenome<T>::className() const {return "GA1DArrayAlleleGenome";}
 template <class T> int
 GA1DArrayAlleleGenome<T>::classID() const {return GAID::ArrayAlleleGenome;}
 
-template <class T> 
+template <class T>
 GA1DArrayAlleleGenome<T>::
 GA1DArrayAlleleGenome(unsigned int length, const GAAlleleSet<T> & s,
 		      GAGenome::Evaluator f, void * u) :
@@ -228,7 +228,7 @@ GA1DArrayGenome<T>(length, f, u){
   this->crossover(GA1DArrayAlleleGenome<T>::DEFAULT_1DARRAY_ALLELE_CROSSOVER);
 }
 
-template <class T> 
+template <class T>
 GA1DArrayAlleleGenome<T>::
 GA1DArrayAlleleGenome(const GAAlleleSetArray<T> & sa,
 		      GAGenome::Evaluator f, void * u) :
@@ -247,9 +247,9 @@ GA1DArrayGenome<T>(sa.size(), f, u) {
 
 // The copy constructor creates a new genome whose allele set refers to the
 // original's allele set.
-template <class T> 
+template <class T>
 GA1DArrayAlleleGenome<T>::
-GA1DArrayAlleleGenome(const GA1DArrayAlleleGenome<T>& orig) : 
+GA1DArrayAlleleGenome(const GA1DArrayAlleleGenome<T>& orig) :
 GA1DArrayGenome<T>(orig.sz) {
   naset = 0;
   aset = (GAAlleleSet<T>*)0;
@@ -265,7 +265,7 @@ GA1DArrayAlleleGenome<T>::~GA1DArrayAlleleGenome(){
 
 
 // This implementation of clone does not make use of the contents/attributes
-// capability because this whole interface isn't quite right yet...  Just 
+// capability because this whole interface isn't quite right yet...  Just
 // clone the entire thing, contents and all.
 template <class T> GAGenome *
 GA1DArrayAlleleGenome<T>::clone(GAGenome::CloneMethod) const {
@@ -273,10 +273,10 @@ GA1DArrayAlleleGenome<T>::clone(GAGenome::CloneMethod) const {
 }
 
 
-template <class T> void 
+template <class T> void
 GA1DArrayAlleleGenome<T>::copy(const GAGenome& orig){
   if(&orig == this) return;
-  const GA1DArrayAlleleGenome<T> * c = 
+  const GA1DArrayAlleleGenome<T> * c =
     DYN_CAST(const GA1DArrayAlleleGenome<T>*, &orig);
   if(c) {
     GA1DArrayGenome<T>::copy(*c);
@@ -339,7 +339,7 @@ GA1DArrayAlleleGenome<T>::equal(const GAGenome & c) const {
 ---------------------------------------------------------------------------- */
 // The random initializer sets the elements of the array based on the alleles
 // set.  We choose randomly the allele for each element.
-template <class ARRAY_TYPE> void 
+template <class ARRAY_TYPE> void
 GA1DArrayAlleleGenome<ARRAY_TYPE>::UniformInitializer(GAGenome & c)
 {
   GA1DArrayAlleleGenome<ARRAY_TYPE> &child=
@@ -354,7 +354,7 @@ GA1DArrayAlleleGenome<ARRAY_TYPE>::UniformInitializer(GAGenome & c)
 // and assign each element the next allele in the allele set.  Once each
 // element has been initialized, scramble the contents by swapping elements.
 // This assumes that there is only one allele set for the array.
-template <class ARRAY_TYPE> void 
+template <class ARRAY_TYPE> void
 GA1DArrayAlleleGenome<ARRAY_TYPE>::OrderedInitializer(GAGenome & c)
 {
   GA1DArrayAlleleGenome<ARRAY_TYPE> &child=
@@ -372,15 +372,15 @@ GA1DArrayAlleleGenome<ARRAY_TYPE>::OrderedInitializer(GAGenome & c)
 }
 
 
-// Randomly pick elements in the array then set the element to any of the 
+// Randomly pick elements in the array then set the element to any of the
 // alleles in the allele set for this genome.  This will work for any number
 // of allele sets for a given array.
-template <class ARRAY_TYPE> int 
+template <class ARRAY_TYPE> int
 GA1DArrayAlleleGenome<ARRAY_TYPE>::FlipMutator(GAGenome & c, float pmut)
 {
   GA1DArrayAlleleGenome<ARRAY_TYPE> &child=
     DYN_CAST(GA1DArrayAlleleGenome<ARRAY_TYPE> &, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.length());
@@ -404,11 +404,11 @@ GA1DArrayAlleleGenome<ARRAY_TYPE>::FlipMutator(GAGenome & c, float pmut)
 
 
 // Randomly swap elements in the array.
-template <class ARRAY_TYPE> int 
+template <class ARRAY_TYPE> int
 GA1DArrayGenome<ARRAY_TYPE>::SwapMutator(GAGenome & c, float pmut)
 {
   GA1DArrayGenome<ARRAY_TYPE> &child=DYN_CAST(GA1DArrayGenome<ARRAY_TYPE>&, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.length());
@@ -469,7 +469,7 @@ ElementComparator(const GAGenome& a, const GAGenome& b)
 #define SWAP(a,b) {unsigned int tmp=a; a=b; b=tmp;}
 
 // Randomly take bits from each parent.  For each bit we flip a coin to see if
-// that bit should come from the mother or the father.  If strings are 
+// that bit should come from the mother or the father.  If strings are
 // different lengths then we need to use the mask to get things right.
 template <class T> int
 GA1DArrayGenome<T>::
@@ -517,8 +517,8 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
     n = 2;
   }
   else if(c1 || c2){
-    GA1DArrayGenome<T> &sis = (c1 ? 
-			       DYN_CAST(GA1DArrayGenome<T> &, *c1) : 
+    GA1DArrayGenome<T> &sis = (c1 ?
+			       DYN_CAST(GA1DArrayGenome<T> &, *c1) :
 			       DYN_CAST(GA1DArrayGenome<T> &, *c2));
 
     if(mom.length() == dad.length() && sis.length() == mom.length()){
@@ -550,7 +550,7 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
 // we cannot handle that and post an error message.
 template <class T> int
 GA1DArrayGenome<T>::
-OnePointCrossover(const GAGenome& p1, const GAGenome& p2, 
+OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 		  GAGenome* c1, GAGenome* c2){
   const GA1DArrayGenome<T> &mom=DYN_CAST(const GA1DArrayGenome<T> &, p1);
   const GA1DArrayGenome<T> &dad=DYN_CAST(const GA1DArrayGenome<T> &, p2);
@@ -565,7 +565,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour() == GAGenome::FIXED_SIZE){
-      if(mom.length() != dad.length() || 
+      if(mom.length() != dad.length() ||
 	 sis.length() != bro.length() ||
 	 sis.length() != mom.length()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -587,17 +587,17 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sis.resize(momsite+dadlen);
       bro.resize(dadsite+momlen);
     }
-    
+
     sis.copy(mom, 0, 0, momsite);
     sis.copy(dad, momsite, dadsite, dadlen);
     bro.copy(dad, 0, 0, dadsite);
     bro.copy(mom, dadsite, momsite, momlen);
-  
+
     nc = 2;
   }
   else if(c1 || c2){
-    GA1DArrayGenome<T> &sis = (c1 ? 
-			       DYN_CAST(GA1DArrayGenome<T> &, *c1) : 
+    GA1DArrayGenome<T> &sis = (c1 ?
+			       DYN_CAST(GA1DArrayGenome<T> &, *c1) :
 			       DYN_CAST(GA1DArrayGenome<T> &, *c2));
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE){
@@ -615,7 +615,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       dadlen = dad.length() - dadsite;
       sis.resize(momsite+dadlen);
     }
-    
+
     if(GARandomBit()){
       sis.copy(mom, 0, 0, momsite);
       sis.copy(dad, momsite, dadsite, dadlen);
@@ -642,14 +642,14 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
 
 // Two point crossover for the 1D array genome.  Similar to the single point
-// crossover, but here we pick two points then grab the sections based upon 
+// crossover, but here we pick two points then grab the sections based upon
 // those two points.
 //   When we pick the points, it doesn't matter where they fall (one is not
 // dependent upon the other).  Make sure we get the lesser one into the first
 // position of our site array.
 template <class T> int
 GA1DArrayGenome<T>::
-TwoPointCrossover(const GAGenome& p1, const GAGenome& p2, 
+TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
 		  GAGenome* c1, GAGenome* c2){
   const GA1DArrayGenome<T> &mom=DYN_CAST(const GA1DArrayGenome<T> &, p1);
   const GA1DArrayGenome<T> &dad=DYN_CAST(const GA1DArrayGenome<T> &, p2);
@@ -664,7 +664,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour() == GAGenome::FIXED_SIZE){
-      if(mom.length() != dad.length() || 
+      if(mom.length() != dad.length() ||
 	 sis.length() != bro.length() ||
 	 sis.length() != mom.length()){
 	GAErr(GA_LOC, mom.className(), "two-point cross", gaErrSameLengthReqd);
@@ -675,7 +675,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
       if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
-      
+
       dadsite[0] = momsite[0];
       dadsite[1] = momsite[1];
       dadlen[0] = momlen[0];
@@ -691,13 +691,13 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
       if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
-      
+
       dadsite[0] = GARandomInt(0, dad.length());
       dadsite[1] = GARandomInt(0, dad.length());
       if(dadsite[0] > dadsite[1]) SWAP(dadsite[0], dadsite[1]);
       dadlen[0] = dadsite[1] - dadsite[0];
       dadlen[1] = dad.length() - dadsite[1];
-      
+
       sis.resize(momsite[0]+dadlen[0]+momlen[1]);
       bro.resize(dadsite[0]+momlen[0]+dadlen[1]);
     }
@@ -726,7 +726,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
       if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
-      
+
       dadsite[0] = momsite[0];
       dadsite[1] = momsite[1];
       dadlen[0] = momlen[0];
@@ -738,7 +738,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
       if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
-      
+
       dadsite[0] = GARandomInt(0, dad.length());
       dadsite[1] = GARandomInt(0, dad.length());
       if(dadsite[0] > dadsite[1]) SWAP(dadsite[0], dadsite[1]);
@@ -771,13 +771,13 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
 
 
 
-// Even and odd crossover for the array works just like it does for the 
+// Even and odd crossover for the array works just like it does for the
 // binary strings.  For even crossover we take the 0th element and every other
 // one after that from the mother.  The 1st and every other come from the
 // father.  For odd crossover, we do just the opposite.
 template <class T> int
 GA1DArrayGenome<T>::
-EvenOddCrossover(const GAGenome& p1, const GAGenome& p2, 
+EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
 		 GAGenome* c1, GAGenome* c2){
   const GA1DArrayGenome<T> &mom=DYN_CAST(const GA1DArrayGenome<T> &, p1);
   const GA1DArrayGenome<T> &dad=DYN_CAST(const GA1DArrayGenome<T> &, p2);
@@ -816,10 +816,10 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
     nc = 2;
   }
   else if(c1 || c2){
-    GA1DArrayGenome<T> &sis = (c1 ? 
-			       DYN_CAST(GA1DArrayGenome<T> &, *c1) : 
+    GA1DArrayGenome<T> &sis = (c1 ?
+			       DYN_CAST(GA1DArrayGenome<T> &, *c1) :
 			       DYN_CAST(GA1DArrayGenome<T> &, *c2));
-    
+
     if(mom.length() == dad.length() && sis.length() == mom.length()){
       for(i=sis.length()-1; i>=1; i-=2){
 	sis.gene(i, mom.gene(i));
@@ -853,7 +853,7 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
 //   We make sure that b will be greater than a.
 template <class T> int
 GA1DArrayGenome<T>::
-PartialMatchCrossover(const GAGenome& p1, const GAGenome& p2, 
+PartialMatchCrossover(const GAGenome& p1, const GAGenome& p2,
 		      GAGenome* c1, GAGenome* c2){
   const GA1DArrayGenome<T> &mom=DYN_CAST(const GA1DArrayGenome<T> &, p1);
   const GA1DArrayGenome<T> &dad=DYN_CAST(const GA1DArrayGenome<T> &, p2);
@@ -868,7 +868,7 @@ PartialMatchCrossover(const GAGenome& p1, const GAGenome& p2,
     GAErr(GA_LOC, mom.className(), "parial match cross", gaErrBadParentLength);
     return nc;
   }
-  
+
   if(c1 && c2){
     GA1DArrayGenome<T> &sis=DYN_CAST(GA1DArrayGenome<T> &, *c1);
     GA1DArrayGenome<T> &bro=DYN_CAST(GA1DArrayGenome<T> &, *c2);
@@ -887,8 +887,8 @@ PartialMatchCrossover(const GAGenome& p1, const GAGenome& p2,
     nc = 2;
   }
   else if(c1 || c2){
-    GA1DArrayGenome<T> &sis = (c1 ? 
-			       DYN_CAST(GA1DArrayGenome<T> &, *c1) : 
+    GA1DArrayGenome<T> &sis = (c1 ?
+			       DYN_CAST(GA1DArrayGenome<T> &, *c1) :
 			       DYN_CAST(GA1DArrayGenome<T> &, *c2));
 
     const GA1DArrayGenome<T> *parent1, *parent2;
@@ -929,7 +929,7 @@ GA1DArrayIsHole(const GA1DArrayGenome<T> &c, const GA1DArrayGenome<T> &dad,
 //   This implementation isn't terribly smart.  For example, I do a linear
 // search rather than caching and doing binary search or smarter hash tables.
 //   First we copy the mother into the sister.  Then move the 'holes' into the
-// crossover section and maintain the ordering of the non-hole elements.  
+// crossover section and maintain the ordering of the non-hole elements.
 // Finally, put the 'holes' in the proper order within the crossover section.
 // After we have done the sister, we do the brother.
 template <class T> int
@@ -949,7 +949,7 @@ OrderCrossover(const GAGenome& p1, const GAGenome& p2,
     GAErr(GA_LOC, mom.className(), "order cross", gaErrBadParentLength);
     return nc;
   }
-  
+
   if(c1 && c2){
     GA1DArrayGenome<T> &sis=DYN_CAST(GA1DArrayGenome<T> &, *c1);
     GA1DArrayGenome<T> &bro=DYN_CAST(GA1DArrayGenome<T> &, *c2);
@@ -962,7 +962,7 @@ OrderCrossover(const GAGenome& p1, const GAGenome& p2,
       if(index >= sis.size()) index=0;
       if(GA1DArrayIsHole(sis,dad,index,a,b)) break;
     }
-    
+
     for(; i<sis.size()-b+a; i++, index++){
       if(index >= sis.size()) index=0;
       j=index;
@@ -999,7 +999,7 @@ OrderCrossover(const GAGenome& p1, const GAGenome& p2,
       } while(GA1DArrayIsHole(bro,mom,j,a,b));
       bro.swap(index,j);
     }
-    
+
 // Now put the 'holes' in the proper order within the crossover section.
     for(i=a; i<b; i++){
       if(bro.gene(i) != mom.gene(i)){
@@ -1011,8 +1011,8 @@ OrderCrossover(const GAGenome& p1, const GAGenome& p2,
     nc = 2;
   }
   else if(c1 || c2){
-    GA1DArrayGenome<T> &sis = (c1 ? 
-			       DYN_CAST(GA1DArrayGenome<T> &, *c1) : 
+    GA1DArrayGenome<T> &sis = (c1 ?
+			       DYN_CAST(GA1DArrayGenome<T> &, *c1) :
 			       DYN_CAST(GA1DArrayGenome<T> &, *c2));
 
     const GA1DArrayGenome<T> *parent1, *parent2;
@@ -1053,7 +1053,7 @@ OrderCrossover(const GAGenome& p1, const GAGenome& p2,
 
 
 
-// Cycle crossover for the 1D array genome.  This is implemented as described 
+// Cycle crossover for the 1D array genome.  This is implemented as described
 // in goldberg's book.  The first is picked from mom, then cycle using dad.
 // Finally, fill in the gaps with the elements from dad.
 //   We allocate space for a temporary array in this routine.  It never frees
@@ -1063,8 +1063,8 @@ OrderCrossover(const GAGenome& p1, const GAGenome& p2,
 //  Allocate space for an array of flags.  We use this to keep track of whether
 // the child's contents came from the mother or the father.  We don't free the
 // space here, but it is not a memory leak.
-//   The first step is to cycle through mom & dad to get the cyclic part of 
-// the crossover.  Then fill in the rest of the sis with dad's contents that 
+//   The first step is to cycle through mom & dad to get the cyclic part of
+// the crossover.  Then fill in the rest of the sis with dad's contents that
 // we didn't use in the cycle.  Finally, do the same thing for the other child.
 //   Notice that this implementation makes serious use of the operator= for the
 // objects in the array.  It also requires the operator != and == comparators.
@@ -1139,7 +1139,7 @@ CycleCrossover(const GAGenome& p1, const GAGenome& p2,
     GAMask mask;
     mask.size(sis.length());
     mask.clear();
-    
+
     sis.gene(0, parent1->gene(0));
     mask[0] = 1;
     while(parent2->gene(current) != parent1->gene(0)){

--- a/Static_MPFA/source/ga-mpi/GA1DBinStrGenome.C
+++ b/Static_MPFA/source/ga-mpi/GA1DBinStrGenome.C
@@ -27,13 +27,13 @@
 // this point - initialization must be done explicitly by the user of the
 // genome (eg when the population is created or reset).  If we called the
 // initializer routine here then we could end up with multiple initializations
-// and/or calls to dummy initializers (for example when the genome is 
+// and/or calls to dummy initializers (for example when the genome is
 // created with a dummy initializer and the initializer is assigned later on).
 GA1DBinaryStringGenome::
-GA1DBinaryStringGenome(unsigned int len, 
+GA1DBinaryStringGenome(unsigned int len,
 		       GAGenome::Evaluator f, void * u) :
 GABinaryString(len),
-GAGenome(DEFAULT_1DBINSTR_INITIALIZER, 
+GAGenome(DEFAULT_1DBINSTR_INITIALIZER,
 	 DEFAULT_1DBINSTR_MUTATOR,
 	 DEFAULT_1DBINSTR_COMPARATOR) {
   evaluator(f);
@@ -60,7 +60,7 @@ GA1DBinaryStringGenome::~GA1DBinaryStringGenome() {
 
 
 // The clone member creates a duplicate (exact or just attributes, depending
-// on the flag).  The caller is responsible for freeing the memory that is 
+// on the flag).  The caller is responsible for freeing the memory that is
 // allocated by this method.
 GAGenome*
 GA1DBinaryStringGenome::clone(GAGenome::CloneMethod flag) const {
@@ -81,7 +81,7 @@ GA1DBinaryStringGenome::clone(GAGenome::CloneMethod flag) const {
 // what we define here - a virtual function).  We should check to be sure that
 // both genomes are the same class and same dimension.  This function tries
 // to be smart about they way it copies.  If we already have data, then we do
-// a memcpy of the one we're supposed to copy.  If we don't or we're not the 
+// a memcpy of the one we're supposed to copy.  If we don't or we're not the
 // same size as the one we're supposed to copy, then we adjust ourselves.
 //   The BinaryStringGenome takes care of the resize in its copy method.
 // It also copies the bitstring for us.
@@ -89,7 +89,7 @@ void
 GA1DBinaryStringGenome::copy(const GAGenome & orig)
 {
   if(&orig == this) return;
-  const GA1DBinaryStringGenome* c = 
+  const GA1DBinaryStringGenome* c =
     DYN_CAST(const GA1DBinaryStringGenome*, &orig);
   if(c) {
     GAGenome::copy(*c);
@@ -173,7 +173,7 @@ GA1DBinaryStringGenome::write(STD_OSTREAM & os) const
 //   Set the resize behaviour of the genome.  A genome can be fixed
 // length, resizeable with a max and min limit, or resizeable with no limits
 // (other than an implicit one that we use internally).
-//   A value of 0 means no resize, a value less than zero mean unlimited 
+//   A value of 0 means no resize, a value less than zero mean unlimited
 // resize, and a positive value means resize with that value as the limit.
 //   We return the upper limit of the genome's size.
 int
@@ -190,21 +190,21 @@ resizeBehaviour(unsigned int lower, unsigned int upper)
   return resizeBehaviour();
 }
 
-int 
+int
 GA1DBinaryStringGenome::resizeBehaviour() const {
   int val = maxX;
   if(maxX == minX) val = FIXED_SIZE;
   return val;
 }
 
-int 
+int
 GA1DBinaryStringGenome::
 equal(const GA1DBinaryStringGenome& c,
       unsigned int dest, unsigned int src, unsigned int len) const {
   return GABinaryString::equal(c,dest,src,len);
 }
 
-int 
+int
 GA1DBinaryStringGenome::equal(const GAGenome & c) const {
   if(this == &c) return 1;
   const GA1DBinaryStringGenome* b = DYN_CAST(const GA1DBinaryStringGenome*,&c);
@@ -231,7 +231,7 @@ GA1DBinaryStringGenome::equal(const GAGenome & c) const {
 // random bit function so we don't have to worry about machine-specific stuff.
 //   We also do a resize so the genome can resize itself (randomly) if it
 // is a resizeable genome.
-void 
+void
 GA1DBinaryStringGenome::UniformInitializer(GAGenome & c)
 {
   GA1DBinaryStringGenome &child=DYN_CAST(GA1DBinaryStringGenome &, c);
@@ -242,7 +242,7 @@ GA1DBinaryStringGenome::UniformInitializer(GAGenome & c)
 
 
 //   Unset all of the bits in the genome.
-void 
+void
 GA1DBinaryStringGenome::UnsetInitializer(GAGenome & c)
 {
   GA1DBinaryStringGenome &child=DYN_CAST(GA1DBinaryStringGenome &, c);
@@ -252,7 +252,7 @@ GA1DBinaryStringGenome::UnsetInitializer(GAGenome & c)
 
 
 //   Set all of the bits in the genome.
-void 
+void
 GA1DBinaryStringGenome::SetInitializer(GAGenome & c)
 {
   GA1DBinaryStringGenome &child=DYN_CAST(GA1DBinaryStringGenome &, c);
@@ -271,11 +271,11 @@ GA1DBinaryStringGenome::SetInitializer(GAGenome & c)
 // better the chance that it will match the desired mutation rate.
 //   If nMut is greater than 1, then we round up, so a mutation of 2.2 would
 // be 3 mutations, and 2.9 would be 3 as well.  nMut of 3 would be 3 mutations.
-int 
+int
 GA1DBinaryStringGenome::FlipMutator(GAGenome & c, float pmut)
 {
   GA1DBinaryStringGenome &child=DYN_CAST(GA1DBinaryStringGenome &, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float, child.length());
@@ -298,10 +298,10 @@ GA1DBinaryStringGenome::FlipMutator(GAGenome & c, float pmut)
 }
 
 
-// Return a number from 0 to 1 to indicate how similar two genomes are.  For 
+// Return a number from 0 to 1 to indicate how similar two genomes are.  For
 // the binary strings we compare bits.  We count the number of bits that are
 // the same then divide by the number of bits.  If the genomes are different
-// length then we return a -1 to indicate that we cannot calculate the 
+// length then we return a -1 to indicate that we cannot calculate the
 // similarity.
 //   Normal hamming distance makes use of population information - this is not
 // a hamming measure!  This is a similarity measure of two individuals, not
@@ -334,7 +334,7 @@ GA1DBinaryStringGenome::BitComparator(const GAGenome& a, const GAGenome& b){
 
 
 // Randomly take bits from each parent.  For each bit we flip a coin to see if
-// that bit should come from the mother or the father.  This operator can be 
+// that bit should come from the mother or the father.  This operator can be
 // used on genomes of different lengths, but the crossover is truncated to the
 // shorter of the parents and child.
 int
@@ -385,8 +385,8 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
     n = 2;
   }
   else if(c1 || c2){
-    GA1DBinaryStringGenome &sis = (c1 ? 
-				   DYN_CAST(GA1DBinaryStringGenome&, *c1) : 
+    GA1DBinaryStringGenome &sis = (c1 ?
+				   DYN_CAST(GA1DBinaryStringGenome&, *c1) :
 				   DYN_CAST(GA1DBinaryStringGenome&, *c2));
 
     if(mom.length() == dad.length() && sis.length() == mom.length()){
@@ -434,7 +434,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour() == GAGenome::FIXED_SIZE){
-      if(mom.length() != dad.length() || 
+      if(mom.length() != dad.length() ||
 	 sis.length() != bro.length() ||
 	 sis.length() != mom.length()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -461,12 +461,12 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
     sis.copy(dad, momsite, dadsite, dadlen);
     bro.copy(dad, 0, 0, dadsite);
     bro.copy(mom, dadsite, momsite, momlen);
-  
+
     n = 2;
   }
   else if(c1 || c2){
-    GA1DBinaryStringGenome &sis = (c1 ? 
-				   DYN_CAST(GA1DBinaryStringGenome&, *c1) : 
+    GA1DBinaryStringGenome &sis = (c1 ?
+				   DYN_CAST(GA1DBinaryStringGenome&, *c1) :
 				   DYN_CAST(GA1DBinaryStringGenome&, *c2));
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE){
@@ -530,7 +530,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour() == GAGenome::FIXED_SIZE){
-      if(mom.length() != dad.length() || 
+      if(mom.length() != dad.length() ||
 	 sis.length() != bro.length() ||
 	 sis.length() != mom.length()){
 	GAErr(GA_LOC, mom.className(), "two-point cross", gaErrSameLengthReqd);
@@ -558,7 +558,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
       if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
-      
+
       dadsite[0] = GARandomInt(0, dad.length());
       dadsite[1] = GARandomInt(0, dad.length());
       if(dadsite[0] > dadsite[1]) SWAP(dadsite[0], dadsite[1]);
@@ -579,8 +579,8 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
     n = 2;
   }
   else if(c1 || c2){
-    GA1DBinaryStringGenome &sis = (c1 ? 
-				   DYN_CAST(GA1DBinaryStringGenome&, *c1) : 
+    GA1DBinaryStringGenome &sis = (c1 ?
+				   DYN_CAST(GA1DBinaryStringGenome&, *c1) :
 				   DYN_CAST(GA1DBinaryStringGenome&, *c2));
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE){
@@ -605,7 +605,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
       if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
-      
+
       dadsite[0] = GARandomInt(0, dad.length());
       dadsite[1] = GARandomInt(0, dad.length());
       if(dadsite[0] > dadsite[1]) SWAP(dadsite[0], dadsite[1]);
@@ -639,10 +639,10 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
 //   Even and odd crossovers take alternating bits from the mother and father.
 // For even crossover, we take every even bit from the mother and every odd bit
 // from the father (the first bit is the 0th bit, so it is even).  Odd
-// crossover is just the opposite.  
+// crossover is just the opposite.
 int
 GA1DBinaryStringGenome::
-EvenOddCrossover(const GAGenome& p1, const GAGenome& p2, 
+EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
 		 GAGenome* c1, GAGenome* c2){
   const GA1DBinaryStringGenome &mom=
     DYN_CAST(const GA1DBinaryStringGenome &, p1);
@@ -685,7 +685,7 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
   }
   else if(c1 || c2){
     GA1DBinaryStringGenome &sis = (c1 ?
-				   DYN_CAST(GA1DBinaryStringGenome&, *c1) : 
+				   DYN_CAST(GA1DBinaryStringGenome&, *c1) :
 				   DYN_CAST(GA1DBinaryStringGenome&, *c2));
 
     if(mom.length() == dad.length() && sis.length() == mom.length()){

--- a/Static_MPFA/source/ga-mpi/GA2DArrayGenome.C
+++ b/Static_MPFA/source/ga-mpi/GA2DArrayGenome.C
@@ -27,13 +27,13 @@ GA2DArrayGenome<T>::className() const {return "GA2DArrayGenome";}
 template <class T> int
 GA2DArrayGenome<T>::classID() const {return GAID::ArrayGenome2D;}
 
-template <class T> 
+template <class T>
 GA2DArrayGenome<T>::
-GA2DArrayGenome(unsigned int width, unsigned int height, 
+GA2DArrayGenome(unsigned int width, unsigned int height,
 		GAGenome::Evaluator f,
 		void * u) :
 GAArray<T>(width*height),
-GAGenome(DEFAULT_2DARRAY_INITIALIZER, 
+GAGenome(DEFAULT_2DARRAY_INITIALIZER,
 	 DEFAULT_2DARRAY_MUTATOR,
 	 DEFAULT_2DARRAY_COMPARATOR)
 {
@@ -44,7 +44,7 @@ GAGenome(DEFAULT_2DARRAY_INITIALIZER,
 }
 
 
-template <class T> 
+template <class T>
 GA2DArrayGenome<T>::
 GA2DArrayGenome(const GA2DArrayGenome<T> & orig) : GAArray<T>(orig.sz){
   GA2DArrayGenome<T>::copy(orig);
@@ -62,10 +62,10 @@ GA2DArrayGenome<T>::copy(const GAGenome & orig){
   if(c) {
     GAGenome::copy(*c);
     GAArray<T>::copy(*c);
-    nx = c->nx; ny = c->ny; 
-    minX = c->minX; minY = c->minY; 
+    nx = c->nx; ny = c->ny;
+    minX = c->minX; minY = c->minY;
     maxX = c->maxX; maxY = c->maxY;
-  } 
+  }
 }
 
 
@@ -77,8 +77,8 @@ GA2DArrayGenome<T>::clone(GAGenome::CloneMethod flag) const {
   }
   else{
     cpy->GAGenome::copy(*this);
-    cpy->minX = minX; cpy->minY = minY; 
-    cpy->maxX = maxX; cpy->maxY = maxY; 
+    cpy->minX = minX; cpy->minY = minY;
+    cpy->maxX = maxX; cpy->maxY = maxY;
   }
   return cpy;
 }
@@ -137,7 +137,7 @@ GA2DArrayGenome<T>::read(STD_ISTREAM &) {
 
 
 template <class T> int
-GA2DArrayGenome<T>::write(STD_OSTREAM & os) const 
+GA2DArrayGenome<T>::write(STD_OSTREAM & os) const
 {
   for(unsigned int j=0; j<ny; j++){
     for(unsigned int i=0; i<nx; i++){
@@ -167,7 +167,7 @@ GA2DArrayGenome<T>::resizeBehaviour(GAGenome::Dimension which) const {
 
 template <class T> int
 GA2DArrayGenome<T>::
-resizeBehaviour(GAGenome::Dimension which, 
+resizeBehaviour(GAGenome::Dimension which,
 		unsigned int lower, unsigned int upper)
 {
   if(upper < lower){
@@ -212,12 +212,12 @@ GA2DArrayGenome<T>::copy(const GA2DArrayGenome<T> & orig,
   for(unsigned int j=0; j<h; j++)
     GAArray<T>::copy(orig, (s+j)*nx+r, (y+j)*orig.nx+x, w);
 
-  _evaluated = gaFalse; 
+  _evaluated = gaFalse;
 }
 
 
 
-template <class T> int 
+template <class T> int
 GA2DArrayGenome<T>::equal(const GAGenome & c) const
 {
   if(this == &c) return 1;
@@ -259,9 +259,9 @@ GA2DArrayAlleleGenome<T>::className() const {return "GA2DArrayAlleleGenome";}
 template <class T> int
 GA2DArrayAlleleGenome<T>::classID() const {return GAID::ArrayAlleleGenome2D;}
 
-template <class T> 
+template <class T>
 GA2DArrayAlleleGenome<T>::
-GA2DArrayAlleleGenome(unsigned int width, unsigned int height, 
+GA2DArrayAlleleGenome(unsigned int width, unsigned int height,
 		      const GAAlleleSet<T> & s,
 		      GAGenome::Evaluator f, void * u) :
 GA2DArrayGenome<T>(width,height,f,u){
@@ -275,9 +275,9 @@ GA2DArrayGenome<T>(width,height,f,u){
   this->crossover(GA2DArrayAlleleGenome<T>::DEFAULT_2DARRAY_ALLELE_CROSSOVER);
 }
 
-template <class T> 
+template <class T>
 GA2DArrayAlleleGenome<T>::
-GA2DArrayAlleleGenome(unsigned int width, unsigned int height, 
+GA2DArrayAlleleGenome(unsigned int width, unsigned int height,
 		      const GAAlleleSetArray<T> & sa,
 		      GAGenome::Evaluator f, void * u) :
 GA2DArrayGenome<T>(width,height, f, u) {
@@ -293,9 +293,9 @@ GA2DArrayGenome<T>(width,height, f, u) {
 }
 
 
-template <class T> 
+template <class T>
 GA2DArrayAlleleGenome<T>::
-GA2DArrayAlleleGenome(const GA2DArrayAlleleGenome<T> & orig) : 
+GA2DArrayAlleleGenome(const GA2DArrayAlleleGenome<T> & orig) :
 GA2DArrayGenome<T>(orig.nx, orig.ny) {
   naset = 0;
   aset = (GAAlleleSet<T>*)0;
@@ -315,10 +315,10 @@ GA2DArrayAlleleGenome<T>::clone(GAGenome::CloneMethod) const {
 }
 
 
-template <class T> void 
+template <class T> void
 GA2DArrayAlleleGenome<T>::copy(const GAGenome& orig){
   if(&orig == this) return;
-  const GA2DArrayAlleleGenome<T>* c = 
+  const GA2DArrayAlleleGenome<T>* c =
     DYN_CAST(const GA2DArrayAlleleGenome<T>*, &orig);
   if(c) {
     GA2DArrayGenome<T>::copy(*c);
@@ -386,24 +386,24 @@ GA2DArrayAlleleGenome<T>::equal(const GAGenome & c) const {
    Operator definitions
 ---------------------------------------------------------------------------- */
 // this does not handle genomes with multiple allele sets!
-template <class ARRAY_TYPE> void 
+template <class ARRAY_TYPE> void
 GA2DArrayAlleleGenome<ARRAY_TYPE>::UniformInitializer(GAGenome & c)
 {
   GA2DArrayAlleleGenome<ARRAY_TYPE> &child=
     DYN_CAST(GA2DArrayAlleleGenome<ARRAY_TYPE> &, c);
-  child.resize(GAGenome::ANY_SIZE,GAGenome::ANY_SIZE); 
+  child.resize(GAGenome::ANY_SIZE,GAGenome::ANY_SIZE);
   for(int i=child.width()-1; i>=0; i--)
     for(int j=child.height()-1; j>=0; j--)
       child.gene(i, j, child.alleleset().allele());
 }
 
 
-template <class ARRAY_TYPE> int 
+template <class ARRAY_TYPE> int
 GA2DArrayAlleleGenome<ARRAY_TYPE>::FlipMutator(GAGenome & c, float pmut)
 {
   GA2DArrayAlleleGenome<ARRAY_TYPE> &child=
     DYN_CAST(GA2DArrayAlleleGenome<ARRAY_TYPE> &, c);
-  register int n, m, i, j;
+  int n, m, i, j;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.size());
@@ -430,11 +430,11 @@ GA2DArrayAlleleGenome<ARRAY_TYPE>::FlipMutator(GAGenome & c, float pmut)
 }
 
 
-template <class ARRAY_TYPE> int 
+template <class ARRAY_TYPE> int
 GA2DArrayGenome<ARRAY_TYPE>::SwapMutator(GAGenome & c, float pmut)
 {
   GA2DArrayGenome<ARRAY_TYPE> &child=DYN_CAST(GA2DArrayGenome<ARRAY_TYPE>&, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.size());
@@ -496,7 +496,7 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
   if(c1 && c2){
     GA2DArrayGenome<T> &sis=DYN_CAST(GA2DArrayGenome<T> &, *c1);
     GA2DArrayGenome<T> &bro=DYN_CAST(GA2DArrayGenome<T> &, *c2);
-    
+
     if(sis.width() == bro.width() && sis.height() == bro.height() &&
        mom.width() == dad.width() && mom.height() == dad.height() &&
        sis.width() == mom.width() && sis.height() == mom.height()){
@@ -567,7 +567,7 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
 
 
 // This crossover does clipping (no padding) for resizables.  Notice that this
-// means that any resizable children of two parents will have identical 
+// means that any resizable children of two parents will have identical
 // dimensions no matter what.
 template <class T> int
 GA2DArrayGenome<T>::
@@ -587,8 +587,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE){
-      if(mom.width() != dad.width() || 
-	 sis.width() != bro.width() || 
+      if(mom.width() != dad.width() ||
+	 sis.width() != bro.width() ||
 	 sis.width() != mom.width()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -612,8 +612,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
-      if(mom.height() != dad.height() || 
-	 sis.height() != bro.height() || 
+      if(mom.height() != dad.height() ||
+	 sis.height() != bro.height() ||
 	 sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -637,12 +637,12 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     sis.resize(sitex+lenx, sitey+leny);
     bro.resize(sitex+lenx, sitey+leny);
-    
+
     sis.copy(mom, 0, 0, momsitex-sitex, momsitey-sitey, sitex, sitey);
     sis.copy(dad, sitex, 0, dadsitex, dadsitey-sitey, lenx, sitey);
     sis.copy(dad, 0, sitey, dadsitex-sitex, dadsitey, sitex, leny);
     sis.copy(mom, sitex, sitey, momsitex, momsitey, lenx, leny);
-    
+
     bro.copy(dad, 0, 0, dadsitex-sitex, dadsitey-sitey, sitex, sitey);
     bro.copy(mom, sitex, 0, momsitex, momsitey-sitey, lenx, sitey);
     bro.copy(mom, 0, sitey, momsitex-sitex, momsitey, sitex, leny);
@@ -652,7 +652,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
   }
   else if(c1){
     GA2DArrayGenome<T> &sis=DYN_CAST(GA2DArrayGenome<T> &, *c1);
-    
+
     if(sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE){
       if(mom.width() != dad.width() || sis.width() != mom.width()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -669,7 +669,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitex = GAMin(momsitex, dadsitex);
       lenx = GAMin(momlenx, dadlenx);
     }
-    
+
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
       if(mom.height() != dad.height() || sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -686,9 +686,9 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitey = GAMin(momsitey, dadsitey);
       leny = GAMin(momleny, dadleny);
     }
-    
+
     sis.resize(sitex+lenx, sitey+leny);
-    
+
     if(GARandomBit()){
       sis.copy(mom, 0, 0, momsitex-sitex, momsitey-sitey, sitex, sitey);
       sis.copy(dad, sitex, 0, dadsitex, dadsitey-sitey, lenx, sitey);
@@ -759,7 +759,7 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
   }
   else if(c1){
     GA2DArrayGenome<T> &sis=DYN_CAST(GA2DArrayGenome<T> &, *c1);
-    
+
     if(mom.width() == dad.width() && mom.height() == dad.height() &&
        sis.width() == mom.width() && sis.height() == mom.height()){
       int count=0;

--- a/Static_MPFA/source/ga-mpi/GA2DBinStrGenome.C
+++ b/Static_MPFA/source/ga-mpi/GA2DBinStrGenome.C
@@ -21,7 +21,7 @@
    Genome class definition
 ---------------------------------------------------------------------------- */
 GA2DBinaryStringGenome::
-GA2DBinaryStringGenome(unsigned int width, unsigned int height, 
+GA2DBinaryStringGenome(unsigned int width, unsigned int height,
 		       GAGenome::Evaluator f, void * u) :
 GABinaryString(width*height),
 GAGenome(DEFAULT_2DBINSTR_INITIALIZER,
@@ -54,8 +54,8 @@ GA2DBinaryStringGenome::clone(GAGenome::CloneMethod flag) const {
   }
   else{
     cpy->GAGenome::copy(*this);
-    cpy->minX = minX; cpy->minY = minY; 
-    cpy->maxX = maxX; cpy->maxY = maxY; 
+    cpy->minX = minX; cpy->minY = minY;
+    cpy->maxX = maxX; cpy->maxY = maxY;
   }
   return cpy;
 }
@@ -69,10 +69,10 @@ GA2DBinaryStringGenome::copy(const GAGenome & orig)
   if(c) {
     GAGenome::copy(*c);
     GABinaryString::copy(*c);
-    nx = c->nx; ny = c->ny; 
-    minX = c->minX; minY = c->minY; 
+    nx = c->nx; ny = c->ny;
+    minX = c->minX; minY = c->minY;
     maxX = c->maxX; maxY = c->maxY;
-  } 
+  }
 }
 
 
@@ -105,7 +105,7 @@ GA2DBinaryStringGenome::resize(int w, int h)
 
 // Move the bits into the right position.  If we're smaller, then shift to
 // the smaller size before we do the resize (the resize method maintains bit
-// integrety).  If we're larger, do the move after the resize.  If we're the 
+// integrety).  If we're larger, do the move after the resize.  If we're the
 // same size the we don't do anything.  When we're adding more bits, the new
 // bits get set randomly to 0 or 1.
 
@@ -153,7 +153,7 @@ GA2DBinaryStringGenome::read(STD_ISTREAM & is)
 
   _evaluated = gaFalse;
 
-  if(is.eof() && 
+  if(is.eof() &&
      ((j < ny) ||	     // didn't get some lines
       (i < nx && i != 0))){   // stopped early on a row
     GAErr(GA_LOC, className(), "read", gaErrUnexpectedEOF);
@@ -168,7 +168,7 @@ GA2DBinaryStringGenome::read(STD_ISTREAM & is)
 // Dump the digits to the stream with a newline between each row.  No newline
 // at the end of the whole thing.
 int
-GA2DBinaryStringGenome::write(STD_OSTREAM & os) const 
+GA2DBinaryStringGenome::write(STD_OSTREAM & os) const
 {
   for(unsigned int j=0; j<ny; j++){
     for(unsigned int i=0; i<nx; i++)
@@ -180,7 +180,7 @@ GA2DBinaryStringGenome::write(STD_OSTREAM & os) const
 #endif
 
 
-int 
+int
 GA2DBinaryStringGenome::resizeBehaviour(GAGenome::Dimension which) const {
   int val = 0;
   if(which == WIDTH) {
@@ -318,7 +318,7 @@ GA2DBinaryStringGenome::equal(const GA2DBinaryStringGenome& orig,
 }
 
 
-int 
+int
 GA2DBinaryStringGenome::equal(const GAGenome & c) const
 {
   if(this == &c) return 1;
@@ -344,7 +344,7 @@ GA2DBinaryStringGenome::equal(const GAGenome & c) const
   The order for looping through indices is height-then-width (ie height loops
 before a single width increment)
 ---------------------------------------------------------------------------- */
-void 
+void
 GA2DBinaryStringGenome::UniformInitializer(GAGenome & c)
 {
   GA2DBinaryStringGenome &child=DYN_CAST(GA2DBinaryStringGenome &, c);
@@ -355,7 +355,7 @@ GA2DBinaryStringGenome::UniformInitializer(GAGenome & c)
 }
 
 
-void 
+void
 GA2DBinaryStringGenome::UnsetInitializer(GAGenome & c)
 {
   GA2DBinaryStringGenome &child=DYN_CAST(GA2DBinaryStringGenome &, c);
@@ -364,20 +364,20 @@ GA2DBinaryStringGenome::UnsetInitializer(GAGenome & c)
 }
 
 
-void 
+void
 GA2DBinaryStringGenome::SetInitializer(GAGenome & c)
 {
   GA2DBinaryStringGenome &child=DYN_CAST(GA2DBinaryStringGenome &, c);
-  child.resize(GAGenome::ANY_SIZE, GAGenome::ANY_SIZE);	
+  child.resize(GAGenome::ANY_SIZE, GAGenome::ANY_SIZE);
   child.set(0, 0, child.width(), child.height());
 }
 
 
-int 
+int
 GA2DBinaryStringGenome::FlipMutator(GAGenome & c, float pmut)
 {
   GA2DBinaryStringGenome &child=DYN_CAST(GA2DBinaryStringGenome &, c);
-  register int n, m, i, j;
+  int n, m, i, j;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float, child.size());
@@ -431,7 +431,7 @@ GA2DBinaryStringGenome::BitComparator(const GAGenome& a, const GAGenome& b){
 
 int
 GA2DBinaryStringGenome::
-UniformCrossover(const GAGenome& p1, const GAGenome& p2, 
+UniformCrossover(const GAGenome& p1, const GAGenome& p2,
 		 GAGenome* c1, GAGenome* c2){
   const GA2DBinaryStringGenome &mom=
     DYN_CAST(const GA2DBinaryStringGenome &, p1);
@@ -486,8 +486,8 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
     nc = 2;
   }
   else if(c1 || c2){
-    GA2DBinaryStringGenome &sis = (c1 ? 
-				   DYN_CAST(GA2DBinaryStringGenome&, *c1) : 
+    GA2DBinaryStringGenome &sis = (c1 ?
+				   DYN_CAST(GA2DBinaryStringGenome&, *c1) :
 				   DYN_CAST(GA2DBinaryStringGenome&, *c2));
 
     if(mom.width() == dad.width() && mom.height() == dad.height() &&
@@ -515,13 +515,13 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
 
 //   When we do single point crossover on resizable 2D genomes we can either
 // clip or pad to make the mismatching geometries work out.  Either way, both
-// children end up with the same dimensions (the children have the same 
+// children end up with the same dimensions (the children have the same
 // dimensions as each other, not the same as if they were clipped/padded).
 //   When we pad, the extra space is filled with random bits.  This
 // implementation does only clipping, no padding!
 int
 GA2DBinaryStringGenome::
-OnePointCrossover(const GAGenome& p1, const GAGenome& p2, 
+OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 		  GAGenome* c1, GAGenome* c2){
   const GA2DBinaryStringGenome &mom=
     DYN_CAST(const GA2DBinaryStringGenome &, p1);
@@ -539,8 +539,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE){
-      if(mom.width() != dad.width() || 
-	 sis.width() != bro.width() || 
+      if(mom.width() != dad.width() ||
+	 sis.width() != bro.width() ||
 	 sis.width() != mom.width()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -564,8 +564,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
-      if(mom.height() != dad.height() || 
-	 sis.height() != bro.height() || 
+      if(mom.height() != dad.height() ||
+	 sis.height() != bro.height() ||
 	 sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -640,9 +640,9 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitey = GAMin(momsitey, dadsitey);
       leny = GAMin(momleny, dadleny);
     }
-    
+
     sis.resize(sitex+lenx, sitey+leny);
-    
+
     if(GARandomBit()){
       sis.copy(mom, 0, 0, momsitex-sitex, momsitey-sitey, sitex, sitey);
       sis.copy(dad, sitex, 0, dadsitex, dadsitey-sitey, lenx, sitey);
@@ -666,7 +666,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
 int
 GA2DBinaryStringGenome::
-EvenOddCrossover(const GAGenome& p1, const GAGenome& p2, 
+EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
 		 GAGenome* c1, GAGenome* c2){
   const GA2DBinaryStringGenome &mom=
     DYN_CAST(const GA2DBinaryStringGenome &, p1);
@@ -679,7 +679,7 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
   if(c1 && c2){
     GA2DBinaryStringGenome &sis=DYN_CAST(GA2DBinaryStringGenome &, *c1);
     GA2DBinaryStringGenome &bro=DYN_CAST(GA2DBinaryStringGenome &, *c2);
-    
+
     if(sis.width() == bro.width() && sis.height() == bro.height() &&
        mom.width() == dad.width() && mom.height() == dad.height() &&
        sis.width() == mom.width() && sis.height() == mom.height()){
@@ -719,10 +719,10 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
     nc = 2;
   }
   else if(c1 || c2){
-    GA2DBinaryStringGenome &sis = (c1 ? 
+    GA2DBinaryStringGenome &sis = (c1 ?
 				   DYN_CAST(GA2DBinaryStringGenome&, *c1) :
 				   DYN_CAST(GA2DBinaryStringGenome&, *c2));
-    
+
     if(mom.width() == dad.width() && mom.height() == dad.height() &&
        sis.width() == mom.width() && sis.height() == mom.height()){
       int count=0;

--- a/Static_MPFA/source/ga-mpi/GA3DArrayGenome.C
+++ b/Static_MPFA/source/ga-mpi/GA3DArrayGenome.C
@@ -27,13 +27,13 @@ GA3DArrayGenome<T>::className() const {return "GA3DArrayGenome";}
 template <class T> int
 GA3DArrayGenome<T>::classID() const {return GAID::ArrayGenome3D;}
 
-template <class T> 
+template <class T>
 GA3DArrayGenome<T>::
 GA3DArrayGenome(unsigned int w, unsigned int h, unsigned int d,
 		GAGenome::Evaluator f,
 		void * u) :
 GAArray<T>(w*h*d),
-GAGenome(DEFAULT_3DARRAY_INITIALIZER, 
+GAGenome(DEFAULT_3DARRAY_INITIALIZER,
 	 DEFAULT_3DARRAY_MUTATOR,
 	 DEFAULT_3DARRAY_COMPARATOR)
 {
@@ -44,7 +44,7 @@ GAGenome(DEFAULT_3DARRAY_INITIALIZER,
 }
 
 
-template <class T> 
+template <class T>
 GA3DArrayGenome<T>::
 GA3DArrayGenome(const GA3DArrayGenome<T> & orig) :
 GAArray<T>(orig.sz), GAGenome(){
@@ -78,7 +78,7 @@ GA3DArrayGenome<T>::clone(GAGenome::CloneMethod flag) const {
   }
   else{
     cpy->GAGenome::copy(*this);
-    cpy->minX = minX; cpy->minY = minY; cpy->minZ = minZ; 
+    cpy->minX = minX; cpy->minY = minY; cpy->minZ = minZ;
     cpy->maxX = maxX; cpy->maxY = maxY; cpy->maxZ = maxZ;
   }
   return cpy;
@@ -145,7 +145,7 @@ GA3DArrayGenome<T>::resize(int w, int h, int d)
 
   GAArray<T>::size(w*h*d);
 
-  if(w > STA_CAST(int,nx) && h > STA_CAST(int,ny)){ 
+  if(w > STA_CAST(int,nx) && h > STA_CAST(int,ny)){
     int z=GAMin(STA_CAST(int,nz),d);
     for(int k=z-1; k>=0; k--)
       for(int j=ny-1; j>=0; j--)
@@ -179,7 +179,7 @@ GA3DArrayGenome<T>::read(STD_ISTREAM &) {
 
 
 template <class T> int
-GA3DArrayGenome<T>::write(STD_OSTREAM & os) const 
+GA3DArrayGenome<T>::write(STD_OSTREAM & os) const
 {
   for(unsigned int k=0; k<nz; k++){
     for(unsigned int j=0; j<ny; j++){
@@ -216,7 +216,7 @@ GA3DArrayGenome<T>::resizeBehaviour(GAGenome::Dimension which) const {
 
 template <class T> int
 GA3DArrayGenome<T>::
-resizeBehaviour(GAGenome::Dimension which, 
+resizeBehaviour(GAGenome::Dimension which,
 		unsigned int lower, unsigned int upper)
 {
   if(upper < lower){
@@ -278,7 +278,7 @@ copy(const GA3DArrayGenome<T> & orig,
 }
 
 
-template <class T> int 
+template <class T> int
 GA3DArrayGenome<T>::equal(const GAGenome & c) const
 {
   if(this == &c) return 1;
@@ -312,7 +312,7 @@ GA3DArrayAlleleGenome<T>::className() const {return "GA3DArrayAlleleGenome";}
 template <class T> int
 GA3DArrayAlleleGenome<T>::classID() const {return GAID::ArrayAlleleGenome3D;}
 
-template <class T> 
+template <class T>
 GA3DArrayAlleleGenome<T>::
 GA3DArrayAlleleGenome(unsigned int w, unsigned int h, unsigned int d,
 		      const GAAlleleSet<T> & s,
@@ -328,7 +328,7 @@ GA3DArrayGenome<T>(w,h,d,f,u) {
   this->crossover(GA3DArrayAlleleGenome<T>::DEFAULT_3DARRAY_ALLELE_CROSSOVER);
 }
 
-template <class T> 
+template <class T>
 GA3DArrayAlleleGenome<T>::
 GA3DArrayAlleleGenome(unsigned int w, unsigned int h, unsigned int d,
 		      const GAAlleleSetArray<T> & sa,
@@ -346,9 +346,9 @@ GA3DArrayGenome<T>(w,h,d, f, u) {
 }
 
 
-template <class T> 
+template <class T>
 GA3DArrayAlleleGenome<T>::
-GA3DArrayAlleleGenome(const GA3DArrayAlleleGenome<T> & orig) : 
+GA3DArrayAlleleGenome(const GA3DArrayAlleleGenome<T> & orig) :
 GA3DArrayGenome<T>(orig.nx, orig.ny, orig.nz) {
   naset = 0;
   aset = (GAAlleleSet<T>*)0;
@@ -368,10 +368,10 @@ GA3DArrayAlleleGenome<T>::clone(GAGenome::CloneMethod) const {
 }
 
 
-template <class T> void 
+template <class T> void
 GA3DArrayAlleleGenome<T>::copy(const GAGenome& orig){
   if(&orig == this) return;
-  const GA3DArrayAlleleGenome<T>* c = 
+  const GA3DArrayAlleleGenome<T>* c =
     DYN_CAST(const GA3DArrayAlleleGenome<T>*, &orig);
   if(c) {
     GA3DArrayGenome<T>::copy(*c);
@@ -414,7 +414,7 @@ GA3DArrayAlleleGenome<T>::resize(int w, int h, int d){
     for(int k=z-1; k>=0; k--)
       for(int j=this->ny-1; j>=0; j--)
 	for(unsigned int i=oldx; i<this->nx; i++)
-	  this->a[k*this->ny*this->nx+j*this->nx+i] = 
+	  this->a[k*this->ny*this->nx+j*this->nx+i] =
 	    aset[(k*this->ny*this->nx+j*this->nx+i) % naset].allele();
   }
   else if(this->ny > oldy){
@@ -463,7 +463,7 @@ GA3DArrayAlleleGenome<T>::equal(const GAGenome & c) const {
    Operator definitions
 ---------------------------------------------------------------------------- */
 // this does not handle genomes with multiple allele sets!
-template <class ARRAY_TYPE> void 
+template <class ARRAY_TYPE> void
 GA3DArrayAlleleGenome<ARRAY_TYPE>::UniformInitializer(GAGenome & c)
 {
   GA3DArrayAlleleGenome<ARRAY_TYPE> &child=
@@ -476,12 +476,12 @@ GA3DArrayAlleleGenome<ARRAY_TYPE>::UniformInitializer(GAGenome & c)
 }
 
 
-template <class ARRAY_TYPE> int 
+template <class ARRAY_TYPE> int
 GA3DArrayAlleleGenome<ARRAY_TYPE>::FlipMutator(GAGenome & c, float pmut)
 {
   GA3DArrayAlleleGenome<ARRAY_TYPE> &child=
     DYN_CAST(GA3DArrayAlleleGenome<ARRAY_TYPE> &, c);
-  register int n, m, d, i, j, k;
+  int n, m, d, i, j, k;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.size());
@@ -512,11 +512,11 @@ GA3DArrayAlleleGenome<ARRAY_TYPE>::FlipMutator(GAGenome & c, float pmut)
 }
 
 
-template <class ARRAY_TYPE> int 
+template <class ARRAY_TYPE> int
 GA3DArrayGenome<ARRAY_TYPE>::SwapMutator(GAGenome & c, float pmut)
 {
   GA3DArrayGenome<ARRAY_TYPE> &child=DYN_CAST(GA3DArrayGenome<ARRAY_TYPE>&, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.size());
@@ -568,7 +568,7 @@ ElementComparator(const GAGenome& a, const GAGenome& b)
 
 
 
-// Make sure our bitmask is big enough, generate a mask, then use it to 
+// Make sure our bitmask is big enough, generate a mask, then use it to
 // extract the information from each parent to stuff the two children.
 // We don't deallocate any space for the masks under the assumption that we'll
 // have to use them again in the future.
@@ -680,12 +680,12 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
 //   This is designed only for genomes that are the same length.  If the child
 // is not the same length as the parent, or if the children are not the same
 // size, we don't do the crossover.
-//   In the interest of speed we do not do any checks for size.  Do not use 
+//   In the interest of speed we do not do any checks for size.  Do not use
 // this crossover method when the parents and children may be different sizes.
 // It might break!
 template <class T> int
 GA3DArrayGenome<T>::
-EvenOddCrossover(const GAGenome& p1, const GAGenome& p2, 
+EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
 GAGenome* c1, GAGenome* c2){
   const GA3DArrayGenome<T> &mom=DYN_CAST(const GA3DArrayGenome<T> &, p1);
   const GA3DArrayGenome<T> &dad=DYN_CAST(const GA3DArrayGenome<T> &, p2);
@@ -696,7 +696,7 @@ GAGenome* c1, GAGenome* c2){
   if(c1 && c2){
     GA3DArrayGenome<T> &sis=DYN_CAST(GA3DArrayGenome<T> &, *c1);
     GA3DArrayGenome<T> &bro=DYN_CAST(GA3DArrayGenome<T> &, *c2);
-    
+
     if(sis.width() == bro.width() && sis.height() == bro.height() &&
        sis.depth() == bro.depth() &&
        mom.width() == dad.width() && mom.height() == dad.height() &&
@@ -806,8 +806,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE){
-      if(mom.width() != dad.width() || 
-	 sis.width() != bro.width() || 
+      if(mom.width() != dad.width() ||
+	 sis.width() != bro.width() ||
 	 sis.width() != mom.width()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -828,11 +828,11 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitex = GAMin(momsitex, dadsitex);
       lenx = GAMin(momlenx, dadlenx);
     }
-    
+
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
-      if(mom.height() != dad.height() || 
-	 sis.height() != bro.height() || 
+      if(mom.height() != dad.height() ||
+	 sis.height() != bro.height() ||
 	 sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -856,8 +856,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE){
-      if(mom.depth() != dad.depth() || 
-	 sis.depth() != bro.depth() || 
+      if(mom.depth() != dad.depth() ||
+	 sis.depth() != bro.depth() ||
 	 sis.depth() != mom.depth()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -882,8 +882,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
     sis.resize(sitex+lenx, sitey+leny, sitez+lenz);
     bro.resize(sitex+lenx, sitey+leny, sitez+lenz);
 
-    sis.copy(mom, 
-	     0, 0, 0, 
+    sis.copy(mom,
+	     0, 0, 0,
 	     momsitex-sitex, momsitey-sitey, momsitez-sitez,
 	     sitex, sitey, sitez);
     sis.copy(dad,
@@ -898,8 +898,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	     sitex, sitey, 0,
 	     momsitex, momsitey, momsitez-sitez,
 	     lenx, leny, sitez);
-    sis.copy(dad, 
-	     0, 0, sitez, 
+    sis.copy(dad,
+	     0, 0, sitez,
 	     dadsitex-sitex, dadsitey-sitey, dadsitez,
 	     sitex, sitey, lenz);
     sis.copy(mom,
@@ -914,9 +914,9 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	     sitex, sitey, sitez,
 	     dadsitex, dadsitey, dadsitez,
 	     lenx, leny, lenz);
-    
-    bro.copy(dad, 
-	     0, 0, 0, 
+
+    bro.copy(dad,
+	     0, 0, 0,
 	     dadsitex-sitex, dadsitey-sitey, dadsitez-sitez,
 	     sitex, sitey, sitez);
     bro.copy(mom,
@@ -931,8 +931,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	     sitex, sitey, 0,
 	     dadsitex, dadsitey, dadsitez-sitez,
 	     lenx, leny, sitez);
-    bro.copy(mom, 
-	     0, 0, sitez, 
+    bro.copy(mom,
+	     0, 0, sitez,
 	     momsitex-sitex, momsitey-sitey, momsitez,
 	     sitex, sitey, lenz);
     bro.copy(dad,
@@ -969,7 +969,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitex = GAMin(momsitex, dadsitex);
       lenx = GAMin(momlenx, dadlenx);
     }
-    
+
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
       if(mom.height() != dad.height() || sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -1003,12 +1003,12 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitez = GAMin(momsitez, dadsitez);
       lenz = GAMin(momlenz, dadlenz);
     }
-    
+
     sis.resize(sitex+lenx, sitey+leny, sitez+lenz);
-    
+
     if(GARandomBit()){
-      sis.copy(mom, 
-	       0, 0, 0, 
+      sis.copy(mom,
+	       0, 0, 0,
 	       momsitex-sitex, momsitey-sitey, momsitez-sitez,
 	       sitex, sitey, sitez);
       sis.copy(dad,
@@ -1023,8 +1023,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	       sitex, sitey, 0,
 	       momsitex, momsitey, momsitez-sitez,
 	       lenx, leny, sitez);
-      sis.copy(dad, 
-	       0, 0, sitez, 
+      sis.copy(dad,
+	       0, 0, sitez,
 	       dadsitex-sitex, dadsitey-sitey, dadsitez,
 	       sitex, sitey, lenz);
       sis.copy(mom,
@@ -1041,8 +1041,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	       lenx, leny, lenz);
     }
     else{
-      sis.copy(dad, 
-	       0, 0, 0, 
+      sis.copy(dad,
+	       0, 0, 0,
 	       dadsitex-sitex, dadsitey-sitey, dadsitez-sitez,
 	       sitex, sitey, sitez);
       sis.copy(mom,
@@ -1057,8 +1057,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	       sitex, sitey, 0,
 	       dadsitex, dadsitey, dadsitez-sitez,
 	       lenx, leny, sitez);
-      sis.copy(mom, 
-	       0, 0, sitez, 
+      sis.copy(mom,
+	       0, 0, sitez,
 	       momsitex-sitex, momsitey-sitey, momsitez,
 	       sitex, sitey, lenz);
       sis.copy(dad,

--- a/Static_MPFA/source/ga-mpi/GA3DBinStrGenome.C
+++ b/Static_MPFA/source/ga-mpi/GA3DBinStrGenome.C
@@ -56,7 +56,7 @@ GA3DBinaryStringGenome::clone(GAGenome::CloneMethod flag) const {
   }
   else{
     cpy->GAGenome::copy(*this);
-    cpy->minX = minX; cpy->minY = minY; cpy->minZ = minZ; 
+    cpy->minX = minX; cpy->minY = minY; cpy->minZ = minZ;
     cpy->maxX = maxX; cpy->maxY = maxY; cpy->maxZ = maxZ;
   }
   return cpy;
@@ -66,7 +66,7 @@ void
 GA3DBinaryStringGenome::copy(const GAGenome & orig)
 {
   if(&orig == this) return;
-  const GA3DBinaryStringGenome* c = 
+  const GA3DBinaryStringGenome* c =
     DYN_CAST(const GA3DBinaryStringGenome*, &orig);
   if(c) {
     GAGenome::copy(*c);
@@ -206,7 +206,7 @@ GA3DBinaryStringGenome::read(STD_ISTREAM & is)
 
   _evaluated = gaFalse;
 
-  if(is.eof() && 
+  if(is.eof() &&
      ((k < nz) ||		// didn't get some lines
       (j < ny && j != 0) ||	// didn't get some lines
       (i < nx && i != 0))){	// didn't get some lines
@@ -219,10 +219,10 @@ GA3DBinaryStringGenome::read(STD_ISTREAM & is)
 }
 
 
-// Dump the bits to the stream with a newline at the end of each row and 
+// Dump the bits to the stream with a newline at the end of each row and
 // another at the end of each layer.  No newline at the end of the block.
 int
-GA3DBinaryStringGenome::write(STD_OSTREAM & os) const 
+GA3DBinaryStringGenome::write(STD_OSTREAM & os) const
 {
   for(unsigned int k=0; k<nz; k++){
     for(unsigned int j=0; j<ny; j++){
@@ -424,13 +424,13 @@ equal(const GA3DBinaryStringGenome& orig,
     for(unsigned int j=0; j<h; j++)
       eq += GABinaryString::equal(orig,
 				  (z+k)*ny*nx + (y+j)*nx + x,
-				  (srcz+k)*ny*nx + (srcy+j)*nx + srcx, 
+				  (srcz+k)*ny*nx + (srcy+j)*nx + srcx,
 				  w);
   return eq==d*h ? 1 : 0;
 }
 
 
-int 
+int
 GA3DBinaryStringGenome::equal(const GAGenome & c) const
 {
   if(this == &c) return 1;
@@ -459,7 +459,7 @@ GA3DBinaryStringGenome::equal(const GAGenome & c) const
 (ie depth loops before a single height increment, height loops before a single
 width increment)
 ---------------------------------------------------------------------------- */
-void 
+void
 GA3DBinaryStringGenome::UniformInitializer(GAGenome & c)
 {
   GA3DBinaryStringGenome &child=DYN_CAST(GA3DBinaryStringGenome &, c);
@@ -471,7 +471,7 @@ GA3DBinaryStringGenome::UniformInitializer(GAGenome & c)
 }
 
 
-void 
+void
 GA3DBinaryStringGenome::UnsetInitializer(GAGenome & c)
 {
   GA3DBinaryStringGenome &child=DYN_CAST(GA3DBinaryStringGenome &, c);
@@ -480,7 +480,7 @@ GA3DBinaryStringGenome::UnsetInitializer(GAGenome & c)
 }
 
 
-void 
+void
 GA3DBinaryStringGenome::SetInitializer(GAGenome & c)
 {
   GA3DBinaryStringGenome &child=DYN_CAST(GA3DBinaryStringGenome &, c);
@@ -489,11 +489,11 @@ GA3DBinaryStringGenome::SetInitializer(GAGenome & c)
 }
 
 
-int 
+int
 GA3DBinaryStringGenome::FlipMutator(GAGenome & c, float pmut)
 {
   GA3DBinaryStringGenome &child=DYN_CAST(GA3DBinaryStringGenome &, c);
-  register int n, m, i, j, k, d;
+  int n, m, i, j, k, d;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.size());
@@ -550,7 +550,7 @@ GA3DBinaryStringGenome::BitComparator(const GAGenome& a, const GAGenome& b){
 
 
 
-// Make sure our bitmask is big enough, generate a mask, then use it to 
+// Make sure our bitmask is big enough, generate a mask, then use it to
 // extract the information from each parent to stuff the two children.
 // We don't deallocate any space for the masks under the assumption that we'll
 // have to use them again in the future.
@@ -626,10 +626,10 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
     nc = 2;
   }
   else if(c1 || c2){
-    GA3DBinaryStringGenome &sis = (c1 ? 
-				   DYN_CAST(GA3DBinaryStringGenome&, *c1) : 
+    GA3DBinaryStringGenome &sis = (c1 ?
+				   DYN_CAST(GA3DBinaryStringGenome&, *c1) :
 				   DYN_CAST(GA3DBinaryStringGenome&, *c2));
-    
+
     if(mom.width() == dad.width() && mom.height() == dad.height() &&
        mom.depth() == dad.depth() &&
        sis.width() == mom.width() && sis.height() == mom.height() &&
@@ -665,7 +665,7 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
 //   This is designed only for genomes that are the same length.  If the child
 // is not the same length as the parent, or if the children are not the same
 // size, we don't do the crossover.
-//   In the interest of speed we do not do any checks for size.  Do not use 
+//   In the interest of speed we do not do any checks for size.  Do not use
 // this crossover method when the parents and children may be different sizes.
 // It might break!
 int
@@ -733,7 +733,7 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
   }
   else if(c1 || c2){
     GA3DBinaryStringGenome &sis = (c1 ?
-				   DYN_CAST(GA3DBinaryStringGenome &, *c1) : 
+				   DYN_CAST(GA3DBinaryStringGenome &, *c1) :
 				   DYN_CAST(GA3DBinaryStringGenome &, *c2));
 
     if(mom.width() == dad.width() && mom.height() == dad.height() &&
@@ -772,7 +772,7 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
 
 
 // Pick a single point in the 3D block and grab alternating quadrants for each
-// child.  If the children are resizable, this crossover does clipping or 
+// child.  If the children are resizable, this crossover does clipping or
 // padding depending on the setting of the clip flag.  If we pad, we fill the
 // additional bits with random contents.
 int
@@ -795,8 +795,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE){
-      if(mom.width() != dad.width() || 
-	 sis.width() != bro.width() || 
+      if(mom.width() != dad.width() ||
+	 sis.width() != bro.width() ||
 	 sis.width() != mom.width()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -817,11 +817,11 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitex = GAMin(momsitex, dadsitex);
       lenx = GAMin(momlenx, dadlenx);
     }
-    
+
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
-      if(mom.height() != dad.height() || 
-	 sis.height() != bro.height() || 
+      if(mom.height() != dad.height() ||
+	 sis.height() != bro.height() ||
 	 sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -842,11 +842,11 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitey = GAMin(momsitey, dadsitey);
       leny = GAMin(momleny, dadleny);
     }
-    
+
     if(sis.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE){
-      if(mom.depth() != dad.depth() || 
-	 sis.depth() != bro.depth() || 
+      if(mom.depth() != dad.depth() ||
+	 sis.depth() != bro.depth() ||
 	 sis.depth() != mom.depth()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -871,8 +871,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
     sis.resize(sitex+lenx, sitey+leny, sitez+lenz);
     bro.resize(sitex+lenx, sitey+leny, sitez+lenz);
 
-    sis.copy(mom, 
-	     0, 0, 0, 
+    sis.copy(mom,
+	     0, 0, 0,
 	     momsitex-sitex, momsitey-sitey, momsitez-sitez,
 	     sitex, sitey, sitez);
     sis.copy(dad,
@@ -887,8 +887,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	     sitex, sitey, 0,
 	     momsitex, momsitey, momsitez-sitez,
 	     lenx, leny, sitez);
-    sis.copy(dad, 
-	     0, 0, sitez, 
+    sis.copy(dad,
+	     0, 0, sitez,
 	     dadsitex-sitex, dadsitey-sitey, dadsitez,
 	     sitex, sitey, lenz);
     sis.copy(mom,
@@ -903,9 +903,9 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	     sitex, sitey, sitez,
 	     dadsitex, dadsitey, dadsitez,
 	     lenx, leny, lenz);
-    
-    bro.copy(dad, 
-	     0, 0, 0, 
+
+    bro.copy(dad,
+	     0, 0, 0,
 	     dadsitex-sitex, dadsitey-sitey, dadsitez-sitez,
 	     sitex, sitey, sitez);
     bro.copy(mom,
@@ -920,8 +920,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	     sitex, sitey, 0,
 	     dadsitex, dadsitey, dadsitez-sitez,
 	     lenx, leny, sitez);
-    bro.copy(mom, 
-	     0, 0, sitez, 
+    bro.copy(mom,
+	     0, 0, sitez,
 	     momsitex-sitex, momsitey-sitey, momsitez,
 	     sitex, sitey, lenz);
     bro.copy(dad,
@@ -936,7 +936,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	     sitex, sitey, sitez,
 	     momsitex, momsitey, momsitez,
 	     lenx, leny, lenz);
-    
+
     nc = 2;
   }
   else if(c1 || c2){
@@ -960,7 +960,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitex = GAMin(momsitex, dadsitex);
       lenx = GAMin(momlenx, dadlenx);
     }
-    
+
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
       if(mom.height() != dad.height() || sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -977,7 +977,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitey = GAMin(momsitey, dadsitey);
       leny = GAMin(momleny, dadleny);
     }
-    
+
     if(sis.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE){
       if(mom.depth() != dad.depth() || sis.depth() != mom.depth()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -998,8 +998,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
     sis.resize(sitex+lenx, sitey+leny, sitez+lenz);
 
     if(GARandomBit()){
-      sis.copy(mom, 
-	       0, 0, 0, 
+      sis.copy(mom,
+	       0, 0, 0,
 	       momsitex-sitex, momsitey-sitey, momsitez-sitez,
 	       sitex, sitey, sitez);
       sis.copy(dad,
@@ -1014,8 +1014,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	       sitex, sitey, 0,
 	       momsitex, momsitey, momsitez-sitez,
 	       lenx, leny, sitez);
-      sis.copy(dad, 
-	       0, 0, sitez, 
+      sis.copy(dad,
+	       0, 0, sitez,
 	       dadsitex-sitex, dadsitey-sitey, dadsitez,
 	       sitex, sitey, lenz);
       sis.copy(mom,
@@ -1032,8 +1032,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	       lenx, leny, lenz);
     }
     else{
-      sis.copy(dad, 
-	       0, 0, 0, 
+      sis.copy(dad,
+	       0, 0, 0,
 	       dadsitex-sitex, dadsitey-sitey, dadsitez-sitez,
 	       sitex, sitey, sitez);
       sis.copy(mom,
@@ -1048,8 +1048,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	       sitex, sitey, 0,
 	       dadsitex, dadsitey, dadsitez-sitez,
 	       lenx, leny, sitez);
-      sis.copy(mom, 
-	       0, 0, sitez, 
+      sis.copy(mom,
+	       0, 0, sitez,
 	       momsitex-sitex, momsitey-sitey, momsitez,
 	       sitex, sitey, lenz);
       sis.copy(dad,

--- a/Static_MPFA/source/ga-mpi/GAListGenome.C
+++ b/Static_MPFA/source/ga-mpi/GAListGenome.C
@@ -17,7 +17,7 @@
 #include <ga-mpi/GAMask.h>
 #include <ga-mpi/garandom.h>
 
-template <class T> int 
+template <class T> int
 GAListIsHole(const GAListGenome<T>&, const GAListGenome<T>&, int, int, int);
 
 
@@ -30,8 +30,8 @@ GAListGenome<T>::className() const {return "GAListGenome";}
 template <class T> int
 GAListGenome<T>::classID() const {return GAID::ListGenome;}
 
-template <class T> 
-GAListGenome<T>::GAListGenome(GAGenome::Evaluator f, void * u) : 
+template <class T>
+GAListGenome<T>::GAListGenome(GAGenome::Evaluator f, void * u) :
 GAList<T>(),
 GAGenome(DEFAULT_LIST_INITIALIZER,
 	 DEFAULT_LIST_MUTATOR,
@@ -42,8 +42,8 @@ GAGenome(DEFAULT_LIST_INITIALIZER,
 }
 
 
-template <class T> 
-GAListGenome<T>::GAListGenome(const GAListGenome<T> & orig) : 
+template <class T>
+GAListGenome<T>::GAListGenome(const GAListGenome<T> & orig) :
 GAList<T>(),
 GAGenome() {
   GAListGenome<T>::copy(orig);
@@ -76,10 +76,10 @@ GAListGenome<T>::copy(const GAGenome & orig){
 
 #ifdef GALIB_USE_STREAMS
 // Traverse the list (breadth-first) and dump the contents as best we can to
-// the stream.  We don't try to write the contents of the nodes - we simply 
+// the stream.  We don't try to write the contents of the nodes - we simply
 // write a . for each node in the list.
 template <class T> int
-GAListGenome<T>::write(STD_OSTREAM & os) const 
+GAListGenome<T>::write(STD_OSTREAM & os) const
 {
   os << "node       next       prev       contents\n";
   if(!this->hd) return 0;;
@@ -105,7 +105,7 @@ GAListGenome<T>::write(STD_OSTREAM & os) const
 // then you have nothing to worry about.
 //   Neither of these operators affects the internal iterator of either
 // list genome in any way.
-template <class T> int 
+template <class T> int
 GAListGenome<T>::equal(const GAGenome & c) const
 {
   if(this == &c) return 1;
@@ -136,14 +136,14 @@ GAListGenome<T>::equal(const GAGenome & c) const
 ---------------------------------------------------------------------------- */
 // Mutate a list by nuking nodes.  Any node has a pmut chance of getting nuked.
 // This is actually kind of bogus for the second part of the if clause (if nMut
-// is greater than or equal to 1).  Nodes end up having more than pmut 
+// is greater than or equal to 1).  Nodes end up having more than pmut
 // probability of getting nuked.
 //   After the mutation the iterator is left at the head of the list.
 template <class T> int
 GAListGenome<T>::DestructiveMutator(GAGenome & c, float pmut)
 {
   GAListGenome<T> &child=DYN_CAST(GAListGenome<T> &, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return 0;
 
   n = child.size();
@@ -171,14 +171,14 @@ GAListGenome<T>::DestructiveMutator(GAGenome & c, float pmut)
 
 // Mutate a list by swapping two nodes.  Any node has a pmut chance of getting
 // swapped, and the swap could happen to any other node.  And in the case of
-// nMut < 1, the swap may generate a swap partner that is the same node, in 
+// nMut < 1, the swap may generate a swap partner that is the same node, in
 // which case no swap occurs (we don't check).
 //   After the mutation the iterator is left at the head of the list.
 template <class T> int
 GAListGenome<T>::SwapMutator(GAGenome & c, float pmut)
 {
   GAListGenome<T> &child=DYN_CAST(GAListGenome<T> &, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return 0;
 
   n = child.size();
@@ -205,7 +205,7 @@ GAListGenome<T>::SwapMutator(GAGenome & c, float pmut)
 
 // This comparator returns the number of elements that the two lists have
 // in common (both in position and in value).  If they are different lengths
-// then we just say they are completely different.  This is probably barely 
+// then we just say they are completely different.  This is probably barely
 // adequate for most applications - we really should give more credit for
 // nodes that are the same but in different positions.  But that would be
 // pretty nasty to compute.
@@ -213,7 +213,7 @@ GAListGenome<T>::SwapMutator(GAGenome & c, float pmut)
 // which to compare this diversity measure.  Its kind of hard to define this
 // one in a general way...
 template <class T> float
-GAListGenome<T>::NodeComparator(const GAGenome& a, const GAGenome& b) 
+GAListGenome<T>::NodeComparator(const GAGenome& a, const GAGenome& b)
 {
   if(&a == &b) return 0;
   const GAListGenome<T>& sis=DYN_CAST(const GAListGenome<T>&, a);
@@ -244,7 +244,7 @@ GAListGenome<T>::NodeComparator(const GAGenome& a, const GAGenome& b)
 
 #define SWAP(a,b) {unsigned int tmp=a; a=b; b=tmp;}
 
-// This crossover picks a site between nodes in each parent.  It is the same 
+// This crossover picks a site between nodes in each parent.  It is the same
 // as single point crossover on a resizeable binary string genome.  The site
 // in the mother is not necessarily the same as the site in the father!
 //   When we pick a crossover site, it is between nodes of the list (otherwise
@@ -253,7 +253,7 @@ GAListGenome<T>::NodeComparator(const GAGenome& a, const GAGenome& b)
 // whereas the cross site possibilities are numbered from 0 to size, inclusive.
 // This means we have to map the site to the list to determine whether an
 // insertion should occur before or after a node.
-//   We first copy the mother into the child (this deletes whatever contents 
+//   We first copy the mother into the child (this deletes whatever contents
 // were in the child originally).  Then we clone the father from the cross site
 // to the end of the list.  Then we delete the tail of the child from the
 // mother's cross site to the end of the list.  Finally, we insert the clone
@@ -265,7 +265,7 @@ GAListGenome<T>::NodeComparator(const GAGenome& a, const GAGenome& b)
 // do better by copying only what we need of the mother.
 template <class T> int
 GAListGenome<T>::
-OnePointCrossover(const GAGenome& p1, const GAGenome& p2, 
+OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 		  GAGenome* c1, GAGenome* c2){
   const GAListGenome<T> &mom=DYN_CAST(const GAListGenome<T> &, p1);
   const GAListGenome<T> &dad=DYN_CAST(const GAListGenome<T> &, p2);
@@ -330,13 +330,13 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 //   This version of the partial match crossover uses objects that are multiply
 // instantiated - each list genome contains its own objects in its nodes.
 // The operator== method must be defined on the object for this implementation
-// to work!  In this case, the 'object' is an int, so we're OK.  If you are 
+// to work!  In this case, the 'object' is an int, so we're OK.  If you are
 // putting your own objects in the nodes, be sure you have operator== defined
 // for your object.  You must also have operator!= defined for your object.  We
 // do not do any assignments, so operator= and/or copy is not required.
 //   We assume that none of the nodes will return a NULL pointer.  Also assume
 // that the cross site has been selected properly.
-//   First we make a copy of the mother.  Then we loop through the match 
+//   First we make a copy of the mother.  Then we loop through the match
 // section and try to swap each element in the child's match section with its
 // partner (as defined by the current node in the father's match section).
 //   Mirroring will work the same way - just swap mom & dad and you're all set.

--- a/Static_MPFA/source/ga-mpi/GARealGenome.C
+++ b/Static_MPFA/source/ga-mpi/GARealGenome.C
@@ -13,7 +13,7 @@
 
 // We must also specialize the allele set so that the alleles are handled
 // properly.  Be sure to handle bounds correctly whether we are discretized
-// or continuous.  Handle the case where someone sets stupid bounds that 
+// or continuous.  Handle the case where someone sets stupid bounds that
 // might cause an infinite loop for exclusive bounds.
 template <> float
 GAAlleleSet<float>::allele() const {
@@ -29,8 +29,8 @@ GAAlleleSet<float>::allele() const {
     if(core->lowerb == GAAllele::EXCLUSIVE) value += core->a[2];
   }
   else{
-    if(core->a[0] == core->a[1] && 
-       core->lowerb == GAAllele::EXCLUSIVE && 
+    if(core->a[0] == core->a[1] &&
+       core->lowerb == GAAllele::EXCLUSIVE &&
        core->upperb == GAAllele::EXCLUSIVE) {
       value = core->a[0];
     }
@@ -74,9 +74,9 @@ GAAlleleSet<float>::allele(unsigned int i) const {
 
 // now the specialization of the genome itself.
 
-template <> const char * 
+template <> const char *
 GA1DArrayAlleleGenome<float>::className() const {return "GARealGenome";}
-template <> int 
+template <> int
 GA1DArrayAlleleGenome<float>::classID() const {return GAID::FloatGenome;}
 
 template <> GA1DArrayAlleleGenome<float>::
@@ -108,7 +108,7 @@ GA1DArrayGenome<float>(sa.size(), f, u){
   crossover(DEFAULT_REAL_CROSSOVER);
 }
 
-template <> 
+template <>
 GA1DArrayAlleleGenome<float>::~GA1DArrayAlleleGenome(){
   delete [] aset;
 }
@@ -148,12 +148,12 @@ GA1DArrayAlleleGenome<float>::read(STD_ISTREAM & is) {
 ---------------------------------------------------------------------------- */
 // The Gaussian mutator picks a new value based on a Gaussian distribution
 // around the current value.  We respect the bounds (if any).
-//*** need to figure out a way to make the stdev other than 1.0 
-int 
+//*** need to figure out a way to make the stdev other than 1.0
+int
 GARealGaussianMutator(GAGenome& g, float pmut){
   GA1DArrayAlleleGenome<float> &child=
     DYN_CAST(GA1DArrayAlleleGenome<float> &, g);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * (float)(child.length());
@@ -200,7 +200,7 @@ GARealGaussianMutator(GAGenome& g, float pmut){
 // identical.  If parents are not the same length, the extra elements are not
 // set!  You might want to add some noise to this so that both children are not
 // the same...
-int 
+int
 GARealArithmeticCrossover(const GAGenome& p1, const GAGenome& p2,
 			  GAGenome* c1, GAGenome* c2) {
   const GA1DArrayGenome<float> &mom=
@@ -222,8 +222,8 @@ GARealArithmeticCrossover(const GAGenome& p1, const GAGenome& p2,
     n = 2;
   }
   else if(c1 || c2){
-    GA1DArrayGenome<float> &sis = (c1 ? 
-				   DYN_CAST(GA1DArrayGenome<float> &, *c1) : 
+    GA1DArrayGenome<float> &sis = (c1 ?
+				   DYN_CAST(GA1DArrayGenome<float> &, *c1) :
 				   DYN_CAST(GA1DArrayGenome<float> &, *c2));
 
     int len = GAMax(mom.length(), dad.length());
@@ -240,7 +240,7 @@ GARealArithmeticCrossover(const GAGenome& p1, const GAGenome& p2,
 // Blend crossover generates a new value based on the interval between parents.
 // We generate a uniform distribution based on the distance between parent
 // values, then choose the child value based upon that distribution.
-int 
+int
 GARealBlendCrossover(const GAGenome& p1, const GAGenome& p2,
 		     GAGenome* c1, GAGenome* c2) {
   const GA1DArrayGenome<float> &mom=
@@ -257,9 +257,9 @@ GARealBlendCrossover(const GAGenome& p1, const GAGenome& p2,
     int len = GAMax(mom.length(), dad.length());
     for(int i=0; i<len; i++) {
       float dist = 0;
-      if(mom.gene(i) > dad.gene(i)) 
+      if(mom.gene(i) > dad.gene(i))
 	dist = mom.gene(i) - dad.gene(i);
-      else 
+      else
 	dist = dad.gene(i) - mom.gene(i);
       float lo = (GAMin(mom.gene(i), dad.gene(i))) - 0.5*dist;
       float hi = (GAMax(mom.gene(i), dad.gene(i))) + 0.5*dist;
@@ -276,9 +276,9 @@ GARealBlendCrossover(const GAGenome& p1, const GAGenome& p2,
     int len = GAMax(mom.length(), dad.length());
     for(int i=0; i<len; i++) {
       float dist = 0;
-      if(mom.gene(i) > dad.gene(i)) 
+      if(mom.gene(i) > dad.gene(i))
 	dist = mom.gene(i) - dad.gene(i);
-      else 
+      else
 	dist = dad.gene(i) - mom.gene(i);
       float lo = (GAMin(mom.gene(i), dad.gene(i))) - 0.5*dist;
       float hi = (GAMax(mom.gene(i), dad.gene(i))) + 0.5*dist;
@@ -298,7 +298,7 @@ GARealBlendCrossover(const GAGenome& p1, const GAGenome& p2,
 //
 // These must be included _after_ the specializations because some compilers
 // get all wigged out about the declaration/specialization order.  Note that
-// some compilers require a syntax different than others when forcing the 
+// some compilers require a syntax different than others when forcing the
 // instantiation (i.e. GNU wants the 'template class', borland does not).
 #ifndef GALIB_USE_AUTO_INST
 #include <ga-mpi/GAAllele.C>

--- a/Static_MPFA/source/ga-mpi/GATreeGenome.C
+++ b/Static_MPFA/source/ga-mpi/GATreeGenome.C
@@ -25,7 +25,7 @@ template <class T> int
 GATreeGenome<T>::classID() const {return GAID::TreeGenome;}
 
 template <class T>
-GATreeGenome<T>::GATreeGenome(GAGenome::Evaluator f, void * u) : 
+GATreeGenome<T>::GATreeGenome(GAGenome::Evaluator f, void * u) :
 GATree<T>(),
 GAGenome(DEFAULT_TREE_INITIALIZER,
 	 DEFAULT_TREE_MUTATOR,
@@ -37,7 +37,7 @@ GAGenome(DEFAULT_TREE_INITIALIZER,
 
 
 template <class T>
-GATreeGenome<T>::GATreeGenome(const GATreeGenome<T> & orig) : 
+GATreeGenome<T>::GATreeGenome(const GATreeGenome<T> & orig) :
 GATree<T>(),
 GAGenome() {
   GATreeGenome<T>::copy(orig);
@@ -70,7 +70,7 @@ GATreeGenome<T>::copy(const GAGenome & orig) {
 
 #ifdef GALIB_USE_STREAMS
 // Traverse the tree (breadth-first) and dump the contents as best we can to
-// the stream.  We don't try to write the contents of the nodes - we simply 
+// the stream.  We don't try to write the contents of the nodes - we simply
 // write a . for each node in the tree.
 //   We allocate space for x,y coord pair for each node in the tree.  Then we
 // do a depth-first traversal of the tree and assign coords to the nodes in the
@@ -102,7 +102,7 @@ _tt(STD_OSTREAM & os, GANode<T> * n)
 }
 
 template <class T> int
-GATreeGenome<T>::write(STD_OSTREAM & os) const 
+GATreeGenome<T>::write(STD_OSTREAM & os) const
 {
   os << "node       parent     child      next       prev       contents\n";
   _tt(os, (GANode<T> *)(this->rt));
@@ -111,7 +111,7 @@ GATreeGenome<T>::write(STD_OSTREAM & os) const
 #endif
 
 
-template <class T> int  
+template <class T> int
 GATreeGenome<T>::equal(const GAGenome & c) const
 {
   if(this == &c) return 1;
@@ -140,7 +140,7 @@ template <class T> int
 GATreeGenome<T>::DestructiveMutator(GAGenome & c, float pmut)
 {
   GATreeGenome<T> &child=DYN_CAST(GATreeGenome<T> &, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return 0;
 
   n = child.size();
@@ -169,14 +169,14 @@ GATreeGenome<T>::DestructiveMutator(GAGenome & c, float pmut)
 // This is a rearranging mutation operator.  It randomly picks two nodes in the
 // tree and swaps them.  Any node has a pmut chance of getting
 // swapped, and the swap could happen to any other node.  And in the case of
-// nMut < 1, the swap may generate a swap partner that is the same node, in 
+// nMut < 1, the swap may generate a swap partner that is the same node, in
 // which case no swap occurs (we don't check).
 //   After the mutation the iterator is left at the root of the tree.
 template <class T> int
 GATreeGenome<T>::SwapNodeMutator(GAGenome & c, float pmut)
 {
   GATreeGenome<T> &child=DYN_CAST(GATreeGenome<T> &, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return 0;
 
   n = child.size();
@@ -214,7 +214,7 @@ template <class T> int
 GATreeGenome<T>::SwapSubtreeMutator(GAGenome & c, float pmut)
 {
   GATreeGenome<T> &child=DYN_CAST(GATreeGenome<T> &, c);
-  register int n, i;
+  int n, i;
   int a, b;
   if(pmut <= 0.0) return 0;
 
@@ -247,7 +247,7 @@ GATreeGenome<T>::SwapSubtreeMutator(GAGenome & c, float pmut)
 // We use the recursive tree function to compare the tree structures.  This
 // does not compare the contents of the nodes.
 template <class T> float
-GATreeGenome<T>::TopologyComparator(const GAGenome& a, const GAGenome& b) 
+GATreeGenome<T>::TopologyComparator(const GAGenome& a, const GAGenome& b)
 {
   if(&a == &b) return 0;
   const GATreeGenome<T>& sis=DYN_CAST(const GATreeGenome<T>&, a);
@@ -277,7 +277,7 @@ GATreeGenome<T>::TopologyComparator(const GAGenome& a, const GAGenome& b)
 //     do the check to see if the crossover site is valid.
 template <class T> int
 GATreeGenome<T>::
-OnePointCrossover(const GAGenome& p1, const GAGenome& p2, 
+OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 		  GAGenome* c1, GAGenome* c2){
   const GATreeGenome<T> &mom=DYN_CAST(const GATreeGenome<T> &, p1);
   const GATreeGenome<T> &dad=DYN_CAST(const GATreeGenome<T> &, p2);

--- a/Transportation_MPFA/source/evolver.cpp
+++ b/Transportation_MPFA/source/evolver.cpp
@@ -11,7 +11,7 @@
 // For shared memory management
 #include <sys/mman.h>
 
-#include <ctime> // For clock()
+#include <ctime>  // For clock()
 #include <chrono> // For clock()
 #include <mpi.h>
 
@@ -31,12 +31,12 @@
 #include <source/MPFA/MPFA_loop_functions.h>
 
 // For timing
-#include <ctime> // For clock()
+#include <ctime>  // For clock()
 #include <chrono> // For clock()
 
 // For shared variable between child and parent process
-#include  <sys/ipc.h>
-#include  <sys/shm.h>
+#include <sys/ipc.h>
+#include <sys/shm.h>
 
 float objective(GAGenome &);
 float LaunchARGoS(GAGenome &);
@@ -44,11 +44,11 @@ float LaunchARGoS(GAGenome &);
 int mpi_tasks, mpi_rank;
 
 int elitism = 0;
-int n_trials = 20; // used by the objective function
+int n_trials = 20;            // used by the objective function
 double mutation_stdev = 1.00; // Gaussian mutation stdev - will be scaled by possible range
 string experiment_path;
 
-void CPFAInitializer(GAGenome & c);
+void CPFAInitializer(GAGenome &c);
 int GARealGaussianMutatorStdev(GAGenome &, float);
 
 std::default_random_engine generator;
@@ -62,125 +62,124 @@ int main(int argc, char **argv)
   MPI_Init(&argc, &argv);
   MPI_Comm_size(MPI_COMM_WORLD, &mpi_tasks);
   MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
-                         
-  char hostname[1024];                                                                                                       
-  hostname[1023] = '\0';                                          
+
+  char hostname[1024];
+  hostname[1023] = '\0';
   gethostname(hostname, 1023);
-  
+
   double mutation_rate = 0.01;
   double crossover_rate = 0.01;
   int population_size = 10;
   int n_generations = 10;
 
-    char c='h';
+  char c = 'h';
   // Handle command line arguments
-  while ((c = getopt (argc, argv, "t:g:p:c:m:s:h:e:x:")) != -1)
+  while ((c = getopt(argc, argv, "t:g:p:c:m:s:h:e:x:")) != -1)
     switch (c)
-      {
-      case 'x':
-	experiment_path = optarg;
+    {
+    case 'x':
+      experiment_path = optarg;
       break;
-      case 't':
-	n_trials = atoi(optarg);
-	break;
-      case 'g':
-        n_generations = atoi(optarg);
-        break;
-      case 'p':
-        population_size = atoi(optarg);
-        break;
-      case 'm':
-        mutation_rate = strtod(optarg, NULL);
-	break;
-      case 'c':
-	crossover_rate = strtod(optarg, NULL);
-	break;
-      case 's':
-        mutation_stdev = strtod(optarg, NULL);
-	break;
-      case 'e':
-        elitism = atoi(optarg);
-	break;
-      case 'h':
-	printf("Usage: %s -p {population size} -g {number of generations} -t {number of trials} -c {crossover rate} -m {mutation rate} -s {mutation standard deviation} -e {elitism 0 or 1}", argv[0]);
-	break;
-      case '?':
-        if (optopt == 'p')
-          fprintf (stderr, "Option -%c requires an argument specifying the population size.\n", optopt);
-	else if (optopt == 'g')
-	  fprintf (stderr, "Option -%c requires an argument specifying the number of generations.\n", optopt);
-	else if (optopt == 't')
-	  fprintf (stderr, "Option -%c requires an argument specifying the number of trials.\n", optopt);
-	else if (optopt == 'c')
-	  fprintf (stderr, "Option -%c requires an argument specifying the crossover rate.\n", optopt);
-	else if (optopt == 'm')
-	  fprintf (stderr, "Option -%c requires an argument specifying the mutation rate.\n", optopt);
-	else if (optopt == 's')
-	  fprintf (stderr, "Option -%c requires an argument specifying the mutation standard deviation.\n", optopt);
-        else if (isprint (optopt))
-          fprintf (stderr, "Unknown option `-%c'.\n", optopt);
-        else
-          fprintf (stderr,
-                   "Unknown option character `\\x%x'.\n",
-                   optopt);
-        return 1;
-      default:
-	printf("Usage: %s -p {population size} -g {number of generations} -t {number of trials} -c {crossover rate} -m {mutation rate} -s {mutation standard deviation}", argv[0]);
-        abort ();
-      }
+    case 't':
+      n_trials = atoi(optarg);
+      break;
+    case 'g':
+      n_generations = atoi(optarg);
+      break;
+    case 'p':
+      population_size = atoi(optarg);
+      break;
+    case 'm':
+      mutation_rate = strtod(optarg, NULL);
+      break;
+    case 'c':
+      crossover_rate = strtod(optarg, NULL);
+      break;
+    case 's':
+      mutation_stdev = strtod(optarg, NULL);
+      break;
+    case 'e':
+      elitism = atoi(optarg);
+      break;
+    case 'h':
+      printf("Usage: %s -p {population size} -g {number of generations} -t {number of trials} -c {crossover rate} -m {mutation rate} -s {mutation standard deviation} -e {elitism 0 or 1}", argv[0]);
+      break;
+    case '?':
+      if (optopt == 'p')
+        fprintf(stderr, "Option -%c requires an argument specifying the population size.\n", optopt);
+      else if (optopt == 'g')
+        fprintf(stderr, "Option -%c requires an argument specifying the number of generations.\n", optopt);
+      else if (optopt == 't')
+        fprintf(stderr, "Option -%c requires an argument specifying the number of trials.\n", optopt);
+      else if (optopt == 'c')
+        fprintf(stderr, "Option -%c requires an argument specifying the crossover rate.\n", optopt);
+      else if (optopt == 'm')
+        fprintf(stderr, "Option -%c requires an argument specifying the mutation rate.\n", optopt);
+      else if (optopt == 's')
+        fprintf(stderr, "Option -%c requires an argument specifying the mutation standard deviation.\n", optopt);
+      else if (isprint(optopt))
+        fprintf(stderr, "Unknown option `-%c'.\n", optopt);
+      else
+        fprintf(stderr,
+                "Unknown option character `\\x%x'.\n",
+                optopt);
+      return 1;
+    default:
+      printf("Usage: %s -p {population size} -g {number of generations} -t {number of trials} -c {crossover rate} -m {mutation rate} -s {mutation standard deviation}", argv[0]);
+      abort();
+    }
 
   if (experiment_path.empty())
-    {
-      printf("Usage: %s -p {population size} -g {number of generations} -t {number of trials} -c {crossover rate} -m {mutation rate} -s {mutation standard deviation} -x {argos experiment file}\n", argv[0]);
-      exit(1);
-    }
+  {
+    printf("Usage: %s -p {population size} -g {number of generations} -t {number of trials} -c {crossover rate} -m {mutation rate} -s {mutation standard deviation} -x {argos experiment file}\n", argv[0]);
+    exit(1);
+  }
 
   float max_float = std::numeric_limits<float>::max();
 
-    //printf("%s:\tworker %d ready.\n", hostname, mpi_rank);                                          
+  // printf("%s:\tworker %d ready.\n", hostname, mpi_rank);
 
   // See if we've been given a seed to use (for testing purposes).  When you
   // specify a random seed, the evolution will be exactly the same each time
   // you use that seed number
   unsigned int seed = 12345;
-  for(int i=1 ; i<argc ; i++)
-    if(strcmp(argv[i++],"seed") == 0)
+  for (int i = 1; i < argc; i++)
+    if (strcmp(argv[i++], "seed") == 0)
       seed = atoi(argv[i]);
 
   srand(seed);
   generator.seed(seed);
   // popsize / mpi_tasks must be an integer
-  population_size = mpi_tasks * int((double)population_size/(double)mpi_tasks+0.999);
-  
-  if (mpi_rank==0)
-    {
-      printf("Population size: %d\nNumber of trials: %d\nNumber of generations: %d\nCrossover rate: %f\nMutation rate: %f\nMutation stdev: %f\nAllocated MPI workers: %d\n", population_size, n_trials, n_generations, crossover_rate, mutation_rate, mutation_stdev, mpi_tasks);
-      	printf("elitism: %d\n", elitism);
-    }
+  population_size = mpi_tasks * int((double)population_size / (double)mpi_tasks + 0.999);
+
+  if (mpi_rank == 0)
+  {
+    printf("Population size: %d\nNumber of trials: %d\nNumber of generations: %d\nCrossover rate: %f\nMutation rate: %f\nMutation stdev: %f\nAllocated MPI workers: %d\n", population_size, n_trials, n_generations, crossover_rate, mutation_rate, mutation_stdev, mpi_tasks);
+    printf("elitism: %d\n", elitism);
+  }
 
   // Define the genome
   GARealAlleleSetArray allele_array;
-  
-  allele_array.add(0, 1.0); // Probability of switching to search
-  allele_array.add(0, 1.0); // Probability of returning to nest
-  allele_array.add(0, 4*M_PI); // Uninformed search variation
-  allele_array.add(0, 20); // Rate of informed search decay
-  allele_array.add(0, 20); // Rate of site fidelity
-  allele_array.add(0, 20); // Rate of laying pheremone
-  allele_array.add(0, 20); // Rate of pheremone decay
-  
-    
+
+  allele_array.add(0, 1.0);      // Probability of switching to search
+  allele_array.add(0, 1.0);      // Probability of returning to nest
+  allele_array.add(0, 4 * M_PI); // Uninformed search variation
+  allele_array.add(0, 20);       // Rate of informed search decay
+  allele_array.add(0, 20);       // Rate of site fidelity
+  allele_array.add(0, 20);       // Rate of laying pheremone
+  allele_array.add(0, 20);       // Rate of pheremone decay
+
   // Create the template genome using the phenotype map we just made.
   GARealGenome genome(allele_array, objective);
   genome.crossover(GARealUniformCrossover);
   genome.mutator(GARealGaussianMutatorStdev); // Specify our version of the Gaussuan mutator
   genome.initializer(CPFAInitializer);
- 
+
   // Now create the GA using the genome and run it.
   GASimpleGA ga(genome);
   GALinearScaling scaling;
-  ga.maximize();		// Maximize the objective
- 
+  ga.maximize(); // Maximize the objective
+
   ga.populationSize(population_size);
   ga.nGenerations(n_generations);
   ga.pMutation(mutation_rate);
@@ -190,7 +189,7 @@ int main(int argc, char **argv)
     ga.elitist(gaTrue);
   else
     ga.elitist(gaFalse);
-  if(mpi_rank == 0)
+  if (mpi_rank == 0)
     ga.scoreFilename("evolution.txt");
   else
     ga.scoreFilename("/dev/null");
@@ -198,338 +197,363 @@ int main(int argc, char **argv)
   ga.scoreFrequency(1);
   ga.flushFrequency(1);
   ga.selectScores(GAStatistics::AllScores);
-  
+
   // Pass MPI data to the GA class
   ga.mpi_rank(mpi_rank);
   ga.mpi_tasks(mpi_tasks);
-  //ga.evolve(seed); // Manual generations
+  // ga.evolve(seed); // Manual generations
 
-// initialize the ga since we are not using the evolve function
+  // initialize the ga since we are not using the evolve function
   ga.initialize(seed); // This is essential for the mpi workers to be sychronized
 
-    // Name the results file with the current time and date
- time_t t = time(0);   // get time now
-    struct tm * now = localtime( & t );
-    stringstream ss;
+  // Name the results file with the current time and date
+  time_t t = time(0); // get time now
+  struct tm *now = localtime(&t);
+  stringstream ss;
 
-    boost::filesystem::path exp_path(experiment_path);
-    
-    ss << "results/CPFA-evolution-"
-       << exp_path.stem().string() << '-'
-       <<GIT_BRANCH<<"-"<<GIT_COMMIT_HASH<<"-"
-       << (now->tm_year) << '-'
-       << (now->tm_mon + 1) << '-'
-       <<  now->tm_mday << '-'
-       <<  now->tm_hour << '-'
-       <<  now->tm_min << '-'
-       <<  now->tm_sec << ".csv";
+  boost::filesystem::path exp_path(experiment_path);
 
-    string results_file_name = ss.str();
+  ss << "results/CPFA-evolution-"
+     << exp_path.stem().string() << '-'
+     << GIT_BRANCH << "-" << GIT_COMMIT_HASH << "-"
+     << (now->tm_year) << '-'
+     << (now->tm_mon + 1) << '-'
+     << now->tm_mday << '-'
+     << now->tm_hour << '-'
+     << now->tm_min << '-'
+     << now->tm_sec << ".csv";
 
-    if (mpi_rank == 0)
-      {
+  string results_file_name = ss.str();
+
+  if (mpi_rank == 0)
+  {
     // Write output file header
     ofstream results_output_stream;
-	results_output_stream.open(results_file_name, ios::app);
-	results_output_stream << "Population size: " << population_size << "\nNumber of trials: " << n_trials << "\nNumber of generations: "<< n_generations<<"\nCrossover rate: "<< crossover_rate<<"\nMutation rate: " << mutation_rate << "\nMutation stdev: "<< mutation_stdev << "Algorithm: CPFA\n" << "Number of searchers: 6\n" << "Number of targets: 256\n" << "Target distribution: power law" << endl;
-	results_output_stream << "Generation" 
-			      << ", " << "Compute Time (s)"
-			      << ", " << "Convergence"
-			      << ", " << "Mean"
-			      << ", " << "Maximum"
-			      << ", " << "Minimum"
-			      << ", " << "Standard Deviation"
-			      << ", " << "Diversity"
-			      << ", " << "ProbabilityOfSwitchingToSearching"
-			      << ", " << "ProbabilityOfReturningToNest"
-			      << ", " << "UninformedSearchVariation"
-			      << ", " << "RateOfInformedSearchDecay"
-			      << ", " << "RateOfSiteFidelity"
-			      << ", " << "RateOfLayingPheromone"
-			      << ", " << "RateOfPheromoneDecay";
+    results_output_stream.open(results_file_name, ios::app);
+    results_output_stream << "Population size: " << population_size << "\nNumber of trials: " << n_trials << "\nNumber of generations: " << n_generations << "\nCrossover rate: " << crossover_rate << "\nMutation rate: " << mutation_rate << "\nMutation stdev: " << mutation_stdev << "Algorithm: CPFA\n"
+                          << "Number of searchers: 6\n"
+                          << "Number of targets: 256\n"
+                          << "Target distribution: power law" << endl;
+    results_output_stream << "Generation"
+                          << ", "
+                          << "Compute Time (s)"
+                          << ", "
+                          << "Convergence"
+                          << ", "
+                          << "Mean"
+                          << ", "
+                          << "Maximum"
+                          << ", "
+                          << "Minimum"
+                          << ", "
+                          << "Standard Deviation"
+                          << ", "
+                          << "Diversity"
+                          << ", "
+                          << "ProbabilityOfSwitchingToSearching"
+                          << ", "
+                          << "ProbabilityOfReturningToNest"
+                          << ", "
+                          << "UninformedSearchVariation"
+                          << ", "
+                          << "RateOfInformedSearchDecay"
+                          << ", "
+                          << "RateOfSiteFidelity"
+                          << ", "
+                          << "RateOfLayingPheromone"
+                          << ", "
+                          << "RateOfPheromoneDecay";
 
-	results_output_stream << endl;
-	results_output_stream.close();
-      }
+    results_output_stream << endl;
+    results_output_stream.close();
+  }
 
-	while(!ga.done())
-	  {
+  while (!ga.done())
+  {
 
-	    std::chrono::time_point<std::chrono::system_clock>generation_start, generation_end;
-	    if (mpi_rank == 0)
-	      {
-		generation_start = std::chrono::system_clock::now();
-	      }
-	    
-      // Calculate the generation
-      ga.step();
+    std::chrono::time_point<std::chrono::system_clock> generation_start, generation_end;
+    if (mpi_rank == 0)
+    {
+      generation_start = std::chrono::system_clock::now();
+    }
 
-    if(mpi_rank == 0)
-      {
-	generation_end = std::chrono::system_clock::now();
-	std::chrono::duration<double> generation_elapsed_seconds = generation_end-generation_start;
-	ofstream results_output_stream;
-	results_output_stream.open(results_file_name, ios::app);
-       results_output_stream << ga.statistics().generation() 
-			     << ", " << generation_elapsed_seconds.count()
-			     << ", " << ga.statistics().convergence()
-			     << ", " << ga.statistics().current(GAStatistics::Mean)
-			     << ", " << ga.statistics().current(GAStatistics::Maximum)
-			     << ", " << ga.statistics().current(GAStatistics::Minimum)
-			     << ", " << ga.statistics().current(GAStatistics::Deviation)
-			     << ", " << ga.statistics().current(GAStatistics::Diversity);
-       
-	  for (int i = 0; i < GENOME_SIZE; i++)
-	    results_output_stream << ", " << dynamic_cast<const GARealGenome&>(ga.population().best()).gene(i);
+    // Calculate the generation
+    ga.step();
 
-	  
-	  const GARealGenome& best_genome = dynamic_cast<const GARealGenome&>(ga.statistics().bestIndividual());
-	  results_output_stream << endl;
-	  
-	  results_output_stream << "The GA found an optimum at: ";
-	  results_output_stream << best_genome.gene(0);
-	  for (int i = 1; i < GENOME_SIZE; i++)
-	    results_output_stream << ", " << best_genome.gene(i);
-	  results_output_stream << " with score: " << best_genome.score();
-	  results_output_stream << endl;
-	  results_output_stream.close();
-      }
-	  }
-	// Display the GA's progress
-	if(mpi_rank == 0)
-	  {
-	    cout << ga.statistics() << " " << ga.parameters() << endl;
-	  }
-	
+    if (mpi_rank == 0)
+    {
+      generation_end = std::chrono::system_clock::now();
+      std::chrono::duration<double> generation_elapsed_seconds = generation_end - generation_start;
+      ofstream results_output_stream;
+      results_output_stream.open(results_file_name, ios::app);
+      results_output_stream << ga.statistics().generation()
+                            << ", " << generation_elapsed_seconds.count()
+                            << ", " << ga.statistics().convergence()
+                            << ", " << ga.statistics().current(GAStatistics::Mean)
+                            << ", " << ga.statistics().current(GAStatistics::Maximum)
+                            << ", " << ga.statistics().current(GAStatistics::Minimum)
+                            << ", " << ga.statistics().current(GAStatistics::Deviation)
+                            << ", " << ga.statistics().current(GAStatistics::Diversity);
+
+      for (int i = 0; i < GENOME_SIZE; i++)
+        results_output_stream << ", " << dynamic_cast<const GARealGenome &>(ga.population().best()).gene(i);
+
+      const GARealGenome &best_genome = dynamic_cast<const GARealGenome &>(ga.statistics().bestIndividual());
+      results_output_stream << endl;
+
+      results_output_stream << "The GA found an optimum at: ";
+      results_output_stream << best_genome.gene(0);
+      for (int i = 1; i < GENOME_SIZE; i++)
+        results_output_stream << ", " << best_genome.gene(i);
+      results_output_stream << " with score: " << best_genome.score();
+      results_output_stream << endl;
+      results_output_stream.close();
+    }
+  }
+  // Display the GA's progress
+  if (mpi_rank == 0)
+  {
+    cout << ga.statistics() << " " << ga.parameters() << endl;
+  }
+
   MPI_Finalize();
 
   program_end = std::chrono::system_clock::now();
- 
-  std::chrono::duration<double> program_elapsed_seconds = program_end-program_start;
 
-  if(mpi_rank == 0)
+  std::chrono::duration<double> program_elapsed_seconds = program_end - program_start;
+
+  if (mpi_rank == 0)
     printf("Run time was %f seconds\n", program_elapsed_seconds.count());
 
   return 0;
-  }
+}
 
-// Initializes the genome according to the Beyond Pheromones paper 
-void CPFAInitializer(GAGenome & c)
+// Initializes the genome according to the Beyond Pheromones paper
+void CPFAInitializer(GAGenome &c)
 {
   // For the exponential PDF needed to initialize some of the genes
-  
+
   std::exponential_distribution<double> exponential_distribution_10(10.0);
   std::exponential_distribution<double> exponential_distribution_5(5.0);
   std::uniform_real_distribution<double> uniform_distribution_0_1(0.0, 1.0);
-  std::uniform_real_distribution<double> uniform_distribution_0_4PI(0.0, 4.0*M_PI);
+  std::uniform_real_distribution<double> uniform_distribution_0_4PI(0.0, 4.0 * M_PI);
   std::uniform_real_distribution<double> uniform_distribution_0_20(0.0, 20.0);
 
-  GA1DArrayAlleleGenome<float> &child= DYN_CAST(GA1DArrayAlleleGenome<float> &, c);
+  GA1DArrayAlleleGenome<float> &child = DYN_CAST(GA1DArrayAlleleGenome<float> &, c);
   child.resize(GAGenome::ANY_SIZE); // let chrom resize if it can
-  
-  child.gene(0, uniform_distribution_0_1(generator)); // Probability of switching to search
-  child.gene(1, uniform_distribution_0_1(generator)); // Probability of returning to nest
-  child.gene(2, uniform_distribution_0_4PI(generator)); // Uninformed search variation
-  child.gene(3, exponential_distribution_5(generator)); // Rate of informed search decay
-  child.gene(4, uniform_distribution_0_20(generator)); // Rate of site fidelity
-  child.gene(5, uniform_distribution_0_20(generator)); // Rate of laying pheremone
+
+  child.gene(0, uniform_distribution_0_1(generator));    // Probability of switching to search
+  child.gene(1, uniform_distribution_0_1(generator));    // Probability of returning to nest
+  child.gene(2, uniform_distribution_0_4PI(generator));  // Uninformed search variation
+  child.gene(3, exponential_distribution_5(generator));  // Rate of informed search decay
+  child.gene(4, uniform_distribution_0_20(generator));   // Rate of site fidelity
+  child.gene(5, uniform_distribution_0_20(generator));   // Rate of laying pheremone
   child.gene(6, exponential_distribution_10(generator)); // Rate of pheremone decay
 }
 
 // The mutation operator based on the original from GALib but adds stdev
 // The Gaussian mutator picks a new value based on a Gaussian distribution
 // around the current value.  We respect the bounds (if any).
-int GARealGaussianMutatorStdev(GAGenome& g, float pmut)
+int GARealGaussianMutatorStdev(GAGenome &g, float pmut)
 {
-  GA1DArrayAlleleGenome<float> &child=
-    DYN_CAST(GA1DArrayAlleleGenome<float> &, g);
-  register int n, i;
-  if(pmut <= 0.0) return(0);
+  GA1DArrayAlleleGenome<float> &child =
+      DYN_CAST(GA1DArrayAlleleGenome<float> &, g);
+  int n, i;
+  if (pmut <= 0.0)
+    return (0);
 
   float nMut = pmut * (float)(child.length());
-  int length = child.length()-1;
-  if(nMut < 1.0){// we have to do a flip test on each element
+  int length = child.length() - 1;
+  if (nMut < 1.0)
+  { // we have to do a flip test on each element
     nMut = 0;
-    for(i=length; i>=0; i--){
+    for (i = length; i >= 0; i--)
+    {
       float value = child.gene(i);
-      if(GAFlipCoin(pmut)){
-	if(child.alleleset(i).type() == GAAllele::ENUMERATED ||
-	   child.alleleset(i).type() == GAAllele::DISCRETIZED)
-	  value = child.alleleset(i).allele();
-	else if(child.alleleset(i).type() == GAAllele::BOUNDED){
-	  value += GAUnitGaussian()*mutation_stdev;//*(child.alleleset(i).upper()-child.alleleset(i).lower()); // since the standard deviation varies proportionally to a constant multiplier 
-	  value = GAMax(child.alleleset(i).lower(), value);
-	  value = GAMin(child.alleleset(i).upper(), value);
-	}
-	child.gene(i, value);
-	nMut++;
+      if (GAFlipCoin(pmut))
+      {
+        if (child.alleleset(i).type() == GAAllele::ENUMERATED ||
+            child.alleleset(i).type() == GAAllele::DISCRETIZED)
+          value = child.alleleset(i).allele();
+        else if (child.alleleset(i).type() == GAAllele::BOUNDED)
+        {
+          value += GAUnitGaussian() * mutation_stdev; //*(child.alleleset(i).upper()-child.alleleset(i).lower()); // since the standard deviation varies proportionally to a constant multiplier
+          value = GAMax(child.alleleset(i).lower(), value);
+          value = GAMin(child.alleleset(i).upper(), value);
+        }
+        child.gene(i, value);
+        nMut++;
       }
     }
   }
-  else{// only mutate the ones we need to
-    for(n=0; n<nMut; n++){
-      int idx = GARandomInt(0,length);
+  else
+  { // only mutate the ones we need to
+    for (n = 0; n < nMut; n++)
+    {
+      int idx = GARandomInt(0, length);
       float value = child.gene(idx);
-      if(child.alleleset(idx).type() == GAAllele::ENUMERATED ||
-	 child.alleleset(idx).type() == GAAllele::DISCRETIZED)
-	value = child.alleleset(idx).allele();
-      else if(child.alleleset(idx).type() == GAAllele::BOUNDED){
-	value += GAUnitGaussian()*mutation_stdev*(child.alleleset(i).upper()-child.alleleset(i).lower()); // since the standard deviation varies proportionally to a constant multiplier 
-	value = GAMax(child.alleleset(idx).lower(), value);
-	value = GAMin(child.alleleset(idx).upper(), value);
+      if (child.alleleset(idx).type() == GAAllele::ENUMERATED ||
+          child.alleleset(idx).type() == GAAllele::DISCRETIZED)
+        value = child.alleleset(idx).allele();
+      else if (child.alleleset(idx).type() == GAAllele::BOUNDED)
+      {
+        value += GAUnitGaussian() * mutation_stdev * (child.alleleset(i).upper() - child.alleleset(i).lower()); // since the standard deviation varies proportionally to a constant multiplier
+        value = GAMax(child.alleleset(idx).lower(), value);
+        value = GAMin(child.alleleset(idx).upper(), value);
       }
       child.gene(idx, value);
     }
   }
-  return((int)nMut);
+  return ((int)nMut);
 }
-
 
 float objective(GAGenome &c)
 {
   float avg = 0;
-  
+
   // For timing
   std::chrono::time_point<std::chrono::system_clock> start, end;
   start = std::chrono::system_clock::now();
 
-  for (int i = 0; i < n_trials; i++) avg += LaunchARGoS(c);
-  
+  for (int i = 0; i < n_trials; i++)
+    avg += LaunchARGoS(c);
+
   avg /= n_trials;
 
-  
   end = std::chrono::system_clock::now();
-  
-  std::chrono::duration<double> elapsed_seconds = end-start;
 
-  MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);     
+  std::chrono::duration<double> elapsed_seconds = end - start;
 
-      char hostname[1024];              
-      hostname[1023] = '\0';                                          
-      gethostname(hostname, 1023);     
- 
-      /*
-      printf("Worker %d on %s evaluated genome [", mpi_rank, hostname);
-      for (int i = 0; i < GENOME_SIZE; i++)
-	printf("%f ",dynamic_cast<const GARealGenome&>(c).gene(i));
-      printf("] in %f seconds. ", elapsed_seconds.count());
-      printf("Fitness: %f.\n", avg );
-      */
+  MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
 
-      return avg;
+  char hostname[1024];
+  hostname[1023] = '\0';
+  gethostname(hostname, 1023);
+
+  /*
+  printf("Worker %d on %s evaluated genome [", mpi_rank, hostname);
+  for (int i = 0; i < GENOME_SIZE; i++)
+printf("%f ",dynamic_cast<const GARealGenome&>(c).gene(i));
+  printf("] in %f seconds. ", elapsed_seconds.count());
+  printf("Fitness: %f.\n", avg );
+  */
+
+  return avg;
 }
 
 /*
  * Launch ARGoS to evaluate a genome.
  */
-float LaunchARGoS(GAGenome& c_genome) 
+float LaunchARGoS(GAGenome &c_genome)
 {
   // Declate the fitness value and the shared memory segment id and address
   float fitness = 0;
-  int    ShmID;
-  float*   ShmPTR;
-  
+  int ShmID;
+  float *ShmPTR;
+
   // Allocate the shared memory to use between this process and the child argos process
   ShmID = shmget(IPC_PRIVATE, sizeof(float), IPC_CREAT | 0666);
-  if (ShmID < 0) {
+  if (ShmID < 0)
+  {
     printf("ERROR: Allocating shared memory segment in main.cpp:LaunchARGoS() failed.\n");
     exit(1);
   }
-  
+
   // Attach to the shared memory segment
-  ShmPTR = (float*) shmat(ShmID, NULL, 0);
-  if ((float*) ShmPTR == (float*)-1) 
-    {
-      printf("ERROR: Attaching to shared memory segment in main.cpp:LaunchARGoS() failed.\n");
-      exit(1);
-    }
+  ShmPTR = (float *)shmat(ShmID, NULL, 0);
+  if ((float *)ShmPTR == (float *)-1)
+  {
+    printf("ERROR: Attaching to shared memory segment in main.cpp:LaunchARGoS() failed.\n");
+    exit(1);
+  }
 
   *ShmPTR = 0; // Initialise
 
   pid_t pid = fork(); // Create the new process with a copy of this memory space
 
   if (pid == 0)
-    {
-      // In child process - run the argos3 simulation
+  {
+    // In child process - run the argos3 simulation
 
-      /* Convert the received genome to the actual genome type */
-      GARealGenome& cRealGenome = dynamic_cast<GARealGenome&>(c_genome);
-  
-      Real* cpfa_genome = new Real[GENOME_SIZE];
+    /* Convert the received genome to the actual genome type */
+    GARealGenome &cRealGenome = dynamic_cast<GARealGenome &>(c_genome);
 
-      // Convert to a convenient format for the argos controller
-      for (int i = 0; i < GENOME_SIZE; i++)
-	cpfa_genome[i] = cRealGenome.gene(i);
-       
-      /*      
-      printf("%s: worker %d started a genome evaluation. (%f, %f, %f, %f, %f, %f, %f)\n", hostname, mpi_rank, 
-	     cpfa_genome[0],
-	     cpfa_genome[1],
-	     cpfa_genome[2],
-	     cpfa_genome[3],
-	     cpfa_genome[4],
-	     cpfa_genome[5],
-	     cpfa_genome[6]);
-      */
+    Real *cpfa_genome = new Real[GENOME_SIZE];
 
-      /* Redirect LOG and LOGERR to dedicated files to prevent clutter on the screen */
-      std::ofstream cLOGFile("argos_logs/ARGoS_LOG_" + ToString(::getpid()), std::ios::out);
-      LOG.DisableColoredOutput();
-      LOG.GetStream().rdbuf(cLOGFile.rdbuf());
-      std::ofstream cLOGERRFile("argos_logs/ARGoS_LOGERR_" + ToString(::getpid()), std::ios::out);
-      LOGERR.DisableColoredOutput();
-      LOGERR.GetStream().rdbuf(cLOGERRFile.rdbuf());
+    // Convert to a convenient format for the argos controller
+    for (int i = 0; i < GENOME_SIZE; i++)
+      cpfa_genome[i] = cRealGenome.gene(i);
 
-      /*
-       * Initialize ARGoS
-       */
-      /* The CSimulator class of ARGoS is a singleton. Therefore, to
-       * manipulate an ARGoS experiment, it is enough to get its instance */
-      argos::CSimulator& cSimulator = argos::CSimulator::GetInstance();
+    /*
+    printf("%s: worker %d started a genome evaluation. (%f, %f, %f, %f, %f, %f, %f)\n", hostname, mpi_rank,
+     cpfa_genome[0],
+     cpfa_genome[1],
+     cpfa_genome[2],
+     cpfa_genome[3],
+     cpfa_genome[4],
+     cpfa_genome[5],
+     cpfa_genome[6]);
+    */
 
-      // Set the .argos configuration file
-      cSimulator.SetExperimentFileName(experiment_path);
-      
-      // Load it to configure ARGoS 
-      cSimulator.LoadExperiment();
+    /* Redirect LOG and LOGERR to dedicated files to prevent clutter on the screen */
+    std::ofstream cLOGFile("argos_logs/ARGoS_LOG_" + ToString(::getpid()), std::ios::out);
+    LOG.DisableColoredOutput();
+    LOG.GetStream().rdbuf(cLOGFile.rdbuf());
+    std::ofstream cLOGERRFile("argos_logs/ARGoS_LOGERR_" + ToString(::getpid()), std::ios::out);
+    LOGERR.DisableColoredOutput();
+    LOGERR.GetStream().rdbuf(cLOGERRFile.rdbuf());
 
-      // Get a reference to the loop functions
-      MPFA_loop_functions& cLoopFunctions = dynamic_cast<MPFA_loop_functions&>(cSimulator.GetLoopFunctions());
+    /*
+     * Initialize ARGoS
+     */
+    /* The CSimulator class of ARGoS is a singleton. Therefore, to
+     * manipulate an ARGoS experiment, it is enough to get its instance */
+    argos::CSimulator &cSimulator = argos::CSimulator::GetInstance();
 
-      // Configure the controller with the genome
-      cLoopFunctions.ConfigureFromGenome(cpfa_genome);
+    // Set the .argos configuration file
+    cSimulator.SetExperimentFileName(experiment_path);
 
-      // Run the experiment
-      cSimulator.Execute();
+    // Load it to configure ARGoS
+    cSimulator.LoadExperiment();
 
-      // Update performance and store in the shared memory segment
-      *ShmPTR = cLoopFunctions.Score();;
+    // Get a reference to the loop functions
+    MPFA_loop_functions &cLoopFunctions = dynamic_cast<MPFA_loop_functions &>(cSimulator.GetLoopFunctions());
 
-      // For testing
-      //float score = 0;
-      //for (int i = 0; i < GENOME_SIZE; i++) score += cpfa_genome[i];
-      //*ShmPTR = score;
+    // Configure the controller with the genome
+    cLoopFunctions.ConfigureFromGenome(cpfa_genome);
 
-      // Clean up the simulation
-      cSimulator.Destroy();
-      
-      // Clean up the temp genome copy
-	delete [] cpfa_genome;
+    // Run the experiment
+    cSimulator.Execute();
 
-	// Make this process exit
-      _Exit(0); 
-    }
-  
+    // Update performance and store in the shared memory segment
+    *ShmPTR = cLoopFunctions.Score();
+    ;
+
+    // For testing
+    // float score = 0;
+    // for (int i = 0; i < GENOME_SIZE; i++) score += cpfa_genome[i];
+    //*ShmPTR = score;
+
+    // Clean up the simulation
+    cSimulator.Destroy();
+
+    // Clean up the temp genome copy
+    delete[] cpfa_genome;
+
+    // Make this process exit
+    _Exit(0);
+  }
+
   // In parent - wait for child to finish
   int status = wait(&status);
 
   // Make a local copy of the shared fitness value
-  fitness = *ShmPTR;  
+  fitness = *ShmPTR;
 
   // Release shared memory
-  shmdt((void *) ShmPTR);
+  shmdt((void *)ShmPTR);
   shmctl(ShmID, IPC_RMID, NULL);
 
-  /* Return the result of the evaluation */  
+  /* Return the result of the evaluation */
   return fitness;
 }

--- a/Transportation_MPFA/source/ga-mpi/GA1DArrayGenome.C
+++ b/Transportation_MPFA/source/ga-mpi/GA1DArrayGenome.C
@@ -18,7 +18,7 @@
 #include <ga-mpi/GA1DArrayGenome.h>
 #include <ga-mpi/GAMask.h>
 
-template <class T> int 
+template <class T> int
 GA1DArrayIsHole(const GA1DArrayGenome<T>&, const GA1DArrayGenome<T>&,
 		int, int, int);
 
@@ -36,15 +36,15 @@ GA1DArrayGenome<T>::classID() const {return GAID::ArrayGenome;}
 // this point - initialization must be done explicitly by the user of the
 // genome (eg when the population is created or reset).  If we called the
 // initializer routine here then we could end up with multiple initializations
-// and/or calls to dummy initializers (for example when the genome is 
+// and/or calls to dummy initializers (for example when the genome is
 // created with a dummy initializer and the initializer is assigned later on).
 // Besides, we default to the no-initialization initializer by calling the
 // default genome constructor.
-template <class T> 
+template <class T>
 GA1DArrayGenome<T>::
 GA1DArrayGenome(unsigned int length, GAGenome::Evaluator f, void * u) :
 GAArray<T>(length),
-GAGenome(DEFAULT_1DARRAY_INITIALIZER, 
+GAGenome(DEFAULT_1DARRAY_INITIALIZER,
 	 DEFAULT_1DARRAY_MUTATOR,
 	 DEFAULT_1DARRAY_COMPARATOR) {
   evaluator(f);
@@ -56,9 +56,9 @@ GAGenome(DEFAULT_1DARRAY_INITIALIZER,
 
 // This is the copy initializer.  We set everything to the default values, then
 // copy the original.  The Array creator takes care of zeroing the data.
-template <class T> 
+template <class T>
 GA1DArrayGenome<T>::
-GA1DArrayGenome(const GA1DArrayGenome<T> & orig) : 
+GA1DArrayGenome(const GA1DArrayGenome<T> & orig) :
 GAArray<T>(orig.sz), GAGenome() {
   GA1DArrayGenome<T>::copy(orig);
 }
@@ -74,7 +74,7 @@ GA1DArrayGenome<T>::~GA1DArrayGenome() { }
 // what we define here - a virtual function).  We should check to be sure that
 // both genomes are the same class and same dimension.  This function tries
 // to be smart about they way it copies.  If we already have data, then we do
-// a memcpy of the one we're supposed to copy.  If we don't or we're not the 
+// a memcpy of the one we're supposed to copy.  If we don't or we're not the
 // same size as the one we're supposed to copy, then we adjust ourselves.
 //   The Array takes care of the resize in its copy method.
 template <class T> void
@@ -92,7 +92,7 @@ GA1DArrayGenome<T>::copy(const GAGenome & orig){
 template <class T> GAGenome *
 GA1DArrayGenome<T>::clone(GAGenome::CloneMethod flag) const {
   GA1DArrayGenome<T> *cpy = new GA1DArrayGenome<T>(nx);
-  if(flag == CONTENTS){ 
+  if(flag == CONTENTS){
     cpy->copy(*this);
   }
   else{
@@ -110,10 +110,10 @@ GA1DArrayGenome<T>::clone(GAGenome::CloneMethod flag) const {
 // length, then we don't do anything.
 //   We pay attention to the values of minX and maxX - they determine what kind
 // of resizing we are allowed to do.  If a resize is requested with a length
-// less than the min length specified by the behaviour, we set the minimum 
+// less than the min length specified by the behaviour, we set the minimum
 // to the length.  If the length is longer than the max length specified by
 // the behaviour, we set the max value to the length.
-//   We return the total size (in bits) of the genome after resize. 
+//   We return the total size (in bits) of the genome after resize.
 //   We don't do anything to the new contents!
 template <class T> int
 GA1DArrayGenome<T>::resize(int len)
@@ -160,7 +160,7 @@ GA1DArrayGenome<T>::write(STD_OSTREAM & os) const {
 //   Set the resize behaviour of the genome.  A genome can be fixed
 // length, resizeable with a max and min limit, or resizeable with no limits
 // (other than an implicit one that we use internally).
-//   A value of 0 means no resize, a value less than zero mean unlimited 
+//   A value of 0 means no resize, a value less than zero mean unlimited
 // resize, and a positive value means resize with that value as the limit.
 template <class T> int
 GA1DArrayGenome<T>::
@@ -183,7 +183,7 @@ GA1DArrayGenome<T>::resizeBehaviour() const {
   return val;
 }
 
-template <class T> int 
+template <class T> int
 GA1DArrayGenome<T>::equal(const GAGenome & c) const {
   const GA1DArrayGenome<T> & b = DYN_CAST(const GA1DArrayGenome<T> &, c);
   return((this == &c) ? 1 : ((nx != b.nx) ? 0 : GAArray<T>::equal(b,0,0,nx)));
@@ -205,7 +205,7 @@ its own, independent allele set.  If we clone a new genome, the new one gets a
 link to our allele set (so we don't end up with zillions of allele sets).  Same
 is true for the copy constructor.
   The array may have a single allele set or an array of allele sets, depending
-on which creator was called.  Either way, the allele set cannot be changed 
+on which creator was called.  Either way, the allele set cannot be changed
 once the array is created.
 ---------------------------------------------------------------------------- */
 template <class T> const char *
@@ -213,7 +213,7 @@ GA1DArrayAlleleGenome<T>::className() const {return "GA1DArrayAlleleGenome";}
 template <class T> int
 GA1DArrayAlleleGenome<T>::classID() const {return GAID::ArrayAlleleGenome;}
 
-template <class T> 
+template <class T>
 GA1DArrayAlleleGenome<T>::
 GA1DArrayAlleleGenome(unsigned int length, const GAAlleleSet<T> & s,
 		      GAGenome::Evaluator f, void * u) :
@@ -228,7 +228,7 @@ GA1DArrayGenome<T>(length, f, u){
   this->crossover(GA1DArrayAlleleGenome<T>::DEFAULT_1DARRAY_ALLELE_CROSSOVER);
 }
 
-template <class T> 
+template <class T>
 GA1DArrayAlleleGenome<T>::
 GA1DArrayAlleleGenome(const GAAlleleSetArray<T> & sa,
 		      GAGenome::Evaluator f, void * u) :
@@ -247,9 +247,9 @@ GA1DArrayGenome<T>(sa.size(), f, u) {
 
 // The copy constructor creates a new genome whose allele set refers to the
 // original's allele set.
-template <class T> 
+template <class T>
 GA1DArrayAlleleGenome<T>::
-GA1DArrayAlleleGenome(const GA1DArrayAlleleGenome<T>& orig) : 
+GA1DArrayAlleleGenome(const GA1DArrayAlleleGenome<T>& orig) :
 GA1DArrayGenome<T>(orig.sz) {
   naset = 0;
   aset = (GAAlleleSet<T>*)0;
@@ -265,7 +265,7 @@ GA1DArrayAlleleGenome<T>::~GA1DArrayAlleleGenome(){
 
 
 // This implementation of clone does not make use of the contents/attributes
-// capability because this whole interface isn't quite right yet...  Just 
+// capability because this whole interface isn't quite right yet...  Just
 // clone the entire thing, contents and all.
 template <class T> GAGenome *
 GA1DArrayAlleleGenome<T>::clone(GAGenome::CloneMethod) const {
@@ -273,10 +273,10 @@ GA1DArrayAlleleGenome<T>::clone(GAGenome::CloneMethod) const {
 }
 
 
-template <class T> void 
+template <class T> void
 GA1DArrayAlleleGenome<T>::copy(const GAGenome& orig){
   if(&orig == this) return;
-  const GA1DArrayAlleleGenome<T> * c = 
+  const GA1DArrayAlleleGenome<T> * c =
     DYN_CAST(const GA1DArrayAlleleGenome<T>*, &orig);
   if(c) {
     GA1DArrayGenome<T>::copy(*c);
@@ -339,7 +339,7 @@ GA1DArrayAlleleGenome<T>::equal(const GAGenome & c) const {
 ---------------------------------------------------------------------------- */
 // The random initializer sets the elements of the array based on the alleles
 // set.  We choose randomly the allele for each element.
-template <class ARRAY_TYPE> void 
+template <class ARRAY_TYPE> void
 GA1DArrayAlleleGenome<ARRAY_TYPE>::UniformInitializer(GAGenome & c)
 {
   GA1DArrayAlleleGenome<ARRAY_TYPE> &child=
@@ -354,7 +354,7 @@ GA1DArrayAlleleGenome<ARRAY_TYPE>::UniformInitializer(GAGenome & c)
 // and assign each element the next allele in the allele set.  Once each
 // element has been initialized, scramble the contents by swapping elements.
 // This assumes that there is only one allele set for the array.
-template <class ARRAY_TYPE> void 
+template <class ARRAY_TYPE> void
 GA1DArrayAlleleGenome<ARRAY_TYPE>::OrderedInitializer(GAGenome & c)
 {
   GA1DArrayAlleleGenome<ARRAY_TYPE> &child=
@@ -372,15 +372,15 @@ GA1DArrayAlleleGenome<ARRAY_TYPE>::OrderedInitializer(GAGenome & c)
 }
 
 
-// Randomly pick elements in the array then set the element to any of the 
+// Randomly pick elements in the array then set the element to any of the
 // alleles in the allele set for this genome.  This will work for any number
 // of allele sets for a given array.
-template <class ARRAY_TYPE> int 
+template <class ARRAY_TYPE> int
 GA1DArrayAlleleGenome<ARRAY_TYPE>::FlipMutator(GAGenome & c, float pmut)
 {
   GA1DArrayAlleleGenome<ARRAY_TYPE> &child=
     DYN_CAST(GA1DArrayAlleleGenome<ARRAY_TYPE> &, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.length());
@@ -404,11 +404,11 @@ GA1DArrayAlleleGenome<ARRAY_TYPE>::FlipMutator(GAGenome & c, float pmut)
 
 
 // Randomly swap elements in the array.
-template <class ARRAY_TYPE> int 
+template <class ARRAY_TYPE> int
 GA1DArrayGenome<ARRAY_TYPE>::SwapMutator(GAGenome & c, float pmut)
 {
   GA1DArrayGenome<ARRAY_TYPE> &child=DYN_CAST(GA1DArrayGenome<ARRAY_TYPE>&, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.length());
@@ -469,7 +469,7 @@ ElementComparator(const GAGenome& a, const GAGenome& b)
 #define SWAP(a,b) {unsigned int tmp=a; a=b; b=tmp;}
 
 // Randomly take bits from each parent.  For each bit we flip a coin to see if
-// that bit should come from the mother or the father.  If strings are 
+// that bit should come from the mother or the father.  If strings are
 // different lengths then we need to use the mask to get things right.
 template <class T> int
 GA1DArrayGenome<T>::
@@ -517,8 +517,8 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
     n = 2;
   }
   else if(c1 || c2){
-    GA1DArrayGenome<T> &sis = (c1 ? 
-			       DYN_CAST(GA1DArrayGenome<T> &, *c1) : 
+    GA1DArrayGenome<T> &sis = (c1 ?
+			       DYN_CAST(GA1DArrayGenome<T> &, *c1) :
 			       DYN_CAST(GA1DArrayGenome<T> &, *c2));
 
     if(mom.length() == dad.length() && sis.length() == mom.length()){
@@ -550,7 +550,7 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
 // we cannot handle that and post an error message.
 template <class T> int
 GA1DArrayGenome<T>::
-OnePointCrossover(const GAGenome& p1, const GAGenome& p2, 
+OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 		  GAGenome* c1, GAGenome* c2){
   const GA1DArrayGenome<T> &mom=DYN_CAST(const GA1DArrayGenome<T> &, p1);
   const GA1DArrayGenome<T> &dad=DYN_CAST(const GA1DArrayGenome<T> &, p2);
@@ -565,7 +565,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour() == GAGenome::FIXED_SIZE){
-      if(mom.length() != dad.length() || 
+      if(mom.length() != dad.length() ||
 	 sis.length() != bro.length() ||
 	 sis.length() != mom.length()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -587,17 +587,17 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sis.resize(momsite+dadlen);
       bro.resize(dadsite+momlen);
     }
-    
+
     sis.copy(mom, 0, 0, momsite);
     sis.copy(dad, momsite, dadsite, dadlen);
     bro.copy(dad, 0, 0, dadsite);
     bro.copy(mom, dadsite, momsite, momlen);
-  
+
     nc = 2;
   }
   else if(c1 || c2){
-    GA1DArrayGenome<T> &sis = (c1 ? 
-			       DYN_CAST(GA1DArrayGenome<T> &, *c1) : 
+    GA1DArrayGenome<T> &sis = (c1 ?
+			       DYN_CAST(GA1DArrayGenome<T> &, *c1) :
 			       DYN_CAST(GA1DArrayGenome<T> &, *c2));
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE){
@@ -615,7 +615,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       dadlen = dad.length() - dadsite;
       sis.resize(momsite+dadlen);
     }
-    
+
     if(GARandomBit()){
       sis.copy(mom, 0, 0, momsite);
       sis.copy(dad, momsite, dadsite, dadlen);
@@ -642,14 +642,14 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
 
 // Two point crossover for the 1D array genome.  Similar to the single point
-// crossover, but here we pick two points then grab the sections based upon 
+// crossover, but here we pick two points then grab the sections based upon
 // those two points.
 //   When we pick the points, it doesn't matter where they fall (one is not
 // dependent upon the other).  Make sure we get the lesser one into the first
 // position of our site array.
 template <class T> int
 GA1DArrayGenome<T>::
-TwoPointCrossover(const GAGenome& p1, const GAGenome& p2, 
+TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
 		  GAGenome* c1, GAGenome* c2){
   const GA1DArrayGenome<T> &mom=DYN_CAST(const GA1DArrayGenome<T> &, p1);
   const GA1DArrayGenome<T> &dad=DYN_CAST(const GA1DArrayGenome<T> &, p2);
@@ -664,7 +664,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour() == GAGenome::FIXED_SIZE){
-      if(mom.length() != dad.length() || 
+      if(mom.length() != dad.length() ||
 	 sis.length() != bro.length() ||
 	 sis.length() != mom.length()){
 	GAErr(GA_LOC, mom.className(), "two-point cross", gaErrSameLengthReqd);
@@ -675,7 +675,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
       if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
-      
+
       dadsite[0] = momsite[0];
       dadsite[1] = momsite[1];
       dadlen[0] = momlen[0];
@@ -691,13 +691,13 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
       if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
-      
+
       dadsite[0] = GARandomInt(0, dad.length());
       dadsite[1] = GARandomInt(0, dad.length());
       if(dadsite[0] > dadsite[1]) SWAP(dadsite[0], dadsite[1]);
       dadlen[0] = dadsite[1] - dadsite[0];
       dadlen[1] = dad.length() - dadsite[1];
-      
+
       sis.resize(momsite[0]+dadlen[0]+momlen[1]);
       bro.resize(dadsite[0]+momlen[0]+dadlen[1]);
     }
@@ -726,7 +726,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
       if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
-      
+
       dadsite[0] = momsite[0];
       dadsite[1] = momsite[1];
       dadlen[0] = momlen[0];
@@ -738,7 +738,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
       if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
-      
+
       dadsite[0] = GARandomInt(0, dad.length());
       dadsite[1] = GARandomInt(0, dad.length());
       if(dadsite[0] > dadsite[1]) SWAP(dadsite[0], dadsite[1]);
@@ -771,13 +771,13 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
 
 
 
-// Even and odd crossover for the array works just like it does for the 
+// Even and odd crossover for the array works just like it does for the
 // binary strings.  For even crossover we take the 0th element and every other
 // one after that from the mother.  The 1st and every other come from the
 // father.  For odd crossover, we do just the opposite.
 template <class T> int
 GA1DArrayGenome<T>::
-EvenOddCrossover(const GAGenome& p1, const GAGenome& p2, 
+EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
 		 GAGenome* c1, GAGenome* c2){
   const GA1DArrayGenome<T> &mom=DYN_CAST(const GA1DArrayGenome<T> &, p1);
   const GA1DArrayGenome<T> &dad=DYN_CAST(const GA1DArrayGenome<T> &, p2);
@@ -816,10 +816,10 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
     nc = 2;
   }
   else if(c1 || c2){
-    GA1DArrayGenome<T> &sis = (c1 ? 
-			       DYN_CAST(GA1DArrayGenome<T> &, *c1) : 
+    GA1DArrayGenome<T> &sis = (c1 ?
+			       DYN_CAST(GA1DArrayGenome<T> &, *c1) :
 			       DYN_CAST(GA1DArrayGenome<T> &, *c2));
-    
+
     if(mom.length() == dad.length() && sis.length() == mom.length()){
       for(i=sis.length()-1; i>=1; i-=2){
 	sis.gene(i, mom.gene(i));
@@ -853,7 +853,7 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
 //   We make sure that b will be greater than a.
 template <class T> int
 GA1DArrayGenome<T>::
-PartialMatchCrossover(const GAGenome& p1, const GAGenome& p2, 
+PartialMatchCrossover(const GAGenome& p1, const GAGenome& p2,
 		      GAGenome* c1, GAGenome* c2){
   const GA1DArrayGenome<T> &mom=DYN_CAST(const GA1DArrayGenome<T> &, p1);
   const GA1DArrayGenome<T> &dad=DYN_CAST(const GA1DArrayGenome<T> &, p2);
@@ -868,7 +868,7 @@ PartialMatchCrossover(const GAGenome& p1, const GAGenome& p2,
     GAErr(GA_LOC, mom.className(), "parial match cross", gaErrBadParentLength);
     return nc;
   }
-  
+
   if(c1 && c2){
     GA1DArrayGenome<T> &sis=DYN_CAST(GA1DArrayGenome<T> &, *c1);
     GA1DArrayGenome<T> &bro=DYN_CAST(GA1DArrayGenome<T> &, *c2);
@@ -887,8 +887,8 @@ PartialMatchCrossover(const GAGenome& p1, const GAGenome& p2,
     nc = 2;
   }
   else if(c1 || c2){
-    GA1DArrayGenome<T> &sis = (c1 ? 
-			       DYN_CAST(GA1DArrayGenome<T> &, *c1) : 
+    GA1DArrayGenome<T> &sis = (c1 ?
+			       DYN_CAST(GA1DArrayGenome<T> &, *c1) :
 			       DYN_CAST(GA1DArrayGenome<T> &, *c2));
 
     const GA1DArrayGenome<T> *parent1, *parent2;
@@ -929,7 +929,7 @@ GA1DArrayIsHole(const GA1DArrayGenome<T> &c, const GA1DArrayGenome<T> &dad,
 //   This implementation isn't terribly smart.  For example, I do a linear
 // search rather than caching and doing binary search or smarter hash tables.
 //   First we copy the mother into the sister.  Then move the 'holes' into the
-// crossover section and maintain the ordering of the non-hole elements.  
+// crossover section and maintain the ordering of the non-hole elements.
 // Finally, put the 'holes' in the proper order within the crossover section.
 // After we have done the sister, we do the brother.
 template <class T> int
@@ -949,7 +949,7 @@ OrderCrossover(const GAGenome& p1, const GAGenome& p2,
     GAErr(GA_LOC, mom.className(), "order cross", gaErrBadParentLength);
     return nc;
   }
-  
+
   if(c1 && c2){
     GA1DArrayGenome<T> &sis=DYN_CAST(GA1DArrayGenome<T> &, *c1);
     GA1DArrayGenome<T> &bro=DYN_CAST(GA1DArrayGenome<T> &, *c2);
@@ -962,7 +962,7 @@ OrderCrossover(const GAGenome& p1, const GAGenome& p2,
       if(index >= sis.size()) index=0;
       if(GA1DArrayIsHole(sis,dad,index,a,b)) break;
     }
-    
+
     for(; i<sis.size()-b+a; i++, index++){
       if(index >= sis.size()) index=0;
       j=index;
@@ -999,7 +999,7 @@ OrderCrossover(const GAGenome& p1, const GAGenome& p2,
       } while(GA1DArrayIsHole(bro,mom,j,a,b));
       bro.swap(index,j);
     }
-    
+
 // Now put the 'holes' in the proper order within the crossover section.
     for(i=a; i<b; i++){
       if(bro.gene(i) != mom.gene(i)){
@@ -1011,8 +1011,8 @@ OrderCrossover(const GAGenome& p1, const GAGenome& p2,
     nc = 2;
   }
   else if(c1 || c2){
-    GA1DArrayGenome<T> &sis = (c1 ? 
-			       DYN_CAST(GA1DArrayGenome<T> &, *c1) : 
+    GA1DArrayGenome<T> &sis = (c1 ?
+			       DYN_CAST(GA1DArrayGenome<T> &, *c1) :
 			       DYN_CAST(GA1DArrayGenome<T> &, *c2));
 
     const GA1DArrayGenome<T> *parent1, *parent2;
@@ -1053,7 +1053,7 @@ OrderCrossover(const GAGenome& p1, const GAGenome& p2,
 
 
 
-// Cycle crossover for the 1D array genome.  This is implemented as described 
+// Cycle crossover for the 1D array genome.  This is implemented as described
 // in goldberg's book.  The first is picked from mom, then cycle using dad.
 // Finally, fill in the gaps with the elements from dad.
 //   We allocate space for a temporary array in this routine.  It never frees
@@ -1063,8 +1063,8 @@ OrderCrossover(const GAGenome& p1, const GAGenome& p2,
 //  Allocate space for an array of flags.  We use this to keep track of whether
 // the child's contents came from the mother or the father.  We don't free the
 // space here, but it is not a memory leak.
-//   The first step is to cycle through mom & dad to get the cyclic part of 
-// the crossover.  Then fill in the rest of the sis with dad's contents that 
+//   The first step is to cycle through mom & dad to get the cyclic part of
+// the crossover.  Then fill in the rest of the sis with dad's contents that
 // we didn't use in the cycle.  Finally, do the same thing for the other child.
 //   Notice that this implementation makes serious use of the operator= for the
 // objects in the array.  It also requires the operator != and == comparators.
@@ -1139,7 +1139,7 @@ CycleCrossover(const GAGenome& p1, const GAGenome& p2,
     GAMask mask;
     mask.size(sis.length());
     mask.clear();
-    
+
     sis.gene(0, parent1->gene(0));
     mask[0] = 1;
     while(parent2->gene(current) != parent1->gene(0)){

--- a/Transportation_MPFA/source/ga-mpi/GA1DBinStrGenome.C
+++ b/Transportation_MPFA/source/ga-mpi/GA1DBinStrGenome.C
@@ -27,13 +27,13 @@
 // this point - initialization must be done explicitly by the user of the
 // genome (eg when the population is created or reset).  If we called the
 // initializer routine here then we could end up with multiple initializations
-// and/or calls to dummy initializers (for example when the genome is 
+// and/or calls to dummy initializers (for example when the genome is
 // created with a dummy initializer and the initializer is assigned later on).
 GA1DBinaryStringGenome::
-GA1DBinaryStringGenome(unsigned int len, 
+GA1DBinaryStringGenome(unsigned int len,
 		       GAGenome::Evaluator f, void * u) :
 GABinaryString(len),
-GAGenome(DEFAULT_1DBINSTR_INITIALIZER, 
+GAGenome(DEFAULT_1DBINSTR_INITIALIZER,
 	 DEFAULT_1DBINSTR_MUTATOR,
 	 DEFAULT_1DBINSTR_COMPARATOR) {
   evaluator(f);
@@ -60,7 +60,7 @@ GA1DBinaryStringGenome::~GA1DBinaryStringGenome() {
 
 
 // The clone member creates a duplicate (exact or just attributes, depending
-// on the flag).  The caller is responsible for freeing the memory that is 
+// on the flag).  The caller is responsible for freeing the memory that is
 // allocated by this method.
 GAGenome*
 GA1DBinaryStringGenome::clone(GAGenome::CloneMethod flag) const {
@@ -81,7 +81,7 @@ GA1DBinaryStringGenome::clone(GAGenome::CloneMethod flag) const {
 // what we define here - a virtual function).  We should check to be sure that
 // both genomes are the same class and same dimension.  This function tries
 // to be smart about they way it copies.  If we already have data, then we do
-// a memcpy of the one we're supposed to copy.  If we don't or we're not the 
+// a memcpy of the one we're supposed to copy.  If we don't or we're not the
 // same size as the one we're supposed to copy, then we adjust ourselves.
 //   The BinaryStringGenome takes care of the resize in its copy method.
 // It also copies the bitstring for us.
@@ -89,7 +89,7 @@ void
 GA1DBinaryStringGenome::copy(const GAGenome & orig)
 {
   if(&orig == this) return;
-  const GA1DBinaryStringGenome* c = 
+  const GA1DBinaryStringGenome* c =
     DYN_CAST(const GA1DBinaryStringGenome*, &orig);
   if(c) {
     GAGenome::copy(*c);
@@ -173,7 +173,7 @@ GA1DBinaryStringGenome::write(STD_OSTREAM & os) const
 //   Set the resize behaviour of the genome.  A genome can be fixed
 // length, resizeable with a max and min limit, or resizeable with no limits
 // (other than an implicit one that we use internally).
-//   A value of 0 means no resize, a value less than zero mean unlimited 
+//   A value of 0 means no resize, a value less than zero mean unlimited
 // resize, and a positive value means resize with that value as the limit.
 //   We return the upper limit of the genome's size.
 int
@@ -190,21 +190,21 @@ resizeBehaviour(unsigned int lower, unsigned int upper)
   return resizeBehaviour();
 }
 
-int 
+int
 GA1DBinaryStringGenome::resizeBehaviour() const {
   int val = maxX;
   if(maxX == minX) val = FIXED_SIZE;
   return val;
 }
 
-int 
+int
 GA1DBinaryStringGenome::
 equal(const GA1DBinaryStringGenome& c,
       unsigned int dest, unsigned int src, unsigned int len) const {
   return GABinaryString::equal(c,dest,src,len);
 }
 
-int 
+int
 GA1DBinaryStringGenome::equal(const GAGenome & c) const {
   if(this == &c) return 1;
   const GA1DBinaryStringGenome* b = DYN_CAST(const GA1DBinaryStringGenome*,&c);
@@ -231,7 +231,7 @@ GA1DBinaryStringGenome::equal(const GAGenome & c) const {
 // random bit function so we don't have to worry about machine-specific stuff.
 //   We also do a resize so the genome can resize itself (randomly) if it
 // is a resizeable genome.
-void 
+void
 GA1DBinaryStringGenome::UniformInitializer(GAGenome & c)
 {
   GA1DBinaryStringGenome &child=DYN_CAST(GA1DBinaryStringGenome &, c);
@@ -242,7 +242,7 @@ GA1DBinaryStringGenome::UniformInitializer(GAGenome & c)
 
 
 //   Unset all of the bits in the genome.
-void 
+void
 GA1DBinaryStringGenome::UnsetInitializer(GAGenome & c)
 {
   GA1DBinaryStringGenome &child=DYN_CAST(GA1DBinaryStringGenome &, c);
@@ -252,7 +252,7 @@ GA1DBinaryStringGenome::UnsetInitializer(GAGenome & c)
 
 
 //   Set all of the bits in the genome.
-void 
+void
 GA1DBinaryStringGenome::SetInitializer(GAGenome & c)
 {
   GA1DBinaryStringGenome &child=DYN_CAST(GA1DBinaryStringGenome &, c);
@@ -271,11 +271,11 @@ GA1DBinaryStringGenome::SetInitializer(GAGenome & c)
 // better the chance that it will match the desired mutation rate.
 //   If nMut is greater than 1, then we round up, so a mutation of 2.2 would
 // be 3 mutations, and 2.9 would be 3 as well.  nMut of 3 would be 3 mutations.
-int 
+int
 GA1DBinaryStringGenome::FlipMutator(GAGenome & c, float pmut)
 {
   GA1DBinaryStringGenome &child=DYN_CAST(GA1DBinaryStringGenome &, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float, child.length());
@@ -298,10 +298,10 @@ GA1DBinaryStringGenome::FlipMutator(GAGenome & c, float pmut)
 }
 
 
-// Return a number from 0 to 1 to indicate how similar two genomes are.  For 
+// Return a number from 0 to 1 to indicate how similar two genomes are.  For
 // the binary strings we compare bits.  We count the number of bits that are
 // the same then divide by the number of bits.  If the genomes are different
-// length then we return a -1 to indicate that we cannot calculate the 
+// length then we return a -1 to indicate that we cannot calculate the
 // similarity.
 //   Normal hamming distance makes use of population information - this is not
 // a hamming measure!  This is a similarity measure of two individuals, not
@@ -334,7 +334,7 @@ GA1DBinaryStringGenome::BitComparator(const GAGenome& a, const GAGenome& b){
 
 
 // Randomly take bits from each parent.  For each bit we flip a coin to see if
-// that bit should come from the mother or the father.  This operator can be 
+// that bit should come from the mother or the father.  This operator can be
 // used on genomes of different lengths, but the crossover is truncated to the
 // shorter of the parents and child.
 int
@@ -385,8 +385,8 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
     n = 2;
   }
   else if(c1 || c2){
-    GA1DBinaryStringGenome &sis = (c1 ? 
-				   DYN_CAST(GA1DBinaryStringGenome&, *c1) : 
+    GA1DBinaryStringGenome &sis = (c1 ?
+				   DYN_CAST(GA1DBinaryStringGenome&, *c1) :
 				   DYN_CAST(GA1DBinaryStringGenome&, *c2));
 
     if(mom.length() == dad.length() && sis.length() == mom.length()){
@@ -434,7 +434,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour() == GAGenome::FIXED_SIZE){
-      if(mom.length() != dad.length() || 
+      if(mom.length() != dad.length() ||
 	 sis.length() != bro.length() ||
 	 sis.length() != mom.length()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -461,12 +461,12 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
     sis.copy(dad, momsite, dadsite, dadlen);
     bro.copy(dad, 0, 0, dadsite);
     bro.copy(mom, dadsite, momsite, momlen);
-  
+
     n = 2;
   }
   else if(c1 || c2){
-    GA1DBinaryStringGenome &sis = (c1 ? 
-				   DYN_CAST(GA1DBinaryStringGenome&, *c1) : 
+    GA1DBinaryStringGenome &sis = (c1 ?
+				   DYN_CAST(GA1DBinaryStringGenome&, *c1) :
 				   DYN_CAST(GA1DBinaryStringGenome&, *c2));
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE){
@@ -530,7 +530,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour() == GAGenome::FIXED_SIZE){
-      if(mom.length() != dad.length() || 
+      if(mom.length() != dad.length() ||
 	 sis.length() != bro.length() ||
 	 sis.length() != mom.length()){
 	GAErr(GA_LOC, mom.className(), "two-point cross", gaErrSameLengthReqd);
@@ -558,7 +558,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
       if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
-      
+
       dadsite[0] = GARandomInt(0, dad.length());
       dadsite[1] = GARandomInt(0, dad.length());
       if(dadsite[0] > dadsite[1]) SWAP(dadsite[0], dadsite[1]);
@@ -579,8 +579,8 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
     n = 2;
   }
   else if(c1 || c2){
-    GA1DBinaryStringGenome &sis = (c1 ? 
-				   DYN_CAST(GA1DBinaryStringGenome&, *c1) : 
+    GA1DBinaryStringGenome &sis = (c1 ?
+				   DYN_CAST(GA1DBinaryStringGenome&, *c1) :
 				   DYN_CAST(GA1DBinaryStringGenome&, *c2));
 
     if(sis.resizeBehaviour() == GAGenome::FIXED_SIZE){
@@ -605,7 +605,7 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
       if(momsite[0] > momsite[1]) SWAP(momsite[0], momsite[1]);
       momlen[0] = momsite[1] - momsite[0];
       momlen[1] = mom.length() - momsite[1];
-      
+
       dadsite[0] = GARandomInt(0, dad.length());
       dadsite[1] = GARandomInt(0, dad.length());
       if(dadsite[0] > dadsite[1]) SWAP(dadsite[0], dadsite[1]);
@@ -639,10 +639,10 @@ TwoPointCrossover(const GAGenome& p1, const GAGenome& p2,
 //   Even and odd crossovers take alternating bits from the mother and father.
 // For even crossover, we take every even bit from the mother and every odd bit
 // from the father (the first bit is the 0th bit, so it is even).  Odd
-// crossover is just the opposite.  
+// crossover is just the opposite.
 int
 GA1DBinaryStringGenome::
-EvenOddCrossover(const GAGenome& p1, const GAGenome& p2, 
+EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
 		 GAGenome* c1, GAGenome* c2){
   const GA1DBinaryStringGenome &mom=
     DYN_CAST(const GA1DBinaryStringGenome &, p1);
@@ -685,7 +685,7 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
   }
   else if(c1 || c2){
     GA1DBinaryStringGenome &sis = (c1 ?
-				   DYN_CAST(GA1DBinaryStringGenome&, *c1) : 
+				   DYN_CAST(GA1DBinaryStringGenome&, *c1) :
 				   DYN_CAST(GA1DBinaryStringGenome&, *c2));
 
     if(mom.length() == dad.length() && sis.length() == mom.length()){

--- a/Transportation_MPFA/source/ga-mpi/GA2DArrayGenome.C
+++ b/Transportation_MPFA/source/ga-mpi/GA2DArrayGenome.C
@@ -27,13 +27,13 @@ GA2DArrayGenome<T>::className() const {return "GA2DArrayGenome";}
 template <class T> int
 GA2DArrayGenome<T>::classID() const {return GAID::ArrayGenome2D;}
 
-template <class T> 
+template <class T>
 GA2DArrayGenome<T>::
-GA2DArrayGenome(unsigned int width, unsigned int height, 
+GA2DArrayGenome(unsigned int width, unsigned int height,
 		GAGenome::Evaluator f,
 		void * u) :
 GAArray<T>(width*height),
-GAGenome(DEFAULT_2DARRAY_INITIALIZER, 
+GAGenome(DEFAULT_2DARRAY_INITIALIZER,
 	 DEFAULT_2DARRAY_MUTATOR,
 	 DEFAULT_2DARRAY_COMPARATOR)
 {
@@ -44,7 +44,7 @@ GAGenome(DEFAULT_2DARRAY_INITIALIZER,
 }
 
 
-template <class T> 
+template <class T>
 GA2DArrayGenome<T>::
 GA2DArrayGenome(const GA2DArrayGenome<T> & orig) : GAArray<T>(orig.sz){
   GA2DArrayGenome<T>::copy(orig);
@@ -62,10 +62,10 @@ GA2DArrayGenome<T>::copy(const GAGenome & orig){
   if(c) {
     GAGenome::copy(*c);
     GAArray<T>::copy(*c);
-    nx = c->nx; ny = c->ny; 
-    minX = c->minX; minY = c->minY; 
+    nx = c->nx; ny = c->ny;
+    minX = c->minX; minY = c->minY;
     maxX = c->maxX; maxY = c->maxY;
-  } 
+  }
 }
 
 
@@ -77,8 +77,8 @@ GA2DArrayGenome<T>::clone(GAGenome::CloneMethod flag) const {
   }
   else{
     cpy->GAGenome::copy(*this);
-    cpy->minX = minX; cpy->minY = minY; 
-    cpy->maxX = maxX; cpy->maxY = maxY; 
+    cpy->minX = minX; cpy->minY = minY;
+    cpy->maxX = maxX; cpy->maxY = maxY;
   }
   return cpy;
 }
@@ -137,7 +137,7 @@ GA2DArrayGenome<T>::read(STD_ISTREAM &) {
 
 
 template <class T> int
-GA2DArrayGenome<T>::write(STD_OSTREAM & os) const 
+GA2DArrayGenome<T>::write(STD_OSTREAM & os) const
 {
   for(unsigned int j=0; j<ny; j++){
     for(unsigned int i=0; i<nx; i++){
@@ -167,7 +167,7 @@ GA2DArrayGenome<T>::resizeBehaviour(GAGenome::Dimension which) const {
 
 template <class T> int
 GA2DArrayGenome<T>::
-resizeBehaviour(GAGenome::Dimension which, 
+resizeBehaviour(GAGenome::Dimension which,
 		unsigned int lower, unsigned int upper)
 {
   if(upper < lower){
@@ -212,12 +212,12 @@ GA2DArrayGenome<T>::copy(const GA2DArrayGenome<T> & orig,
   for(unsigned int j=0; j<h; j++)
     GAArray<T>::copy(orig, (s+j)*nx+r, (y+j)*orig.nx+x, w);
 
-  _evaluated = gaFalse; 
+  _evaluated = gaFalse;
 }
 
 
 
-template <class T> int 
+template <class T> int
 GA2DArrayGenome<T>::equal(const GAGenome & c) const
 {
   if(this == &c) return 1;
@@ -259,9 +259,9 @@ GA2DArrayAlleleGenome<T>::className() const {return "GA2DArrayAlleleGenome";}
 template <class T> int
 GA2DArrayAlleleGenome<T>::classID() const {return GAID::ArrayAlleleGenome2D;}
 
-template <class T> 
+template <class T>
 GA2DArrayAlleleGenome<T>::
-GA2DArrayAlleleGenome(unsigned int width, unsigned int height, 
+GA2DArrayAlleleGenome(unsigned int width, unsigned int height,
 		      const GAAlleleSet<T> & s,
 		      GAGenome::Evaluator f, void * u) :
 GA2DArrayGenome<T>(width,height,f,u){
@@ -275,9 +275,9 @@ GA2DArrayGenome<T>(width,height,f,u){
   this->crossover(GA2DArrayAlleleGenome<T>::DEFAULT_2DARRAY_ALLELE_CROSSOVER);
 }
 
-template <class T> 
+template <class T>
 GA2DArrayAlleleGenome<T>::
-GA2DArrayAlleleGenome(unsigned int width, unsigned int height, 
+GA2DArrayAlleleGenome(unsigned int width, unsigned int height,
 		      const GAAlleleSetArray<T> & sa,
 		      GAGenome::Evaluator f, void * u) :
 GA2DArrayGenome<T>(width,height, f, u) {
@@ -293,9 +293,9 @@ GA2DArrayGenome<T>(width,height, f, u) {
 }
 
 
-template <class T> 
+template <class T>
 GA2DArrayAlleleGenome<T>::
-GA2DArrayAlleleGenome(const GA2DArrayAlleleGenome<T> & orig) : 
+GA2DArrayAlleleGenome(const GA2DArrayAlleleGenome<T> & orig) :
 GA2DArrayGenome<T>(orig.nx, orig.ny) {
   naset = 0;
   aset = (GAAlleleSet<T>*)0;
@@ -315,10 +315,10 @@ GA2DArrayAlleleGenome<T>::clone(GAGenome::CloneMethod) const {
 }
 
 
-template <class T> void 
+template <class T> void
 GA2DArrayAlleleGenome<T>::copy(const GAGenome& orig){
   if(&orig == this) return;
-  const GA2DArrayAlleleGenome<T>* c = 
+  const GA2DArrayAlleleGenome<T>* c =
     DYN_CAST(const GA2DArrayAlleleGenome<T>*, &orig);
   if(c) {
     GA2DArrayGenome<T>::copy(*c);
@@ -386,24 +386,24 @@ GA2DArrayAlleleGenome<T>::equal(const GAGenome & c) const {
    Operator definitions
 ---------------------------------------------------------------------------- */
 // this does not handle genomes with multiple allele sets!
-template <class ARRAY_TYPE> void 
+template <class ARRAY_TYPE> void
 GA2DArrayAlleleGenome<ARRAY_TYPE>::UniformInitializer(GAGenome & c)
 {
   GA2DArrayAlleleGenome<ARRAY_TYPE> &child=
     DYN_CAST(GA2DArrayAlleleGenome<ARRAY_TYPE> &, c);
-  child.resize(GAGenome::ANY_SIZE,GAGenome::ANY_SIZE); 
+  child.resize(GAGenome::ANY_SIZE,GAGenome::ANY_SIZE);
   for(int i=child.width()-1; i>=0; i--)
     for(int j=child.height()-1; j>=0; j--)
       child.gene(i, j, child.alleleset().allele());
 }
 
 
-template <class ARRAY_TYPE> int 
+template <class ARRAY_TYPE> int
 GA2DArrayAlleleGenome<ARRAY_TYPE>::FlipMutator(GAGenome & c, float pmut)
 {
   GA2DArrayAlleleGenome<ARRAY_TYPE> &child=
     DYN_CAST(GA2DArrayAlleleGenome<ARRAY_TYPE> &, c);
-  register int n, m, i, j;
+  int n, m, i, j;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.size());
@@ -430,11 +430,11 @@ GA2DArrayAlleleGenome<ARRAY_TYPE>::FlipMutator(GAGenome & c, float pmut)
 }
 
 
-template <class ARRAY_TYPE> int 
+template <class ARRAY_TYPE> int
 GA2DArrayGenome<ARRAY_TYPE>::SwapMutator(GAGenome & c, float pmut)
 {
   GA2DArrayGenome<ARRAY_TYPE> &child=DYN_CAST(GA2DArrayGenome<ARRAY_TYPE>&, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.size());
@@ -496,7 +496,7 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
   if(c1 && c2){
     GA2DArrayGenome<T> &sis=DYN_CAST(GA2DArrayGenome<T> &, *c1);
     GA2DArrayGenome<T> &bro=DYN_CAST(GA2DArrayGenome<T> &, *c2);
-    
+
     if(sis.width() == bro.width() && sis.height() == bro.height() &&
        mom.width() == dad.width() && mom.height() == dad.height() &&
        sis.width() == mom.width() && sis.height() == mom.height()){
@@ -567,7 +567,7 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
 
 
 // This crossover does clipping (no padding) for resizables.  Notice that this
-// means that any resizable children of two parents will have identical 
+// means that any resizable children of two parents will have identical
 // dimensions no matter what.
 template <class T> int
 GA2DArrayGenome<T>::
@@ -587,8 +587,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE){
-      if(mom.width() != dad.width() || 
-	 sis.width() != bro.width() || 
+      if(mom.width() != dad.width() ||
+	 sis.width() != bro.width() ||
 	 sis.width() != mom.width()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -612,8 +612,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
-      if(mom.height() != dad.height() || 
-	 sis.height() != bro.height() || 
+      if(mom.height() != dad.height() ||
+	 sis.height() != bro.height() ||
 	 sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -637,12 +637,12 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     sis.resize(sitex+lenx, sitey+leny);
     bro.resize(sitex+lenx, sitey+leny);
-    
+
     sis.copy(mom, 0, 0, momsitex-sitex, momsitey-sitey, sitex, sitey);
     sis.copy(dad, sitex, 0, dadsitex, dadsitey-sitey, lenx, sitey);
     sis.copy(dad, 0, sitey, dadsitex-sitex, dadsitey, sitex, leny);
     sis.copy(mom, sitex, sitey, momsitex, momsitey, lenx, leny);
-    
+
     bro.copy(dad, 0, 0, dadsitex-sitex, dadsitey-sitey, sitex, sitey);
     bro.copy(mom, sitex, 0, momsitex, momsitey-sitey, lenx, sitey);
     bro.copy(mom, 0, sitey, momsitex-sitex, momsitey, sitex, leny);
@@ -652,7 +652,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
   }
   else if(c1){
     GA2DArrayGenome<T> &sis=DYN_CAST(GA2DArrayGenome<T> &, *c1);
-    
+
     if(sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE){
       if(mom.width() != dad.width() || sis.width() != mom.width()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -669,7 +669,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitex = GAMin(momsitex, dadsitex);
       lenx = GAMin(momlenx, dadlenx);
     }
-    
+
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
       if(mom.height() != dad.height() || sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -686,9 +686,9 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitey = GAMin(momsitey, dadsitey);
       leny = GAMin(momleny, dadleny);
     }
-    
+
     sis.resize(sitex+lenx, sitey+leny);
-    
+
     if(GARandomBit()){
       sis.copy(mom, 0, 0, momsitex-sitex, momsitey-sitey, sitex, sitey);
       sis.copy(dad, sitex, 0, dadsitex, dadsitey-sitey, lenx, sitey);
@@ -759,7 +759,7 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
   }
   else if(c1){
     GA2DArrayGenome<T> &sis=DYN_CAST(GA2DArrayGenome<T> &, *c1);
-    
+
     if(mom.width() == dad.width() && mom.height() == dad.height() &&
        sis.width() == mom.width() && sis.height() == mom.height()){
       int count=0;

--- a/Transportation_MPFA/source/ga-mpi/GA2DBinStrGenome.C
+++ b/Transportation_MPFA/source/ga-mpi/GA2DBinStrGenome.C
@@ -21,7 +21,7 @@
    Genome class definition
 ---------------------------------------------------------------------------- */
 GA2DBinaryStringGenome::
-GA2DBinaryStringGenome(unsigned int width, unsigned int height, 
+GA2DBinaryStringGenome(unsigned int width, unsigned int height,
 		       GAGenome::Evaluator f, void * u) :
 GABinaryString(width*height),
 GAGenome(DEFAULT_2DBINSTR_INITIALIZER,
@@ -54,8 +54,8 @@ GA2DBinaryStringGenome::clone(GAGenome::CloneMethod flag) const {
   }
   else{
     cpy->GAGenome::copy(*this);
-    cpy->minX = minX; cpy->minY = minY; 
-    cpy->maxX = maxX; cpy->maxY = maxY; 
+    cpy->minX = minX; cpy->minY = minY;
+    cpy->maxX = maxX; cpy->maxY = maxY;
   }
   return cpy;
 }
@@ -69,10 +69,10 @@ GA2DBinaryStringGenome::copy(const GAGenome & orig)
   if(c) {
     GAGenome::copy(*c);
     GABinaryString::copy(*c);
-    nx = c->nx; ny = c->ny; 
-    minX = c->minX; minY = c->minY; 
+    nx = c->nx; ny = c->ny;
+    minX = c->minX; minY = c->minY;
     maxX = c->maxX; maxY = c->maxY;
-  } 
+  }
 }
 
 
@@ -105,7 +105,7 @@ GA2DBinaryStringGenome::resize(int w, int h)
 
 // Move the bits into the right position.  If we're smaller, then shift to
 // the smaller size before we do the resize (the resize method maintains bit
-// integrety).  If we're larger, do the move after the resize.  If we're the 
+// integrety).  If we're larger, do the move after the resize.  If we're the
 // same size the we don't do anything.  When we're adding more bits, the new
 // bits get set randomly to 0 or 1.
 
@@ -153,7 +153,7 @@ GA2DBinaryStringGenome::read(STD_ISTREAM & is)
 
   _evaluated = gaFalse;
 
-  if(is.eof() && 
+  if(is.eof() &&
      ((j < ny) ||	     // didn't get some lines
       (i < nx && i != 0))){   // stopped early on a row
     GAErr(GA_LOC, className(), "read", gaErrUnexpectedEOF);
@@ -168,7 +168,7 @@ GA2DBinaryStringGenome::read(STD_ISTREAM & is)
 // Dump the digits to the stream with a newline between each row.  No newline
 // at the end of the whole thing.
 int
-GA2DBinaryStringGenome::write(STD_OSTREAM & os) const 
+GA2DBinaryStringGenome::write(STD_OSTREAM & os) const
 {
   for(unsigned int j=0; j<ny; j++){
     for(unsigned int i=0; i<nx; i++)
@@ -180,7 +180,7 @@ GA2DBinaryStringGenome::write(STD_OSTREAM & os) const
 #endif
 
 
-int 
+int
 GA2DBinaryStringGenome::resizeBehaviour(GAGenome::Dimension which) const {
   int val = 0;
   if(which == WIDTH) {
@@ -318,7 +318,7 @@ GA2DBinaryStringGenome::equal(const GA2DBinaryStringGenome& orig,
 }
 
 
-int 
+int
 GA2DBinaryStringGenome::equal(const GAGenome & c) const
 {
   if(this == &c) return 1;
@@ -344,7 +344,7 @@ GA2DBinaryStringGenome::equal(const GAGenome & c) const
   The order for looping through indices is height-then-width (ie height loops
 before a single width increment)
 ---------------------------------------------------------------------------- */
-void 
+void
 GA2DBinaryStringGenome::UniformInitializer(GAGenome & c)
 {
   GA2DBinaryStringGenome &child=DYN_CAST(GA2DBinaryStringGenome &, c);
@@ -355,7 +355,7 @@ GA2DBinaryStringGenome::UniformInitializer(GAGenome & c)
 }
 
 
-void 
+void
 GA2DBinaryStringGenome::UnsetInitializer(GAGenome & c)
 {
   GA2DBinaryStringGenome &child=DYN_CAST(GA2DBinaryStringGenome &, c);
@@ -364,20 +364,20 @@ GA2DBinaryStringGenome::UnsetInitializer(GAGenome & c)
 }
 
 
-void 
+void
 GA2DBinaryStringGenome::SetInitializer(GAGenome & c)
 {
   GA2DBinaryStringGenome &child=DYN_CAST(GA2DBinaryStringGenome &, c);
-  child.resize(GAGenome::ANY_SIZE, GAGenome::ANY_SIZE);	
+  child.resize(GAGenome::ANY_SIZE, GAGenome::ANY_SIZE);
   child.set(0, 0, child.width(), child.height());
 }
 
 
-int 
+int
 GA2DBinaryStringGenome::FlipMutator(GAGenome & c, float pmut)
 {
   GA2DBinaryStringGenome &child=DYN_CAST(GA2DBinaryStringGenome &, c);
-  register int n, m, i, j;
+  int n, m, i, j;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float, child.size());
@@ -431,7 +431,7 @@ GA2DBinaryStringGenome::BitComparator(const GAGenome& a, const GAGenome& b){
 
 int
 GA2DBinaryStringGenome::
-UniformCrossover(const GAGenome& p1, const GAGenome& p2, 
+UniformCrossover(const GAGenome& p1, const GAGenome& p2,
 		 GAGenome* c1, GAGenome* c2){
   const GA2DBinaryStringGenome &mom=
     DYN_CAST(const GA2DBinaryStringGenome &, p1);
@@ -486,8 +486,8 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
     nc = 2;
   }
   else if(c1 || c2){
-    GA2DBinaryStringGenome &sis = (c1 ? 
-				   DYN_CAST(GA2DBinaryStringGenome&, *c1) : 
+    GA2DBinaryStringGenome &sis = (c1 ?
+				   DYN_CAST(GA2DBinaryStringGenome&, *c1) :
 				   DYN_CAST(GA2DBinaryStringGenome&, *c2));
 
     if(mom.width() == dad.width() && mom.height() == dad.height() &&
@@ -515,13 +515,13 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
 
 //   When we do single point crossover on resizable 2D genomes we can either
 // clip or pad to make the mismatching geometries work out.  Either way, both
-// children end up with the same dimensions (the children have the same 
+// children end up with the same dimensions (the children have the same
 // dimensions as each other, not the same as if they were clipped/padded).
 //   When we pad, the extra space is filled with random bits.  This
 // implementation does only clipping, no padding!
 int
 GA2DBinaryStringGenome::
-OnePointCrossover(const GAGenome& p1, const GAGenome& p2, 
+OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 		  GAGenome* c1, GAGenome* c2){
   const GA2DBinaryStringGenome &mom=
     DYN_CAST(const GA2DBinaryStringGenome &, p1);
@@ -539,8 +539,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE){
-      if(mom.width() != dad.width() || 
-	 sis.width() != bro.width() || 
+      if(mom.width() != dad.width() ||
+	 sis.width() != bro.width() ||
 	 sis.width() != mom.width()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -564,8 +564,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
-      if(mom.height() != dad.height() || 
-	 sis.height() != bro.height() || 
+      if(mom.height() != dad.height() ||
+	 sis.height() != bro.height() ||
 	 sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -640,9 +640,9 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitey = GAMin(momsitey, dadsitey);
       leny = GAMin(momleny, dadleny);
     }
-    
+
     sis.resize(sitex+lenx, sitey+leny);
-    
+
     if(GARandomBit()){
       sis.copy(mom, 0, 0, momsitex-sitex, momsitey-sitey, sitex, sitey);
       sis.copy(dad, sitex, 0, dadsitex, dadsitey-sitey, lenx, sitey);
@@ -666,7 +666,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
 int
 GA2DBinaryStringGenome::
-EvenOddCrossover(const GAGenome& p1, const GAGenome& p2, 
+EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
 		 GAGenome* c1, GAGenome* c2){
   const GA2DBinaryStringGenome &mom=
     DYN_CAST(const GA2DBinaryStringGenome &, p1);
@@ -679,7 +679,7 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
   if(c1 && c2){
     GA2DBinaryStringGenome &sis=DYN_CAST(GA2DBinaryStringGenome &, *c1);
     GA2DBinaryStringGenome &bro=DYN_CAST(GA2DBinaryStringGenome &, *c2);
-    
+
     if(sis.width() == bro.width() && sis.height() == bro.height() &&
        mom.width() == dad.width() && mom.height() == dad.height() &&
        sis.width() == mom.width() && sis.height() == mom.height()){
@@ -719,10 +719,10 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
     nc = 2;
   }
   else if(c1 || c2){
-    GA2DBinaryStringGenome &sis = (c1 ? 
+    GA2DBinaryStringGenome &sis = (c1 ?
 				   DYN_CAST(GA2DBinaryStringGenome&, *c1) :
 				   DYN_CAST(GA2DBinaryStringGenome&, *c2));
-    
+
     if(mom.width() == dad.width() && mom.height() == dad.height() &&
        sis.width() == mom.width() && sis.height() == mom.height()){
       int count=0;

--- a/Transportation_MPFA/source/ga-mpi/GA3DArrayGenome.C
+++ b/Transportation_MPFA/source/ga-mpi/GA3DArrayGenome.C
@@ -27,13 +27,13 @@ GA3DArrayGenome<T>::className() const {return "GA3DArrayGenome";}
 template <class T> int
 GA3DArrayGenome<T>::classID() const {return GAID::ArrayGenome3D;}
 
-template <class T> 
+template <class T>
 GA3DArrayGenome<T>::
 GA3DArrayGenome(unsigned int w, unsigned int h, unsigned int d,
 		GAGenome::Evaluator f,
 		void * u) :
 GAArray<T>(w*h*d),
-GAGenome(DEFAULT_3DARRAY_INITIALIZER, 
+GAGenome(DEFAULT_3DARRAY_INITIALIZER,
 	 DEFAULT_3DARRAY_MUTATOR,
 	 DEFAULT_3DARRAY_COMPARATOR)
 {
@@ -44,7 +44,7 @@ GAGenome(DEFAULT_3DARRAY_INITIALIZER,
 }
 
 
-template <class T> 
+template <class T>
 GA3DArrayGenome<T>::
 GA3DArrayGenome(const GA3DArrayGenome<T> & orig) :
 GAArray<T>(orig.sz), GAGenome(){
@@ -78,7 +78,7 @@ GA3DArrayGenome<T>::clone(GAGenome::CloneMethod flag) const {
   }
   else{
     cpy->GAGenome::copy(*this);
-    cpy->minX = minX; cpy->minY = minY; cpy->minZ = minZ; 
+    cpy->minX = minX; cpy->minY = minY; cpy->minZ = minZ;
     cpy->maxX = maxX; cpy->maxY = maxY; cpy->maxZ = maxZ;
   }
   return cpy;
@@ -145,7 +145,7 @@ GA3DArrayGenome<T>::resize(int w, int h, int d)
 
   GAArray<T>::size(w*h*d);
 
-  if(w > STA_CAST(int,nx) && h > STA_CAST(int,ny)){ 
+  if(w > STA_CAST(int,nx) && h > STA_CAST(int,ny)){
     int z=GAMin(STA_CAST(int,nz),d);
     for(int k=z-1; k>=0; k--)
       for(int j=ny-1; j>=0; j--)
@@ -179,7 +179,7 @@ GA3DArrayGenome<T>::read(STD_ISTREAM &) {
 
 
 template <class T> int
-GA3DArrayGenome<T>::write(STD_OSTREAM & os) const 
+GA3DArrayGenome<T>::write(STD_OSTREAM & os) const
 {
   for(unsigned int k=0; k<nz; k++){
     for(unsigned int j=0; j<ny; j++){
@@ -216,7 +216,7 @@ GA3DArrayGenome<T>::resizeBehaviour(GAGenome::Dimension which) const {
 
 template <class T> int
 GA3DArrayGenome<T>::
-resizeBehaviour(GAGenome::Dimension which, 
+resizeBehaviour(GAGenome::Dimension which,
 		unsigned int lower, unsigned int upper)
 {
   if(upper < lower){
@@ -278,7 +278,7 @@ copy(const GA3DArrayGenome<T> & orig,
 }
 
 
-template <class T> int 
+template <class T> int
 GA3DArrayGenome<T>::equal(const GAGenome & c) const
 {
   if(this == &c) return 1;
@@ -312,7 +312,7 @@ GA3DArrayAlleleGenome<T>::className() const {return "GA3DArrayAlleleGenome";}
 template <class T> int
 GA3DArrayAlleleGenome<T>::classID() const {return GAID::ArrayAlleleGenome3D;}
 
-template <class T> 
+template <class T>
 GA3DArrayAlleleGenome<T>::
 GA3DArrayAlleleGenome(unsigned int w, unsigned int h, unsigned int d,
 		      const GAAlleleSet<T> & s,
@@ -328,7 +328,7 @@ GA3DArrayGenome<T>(w,h,d,f,u) {
   this->crossover(GA3DArrayAlleleGenome<T>::DEFAULT_3DARRAY_ALLELE_CROSSOVER);
 }
 
-template <class T> 
+template <class T>
 GA3DArrayAlleleGenome<T>::
 GA3DArrayAlleleGenome(unsigned int w, unsigned int h, unsigned int d,
 		      const GAAlleleSetArray<T> & sa,
@@ -346,9 +346,9 @@ GA3DArrayGenome<T>(w,h,d, f, u) {
 }
 
 
-template <class T> 
+template <class T>
 GA3DArrayAlleleGenome<T>::
-GA3DArrayAlleleGenome(const GA3DArrayAlleleGenome<T> & orig) : 
+GA3DArrayAlleleGenome(const GA3DArrayAlleleGenome<T> & orig) :
 GA3DArrayGenome<T>(orig.nx, orig.ny, orig.nz) {
   naset = 0;
   aset = (GAAlleleSet<T>*)0;
@@ -368,10 +368,10 @@ GA3DArrayAlleleGenome<T>::clone(GAGenome::CloneMethod) const {
 }
 
 
-template <class T> void 
+template <class T> void
 GA3DArrayAlleleGenome<T>::copy(const GAGenome& orig){
   if(&orig == this) return;
-  const GA3DArrayAlleleGenome<T>* c = 
+  const GA3DArrayAlleleGenome<T>* c =
     DYN_CAST(const GA3DArrayAlleleGenome<T>*, &orig);
   if(c) {
     GA3DArrayGenome<T>::copy(*c);
@@ -414,7 +414,7 @@ GA3DArrayAlleleGenome<T>::resize(int w, int h, int d){
     for(int k=z-1; k>=0; k--)
       for(int j=this->ny-1; j>=0; j--)
 	for(unsigned int i=oldx; i<this->nx; i++)
-	  this->a[k*this->ny*this->nx+j*this->nx+i] = 
+	  this->a[k*this->ny*this->nx+j*this->nx+i] =
 	    aset[(k*this->ny*this->nx+j*this->nx+i) % naset].allele();
   }
   else if(this->ny > oldy){
@@ -463,7 +463,7 @@ GA3DArrayAlleleGenome<T>::equal(const GAGenome & c) const {
    Operator definitions
 ---------------------------------------------------------------------------- */
 // this does not handle genomes with multiple allele sets!
-template <class ARRAY_TYPE> void 
+template <class ARRAY_TYPE> void
 GA3DArrayAlleleGenome<ARRAY_TYPE>::UniformInitializer(GAGenome & c)
 {
   GA3DArrayAlleleGenome<ARRAY_TYPE> &child=
@@ -476,12 +476,12 @@ GA3DArrayAlleleGenome<ARRAY_TYPE>::UniformInitializer(GAGenome & c)
 }
 
 
-template <class ARRAY_TYPE> int 
+template <class ARRAY_TYPE> int
 GA3DArrayAlleleGenome<ARRAY_TYPE>::FlipMutator(GAGenome & c, float pmut)
 {
   GA3DArrayAlleleGenome<ARRAY_TYPE> &child=
     DYN_CAST(GA3DArrayAlleleGenome<ARRAY_TYPE> &, c);
-  register int n, m, d, i, j, k;
+  int n, m, d, i, j, k;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.size());
@@ -512,11 +512,11 @@ GA3DArrayAlleleGenome<ARRAY_TYPE>::FlipMutator(GAGenome & c, float pmut)
 }
 
 
-template <class ARRAY_TYPE> int 
+template <class ARRAY_TYPE> int
 GA3DArrayGenome<ARRAY_TYPE>::SwapMutator(GAGenome & c, float pmut)
 {
   GA3DArrayGenome<ARRAY_TYPE> &child=DYN_CAST(GA3DArrayGenome<ARRAY_TYPE>&, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.size());
@@ -568,7 +568,7 @@ ElementComparator(const GAGenome& a, const GAGenome& b)
 
 
 
-// Make sure our bitmask is big enough, generate a mask, then use it to 
+// Make sure our bitmask is big enough, generate a mask, then use it to
 // extract the information from each parent to stuff the two children.
 // We don't deallocate any space for the masks under the assumption that we'll
 // have to use them again in the future.
@@ -680,12 +680,12 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
 //   This is designed only for genomes that are the same length.  If the child
 // is not the same length as the parent, or if the children are not the same
 // size, we don't do the crossover.
-//   In the interest of speed we do not do any checks for size.  Do not use 
+//   In the interest of speed we do not do any checks for size.  Do not use
 // this crossover method when the parents and children may be different sizes.
 // It might break!
 template <class T> int
 GA3DArrayGenome<T>::
-EvenOddCrossover(const GAGenome& p1, const GAGenome& p2, 
+EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
 GAGenome* c1, GAGenome* c2){
   const GA3DArrayGenome<T> &mom=DYN_CAST(const GA3DArrayGenome<T> &, p1);
   const GA3DArrayGenome<T> &dad=DYN_CAST(const GA3DArrayGenome<T> &, p2);
@@ -696,7 +696,7 @@ GAGenome* c1, GAGenome* c2){
   if(c1 && c2){
     GA3DArrayGenome<T> &sis=DYN_CAST(GA3DArrayGenome<T> &, *c1);
     GA3DArrayGenome<T> &bro=DYN_CAST(GA3DArrayGenome<T> &, *c2);
-    
+
     if(sis.width() == bro.width() && sis.height() == bro.height() &&
        sis.depth() == bro.depth() &&
        mom.width() == dad.width() && mom.height() == dad.height() &&
@@ -806,8 +806,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE){
-      if(mom.width() != dad.width() || 
-	 sis.width() != bro.width() || 
+      if(mom.width() != dad.width() ||
+	 sis.width() != bro.width() ||
 	 sis.width() != mom.width()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -828,11 +828,11 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitex = GAMin(momsitex, dadsitex);
       lenx = GAMin(momlenx, dadlenx);
     }
-    
+
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
-      if(mom.height() != dad.height() || 
-	 sis.height() != bro.height() || 
+      if(mom.height() != dad.height() ||
+	 sis.height() != bro.height() ||
 	 sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -856,8 +856,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE){
-      if(mom.depth() != dad.depth() || 
-	 sis.depth() != bro.depth() || 
+      if(mom.depth() != dad.depth() ||
+	 sis.depth() != bro.depth() ||
 	 sis.depth() != mom.depth()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -882,8 +882,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
     sis.resize(sitex+lenx, sitey+leny, sitez+lenz);
     bro.resize(sitex+lenx, sitey+leny, sitez+lenz);
 
-    sis.copy(mom, 
-	     0, 0, 0, 
+    sis.copy(mom,
+	     0, 0, 0,
 	     momsitex-sitex, momsitey-sitey, momsitez-sitez,
 	     sitex, sitey, sitez);
     sis.copy(dad,
@@ -898,8 +898,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	     sitex, sitey, 0,
 	     momsitex, momsitey, momsitez-sitez,
 	     lenx, leny, sitez);
-    sis.copy(dad, 
-	     0, 0, sitez, 
+    sis.copy(dad,
+	     0, 0, sitez,
 	     dadsitex-sitex, dadsitey-sitey, dadsitez,
 	     sitex, sitey, lenz);
     sis.copy(mom,
@@ -914,9 +914,9 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	     sitex, sitey, sitez,
 	     dadsitex, dadsitey, dadsitez,
 	     lenx, leny, lenz);
-    
-    bro.copy(dad, 
-	     0, 0, 0, 
+
+    bro.copy(dad,
+	     0, 0, 0,
 	     dadsitex-sitex, dadsitey-sitey, dadsitez-sitez,
 	     sitex, sitey, sitez);
     bro.copy(mom,
@@ -931,8 +931,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	     sitex, sitey, 0,
 	     dadsitex, dadsitey, dadsitez-sitez,
 	     lenx, leny, sitez);
-    bro.copy(mom, 
-	     0, 0, sitez, 
+    bro.copy(mom,
+	     0, 0, sitez,
 	     momsitex-sitex, momsitey-sitey, momsitez,
 	     sitex, sitey, lenz);
     bro.copy(dad,
@@ -969,7 +969,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitex = GAMin(momsitex, dadsitex);
       lenx = GAMin(momlenx, dadlenx);
     }
-    
+
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
       if(mom.height() != dad.height() || sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -1003,12 +1003,12 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitez = GAMin(momsitez, dadsitez);
       lenz = GAMin(momlenz, dadlenz);
     }
-    
+
     sis.resize(sitex+lenx, sitey+leny, sitez+lenz);
-    
+
     if(GARandomBit()){
-      sis.copy(mom, 
-	       0, 0, 0, 
+      sis.copy(mom,
+	       0, 0, 0,
 	       momsitex-sitex, momsitey-sitey, momsitez-sitez,
 	       sitex, sitey, sitez);
       sis.copy(dad,
@@ -1023,8 +1023,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	       sitex, sitey, 0,
 	       momsitex, momsitey, momsitez-sitez,
 	       lenx, leny, sitez);
-      sis.copy(dad, 
-	       0, 0, sitez, 
+      sis.copy(dad,
+	       0, 0, sitez,
 	       dadsitex-sitex, dadsitey-sitey, dadsitez,
 	       sitex, sitey, lenz);
       sis.copy(mom,
@@ -1041,8 +1041,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	       lenx, leny, lenz);
     }
     else{
-      sis.copy(dad, 
-	       0, 0, 0, 
+      sis.copy(dad,
+	       0, 0, 0,
 	       dadsitex-sitex, dadsitey-sitey, dadsitez-sitez,
 	       sitex, sitey, sitez);
       sis.copy(mom,
@@ -1057,8 +1057,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	       sitex, sitey, 0,
 	       dadsitex, dadsitey, dadsitez-sitez,
 	       lenx, leny, sitez);
-      sis.copy(mom, 
-	       0, 0, sitez, 
+      sis.copy(mom,
+	       0, 0, sitez,
 	       momsitex-sitex, momsitey-sitey, momsitez,
 	       sitex, sitey, lenz);
       sis.copy(dad,

--- a/Transportation_MPFA/source/ga-mpi/GA3DBinStrGenome.C
+++ b/Transportation_MPFA/source/ga-mpi/GA3DBinStrGenome.C
@@ -56,7 +56,7 @@ GA3DBinaryStringGenome::clone(GAGenome::CloneMethod flag) const {
   }
   else{
     cpy->GAGenome::copy(*this);
-    cpy->minX = minX; cpy->minY = minY; cpy->minZ = minZ; 
+    cpy->minX = minX; cpy->minY = minY; cpy->minZ = minZ;
     cpy->maxX = maxX; cpy->maxY = maxY; cpy->maxZ = maxZ;
   }
   return cpy;
@@ -66,7 +66,7 @@ void
 GA3DBinaryStringGenome::copy(const GAGenome & orig)
 {
   if(&orig == this) return;
-  const GA3DBinaryStringGenome* c = 
+  const GA3DBinaryStringGenome* c =
     DYN_CAST(const GA3DBinaryStringGenome*, &orig);
   if(c) {
     GAGenome::copy(*c);
@@ -206,7 +206,7 @@ GA3DBinaryStringGenome::read(STD_ISTREAM & is)
 
   _evaluated = gaFalse;
 
-  if(is.eof() && 
+  if(is.eof() &&
      ((k < nz) ||		// didn't get some lines
       (j < ny && j != 0) ||	// didn't get some lines
       (i < nx && i != 0))){	// didn't get some lines
@@ -219,10 +219,10 @@ GA3DBinaryStringGenome::read(STD_ISTREAM & is)
 }
 
 
-// Dump the bits to the stream with a newline at the end of each row and 
+// Dump the bits to the stream with a newline at the end of each row and
 // another at the end of each layer.  No newline at the end of the block.
 int
-GA3DBinaryStringGenome::write(STD_OSTREAM & os) const 
+GA3DBinaryStringGenome::write(STD_OSTREAM & os) const
 {
   for(unsigned int k=0; k<nz; k++){
     for(unsigned int j=0; j<ny; j++){
@@ -424,13 +424,13 @@ equal(const GA3DBinaryStringGenome& orig,
     for(unsigned int j=0; j<h; j++)
       eq += GABinaryString::equal(orig,
 				  (z+k)*ny*nx + (y+j)*nx + x,
-				  (srcz+k)*ny*nx + (srcy+j)*nx + srcx, 
+				  (srcz+k)*ny*nx + (srcy+j)*nx + srcx,
 				  w);
   return eq==d*h ? 1 : 0;
 }
 
 
-int 
+int
 GA3DBinaryStringGenome::equal(const GAGenome & c) const
 {
   if(this == &c) return 1;
@@ -459,7 +459,7 @@ GA3DBinaryStringGenome::equal(const GAGenome & c) const
 (ie depth loops before a single height increment, height loops before a single
 width increment)
 ---------------------------------------------------------------------------- */
-void 
+void
 GA3DBinaryStringGenome::UniformInitializer(GAGenome & c)
 {
   GA3DBinaryStringGenome &child=DYN_CAST(GA3DBinaryStringGenome &, c);
@@ -471,7 +471,7 @@ GA3DBinaryStringGenome::UniformInitializer(GAGenome & c)
 }
 
 
-void 
+void
 GA3DBinaryStringGenome::UnsetInitializer(GAGenome & c)
 {
   GA3DBinaryStringGenome &child=DYN_CAST(GA3DBinaryStringGenome &, c);
@@ -480,7 +480,7 @@ GA3DBinaryStringGenome::UnsetInitializer(GAGenome & c)
 }
 
 
-void 
+void
 GA3DBinaryStringGenome::SetInitializer(GAGenome & c)
 {
   GA3DBinaryStringGenome &child=DYN_CAST(GA3DBinaryStringGenome &, c);
@@ -489,11 +489,11 @@ GA3DBinaryStringGenome::SetInitializer(GAGenome & c)
 }
 
 
-int 
+int
 GA3DBinaryStringGenome::FlipMutator(GAGenome & c, float pmut)
 {
   GA3DBinaryStringGenome &child=DYN_CAST(GA3DBinaryStringGenome &, c);
-  register int n, m, i, j, k, d;
+  int n, m, i, j, k, d;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * STA_CAST(float,child.size());
@@ -550,7 +550,7 @@ GA3DBinaryStringGenome::BitComparator(const GAGenome& a, const GAGenome& b){
 
 
 
-// Make sure our bitmask is big enough, generate a mask, then use it to 
+// Make sure our bitmask is big enough, generate a mask, then use it to
 // extract the information from each parent to stuff the two children.
 // We don't deallocate any space for the masks under the assumption that we'll
 // have to use them again in the future.
@@ -626,10 +626,10 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
     nc = 2;
   }
   else if(c1 || c2){
-    GA3DBinaryStringGenome &sis = (c1 ? 
-				   DYN_CAST(GA3DBinaryStringGenome&, *c1) : 
+    GA3DBinaryStringGenome &sis = (c1 ?
+				   DYN_CAST(GA3DBinaryStringGenome&, *c1) :
 				   DYN_CAST(GA3DBinaryStringGenome&, *c2));
-    
+
     if(mom.width() == dad.width() && mom.height() == dad.height() &&
        mom.depth() == dad.depth() &&
        sis.width() == mom.width() && sis.height() == mom.height() &&
@@ -665,7 +665,7 @@ UniformCrossover(const GAGenome& p1, const GAGenome& p2,
 //   This is designed only for genomes that are the same length.  If the child
 // is not the same length as the parent, or if the children are not the same
 // size, we don't do the crossover.
-//   In the interest of speed we do not do any checks for size.  Do not use 
+//   In the interest of speed we do not do any checks for size.  Do not use
 // this crossover method when the parents and children may be different sizes.
 // It might break!
 int
@@ -733,7 +733,7 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
   }
   else if(c1 || c2){
     GA3DBinaryStringGenome &sis = (c1 ?
-				   DYN_CAST(GA3DBinaryStringGenome &, *c1) : 
+				   DYN_CAST(GA3DBinaryStringGenome &, *c1) :
 				   DYN_CAST(GA3DBinaryStringGenome &, *c2));
 
     if(mom.width() == dad.width() && mom.height() == dad.height() &&
@@ -772,7 +772,7 @@ EvenOddCrossover(const GAGenome& p1, const GAGenome& p2,
 
 
 // Pick a single point in the 3D block and grab alternating quadrants for each
-// child.  If the children are resizable, this crossover does clipping or 
+// child.  If the children are resizable, this crossover does clipping or
 // padding depending on the setting of the clip flag.  If we pad, we fill the
 // additional bits with random contents.
 int
@@ -795,8 +795,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 
     if(sis.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::WIDTH) == GAGenome::FIXED_SIZE){
-      if(mom.width() != dad.width() || 
-	 sis.width() != bro.width() || 
+      if(mom.width() != dad.width() ||
+	 sis.width() != bro.width() ||
 	 sis.width() != mom.width()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -817,11 +817,11 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitex = GAMin(momsitex, dadsitex);
       lenx = GAMin(momlenx, dadlenx);
     }
-    
+
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
-      if(mom.height() != dad.height() || 
-	 sis.height() != bro.height() || 
+      if(mom.height() != dad.height() ||
+	 sis.height() != bro.height() ||
 	 sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -842,11 +842,11 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitey = GAMin(momsitey, dadsitey);
       leny = GAMin(momleny, dadleny);
     }
-    
+
     if(sis.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE &&
        bro.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE){
-      if(mom.depth() != dad.depth() || 
-	 sis.depth() != bro.depth() || 
+      if(mom.depth() != dad.depth() ||
+	 sis.depth() != bro.depth() ||
 	 sis.depth() != mom.depth()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
 	return nc;
@@ -871,8 +871,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
     sis.resize(sitex+lenx, sitey+leny, sitez+lenz);
     bro.resize(sitex+lenx, sitey+leny, sitez+lenz);
 
-    sis.copy(mom, 
-	     0, 0, 0, 
+    sis.copy(mom,
+	     0, 0, 0,
 	     momsitex-sitex, momsitey-sitey, momsitez-sitez,
 	     sitex, sitey, sitez);
     sis.copy(dad,
@@ -887,8 +887,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	     sitex, sitey, 0,
 	     momsitex, momsitey, momsitez-sitez,
 	     lenx, leny, sitez);
-    sis.copy(dad, 
-	     0, 0, sitez, 
+    sis.copy(dad,
+	     0, 0, sitez,
 	     dadsitex-sitex, dadsitey-sitey, dadsitez,
 	     sitex, sitey, lenz);
     sis.copy(mom,
@@ -903,9 +903,9 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	     sitex, sitey, sitez,
 	     dadsitex, dadsitey, dadsitez,
 	     lenx, leny, lenz);
-    
-    bro.copy(dad, 
-	     0, 0, 0, 
+
+    bro.copy(dad,
+	     0, 0, 0,
 	     dadsitex-sitex, dadsitey-sitey, dadsitez-sitez,
 	     sitex, sitey, sitez);
     bro.copy(mom,
@@ -920,8 +920,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	     sitex, sitey, 0,
 	     dadsitex, dadsitey, dadsitez-sitez,
 	     lenx, leny, sitez);
-    bro.copy(mom, 
-	     0, 0, sitez, 
+    bro.copy(mom,
+	     0, 0, sitez,
 	     momsitex-sitex, momsitey-sitey, momsitez,
 	     sitex, sitey, lenz);
     bro.copy(dad,
@@ -936,7 +936,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	     sitex, sitey, sitez,
 	     momsitex, momsitey, momsitez,
 	     lenx, leny, lenz);
-    
+
     nc = 2;
   }
   else if(c1 || c2){
@@ -960,7 +960,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitex = GAMin(momsitex, dadsitex);
       lenx = GAMin(momlenx, dadlenx);
     }
-    
+
     if(sis.resizeBehaviour(GAGenome::HEIGHT) == GAGenome::FIXED_SIZE){
       if(mom.height() != dad.height() || sis.height() != mom.height()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -977,7 +977,7 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
       sitey = GAMin(momsitey, dadsitey);
       leny = GAMin(momleny, dadleny);
     }
-    
+
     if(sis.resizeBehaviour(GAGenome::DEPTH) == GAGenome::FIXED_SIZE){
       if(mom.depth() != dad.depth() || sis.depth() != mom.depth()){
 	GAErr(GA_LOC, mom.className(), "one-point cross", gaErrSameLengthReqd);
@@ -998,8 +998,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
     sis.resize(sitex+lenx, sitey+leny, sitez+lenz);
 
     if(GARandomBit()){
-      sis.copy(mom, 
-	       0, 0, 0, 
+      sis.copy(mom,
+	       0, 0, 0,
 	       momsitex-sitex, momsitey-sitey, momsitez-sitez,
 	       sitex, sitey, sitez);
       sis.copy(dad,
@@ -1014,8 +1014,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	       sitex, sitey, 0,
 	       momsitex, momsitey, momsitez-sitez,
 	       lenx, leny, sitez);
-      sis.copy(dad, 
-	       0, 0, sitez, 
+      sis.copy(dad,
+	       0, 0, sitez,
 	       dadsitex-sitex, dadsitey-sitey, dadsitez,
 	       sitex, sitey, lenz);
       sis.copy(mom,
@@ -1032,8 +1032,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	       lenx, leny, lenz);
     }
     else{
-      sis.copy(dad, 
-	       0, 0, 0, 
+      sis.copy(dad,
+	       0, 0, 0,
 	       dadsitex-sitex, dadsitey-sitey, dadsitez-sitez,
 	       sitex, sitey, sitez);
       sis.copy(mom,
@@ -1048,8 +1048,8 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 	       sitex, sitey, 0,
 	       dadsitex, dadsitey, dadsitez-sitez,
 	       lenx, leny, sitez);
-      sis.copy(mom, 
-	       0, 0, sitez, 
+      sis.copy(mom,
+	       0, 0, sitez,
 	       momsitex-sitex, momsitey-sitey, momsitez,
 	       sitex, sitey, lenz);
       sis.copy(dad,

--- a/Transportation_MPFA/source/ga-mpi/GAListGenome.C
+++ b/Transportation_MPFA/source/ga-mpi/GAListGenome.C
@@ -17,7 +17,7 @@
 #include <ga-mpi/GAMask.h>
 #include <ga-mpi/garandom.h>
 
-template <class T> int 
+template <class T> int
 GAListIsHole(const GAListGenome<T>&, const GAListGenome<T>&, int, int, int);
 
 
@@ -30,8 +30,8 @@ GAListGenome<T>::className() const {return "GAListGenome";}
 template <class T> int
 GAListGenome<T>::classID() const {return GAID::ListGenome;}
 
-template <class T> 
-GAListGenome<T>::GAListGenome(GAGenome::Evaluator f, void * u) : 
+template <class T>
+GAListGenome<T>::GAListGenome(GAGenome::Evaluator f, void * u) :
 GAList<T>(),
 GAGenome(DEFAULT_LIST_INITIALIZER,
 	 DEFAULT_LIST_MUTATOR,
@@ -42,8 +42,8 @@ GAGenome(DEFAULT_LIST_INITIALIZER,
 }
 
 
-template <class T> 
-GAListGenome<T>::GAListGenome(const GAListGenome<T> & orig) : 
+template <class T>
+GAListGenome<T>::GAListGenome(const GAListGenome<T> & orig) :
 GAList<T>(),
 GAGenome() {
   GAListGenome<T>::copy(orig);
@@ -76,10 +76,10 @@ GAListGenome<T>::copy(const GAGenome & orig){
 
 #ifdef GALIB_USE_STREAMS
 // Traverse the list (breadth-first) and dump the contents as best we can to
-// the stream.  We don't try to write the contents of the nodes - we simply 
+// the stream.  We don't try to write the contents of the nodes - we simply
 // write a . for each node in the list.
 template <class T> int
-GAListGenome<T>::write(STD_OSTREAM & os) const 
+GAListGenome<T>::write(STD_OSTREAM & os) const
 {
   os << "node       next       prev       contents\n";
   if(!this->hd) return 0;;
@@ -105,7 +105,7 @@ GAListGenome<T>::write(STD_OSTREAM & os) const
 // then you have nothing to worry about.
 //   Neither of these operators affects the internal iterator of either
 // list genome in any way.
-template <class T> int 
+template <class T> int
 GAListGenome<T>::equal(const GAGenome & c) const
 {
   if(this == &c) return 1;
@@ -136,14 +136,14 @@ GAListGenome<T>::equal(const GAGenome & c) const
 ---------------------------------------------------------------------------- */
 // Mutate a list by nuking nodes.  Any node has a pmut chance of getting nuked.
 // This is actually kind of bogus for the second part of the if clause (if nMut
-// is greater than or equal to 1).  Nodes end up having more than pmut 
+// is greater than or equal to 1).  Nodes end up having more than pmut
 // probability of getting nuked.
 //   After the mutation the iterator is left at the head of the list.
 template <class T> int
 GAListGenome<T>::DestructiveMutator(GAGenome & c, float pmut)
 {
   GAListGenome<T> &child=DYN_CAST(GAListGenome<T> &, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return 0;
 
   n = child.size();
@@ -171,14 +171,14 @@ GAListGenome<T>::DestructiveMutator(GAGenome & c, float pmut)
 
 // Mutate a list by swapping two nodes.  Any node has a pmut chance of getting
 // swapped, and the swap could happen to any other node.  And in the case of
-// nMut < 1, the swap may generate a swap partner that is the same node, in 
+// nMut < 1, the swap may generate a swap partner that is the same node, in
 // which case no swap occurs (we don't check).
 //   After the mutation the iterator is left at the head of the list.
 template <class T> int
 GAListGenome<T>::SwapMutator(GAGenome & c, float pmut)
 {
   GAListGenome<T> &child=DYN_CAST(GAListGenome<T> &, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return 0;
 
   n = child.size();
@@ -205,7 +205,7 @@ GAListGenome<T>::SwapMutator(GAGenome & c, float pmut)
 
 // This comparator returns the number of elements that the two lists have
 // in common (both in position and in value).  If they are different lengths
-// then we just say they are completely different.  This is probably barely 
+// then we just say they are completely different.  This is probably barely
 // adequate for most applications - we really should give more credit for
 // nodes that are the same but in different positions.  But that would be
 // pretty nasty to compute.
@@ -213,7 +213,7 @@ GAListGenome<T>::SwapMutator(GAGenome & c, float pmut)
 // which to compare this diversity measure.  Its kind of hard to define this
 // one in a general way...
 template <class T> float
-GAListGenome<T>::NodeComparator(const GAGenome& a, const GAGenome& b) 
+GAListGenome<T>::NodeComparator(const GAGenome& a, const GAGenome& b)
 {
   if(&a == &b) return 0;
   const GAListGenome<T>& sis=DYN_CAST(const GAListGenome<T>&, a);
@@ -244,7 +244,7 @@ GAListGenome<T>::NodeComparator(const GAGenome& a, const GAGenome& b)
 
 #define SWAP(a,b) {unsigned int tmp=a; a=b; b=tmp;}
 
-// This crossover picks a site between nodes in each parent.  It is the same 
+// This crossover picks a site between nodes in each parent.  It is the same
 // as single point crossover on a resizeable binary string genome.  The site
 // in the mother is not necessarily the same as the site in the father!
 //   When we pick a crossover site, it is between nodes of the list (otherwise
@@ -253,7 +253,7 @@ GAListGenome<T>::NodeComparator(const GAGenome& a, const GAGenome& b)
 // whereas the cross site possibilities are numbered from 0 to size, inclusive.
 // This means we have to map the site to the list to determine whether an
 // insertion should occur before or after a node.
-//   We first copy the mother into the child (this deletes whatever contents 
+//   We first copy the mother into the child (this deletes whatever contents
 // were in the child originally).  Then we clone the father from the cross site
 // to the end of the list.  Then we delete the tail of the child from the
 // mother's cross site to the end of the list.  Finally, we insert the clone
@@ -265,7 +265,7 @@ GAListGenome<T>::NodeComparator(const GAGenome& a, const GAGenome& b)
 // do better by copying only what we need of the mother.
 template <class T> int
 GAListGenome<T>::
-OnePointCrossover(const GAGenome& p1, const GAGenome& p2, 
+OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 		  GAGenome* c1, GAGenome* c2){
   const GAListGenome<T> &mom=DYN_CAST(const GAListGenome<T> &, p1);
   const GAListGenome<T> &dad=DYN_CAST(const GAListGenome<T> &, p2);
@@ -330,13 +330,13 @@ OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 //   This version of the partial match crossover uses objects that are multiply
 // instantiated - each list genome contains its own objects in its nodes.
 // The operator== method must be defined on the object for this implementation
-// to work!  In this case, the 'object' is an int, so we're OK.  If you are 
+// to work!  In this case, the 'object' is an int, so we're OK.  If you are
 // putting your own objects in the nodes, be sure you have operator== defined
 // for your object.  You must also have operator!= defined for your object.  We
 // do not do any assignments, so operator= and/or copy is not required.
 //   We assume that none of the nodes will return a NULL pointer.  Also assume
 // that the cross site has been selected properly.
-//   First we make a copy of the mother.  Then we loop through the match 
+//   First we make a copy of the mother.  Then we loop through the match
 // section and try to swap each element in the child's match section with its
 // partner (as defined by the current node in the father's match section).
 //   Mirroring will work the same way - just swap mom & dad and you're all set.

--- a/Transportation_MPFA/source/ga-mpi/GARealGenome.C
+++ b/Transportation_MPFA/source/ga-mpi/GARealGenome.C
@@ -13,7 +13,7 @@
 
 // We must also specialize the allele set so that the alleles are handled
 // properly.  Be sure to handle bounds correctly whether we are discretized
-// or continuous.  Handle the case where someone sets stupid bounds that 
+// or continuous.  Handle the case where someone sets stupid bounds that
 // might cause an infinite loop for exclusive bounds.
 template <> float
 GAAlleleSet<float>::allele() const {
@@ -29,8 +29,8 @@ GAAlleleSet<float>::allele() const {
     if(core->lowerb == GAAllele::EXCLUSIVE) value += core->a[2];
   }
   else{
-    if(core->a[0] == core->a[1] && 
-       core->lowerb == GAAllele::EXCLUSIVE && 
+    if(core->a[0] == core->a[1] &&
+       core->lowerb == GAAllele::EXCLUSIVE &&
        core->upperb == GAAllele::EXCLUSIVE) {
       value = core->a[0];
     }
@@ -74,9 +74,9 @@ GAAlleleSet<float>::allele(unsigned int i) const {
 
 // now the specialization of the genome itself.
 
-template <> const char * 
+template <> const char *
 GA1DArrayAlleleGenome<float>::className() const {return "GARealGenome";}
-template <> int 
+template <> int
 GA1DArrayAlleleGenome<float>::classID() const {return GAID::FloatGenome;}
 
 template <> GA1DArrayAlleleGenome<float>::
@@ -108,7 +108,7 @@ GA1DArrayGenome<float>(sa.size(), f, u){
   crossover(DEFAULT_REAL_CROSSOVER);
 }
 
-template <> 
+template <>
 GA1DArrayAlleleGenome<float>::~GA1DArrayAlleleGenome(){
   delete [] aset;
 }
@@ -148,12 +148,12 @@ GA1DArrayAlleleGenome<float>::read(STD_ISTREAM & is) {
 ---------------------------------------------------------------------------- */
 // The Gaussian mutator picks a new value based on a Gaussian distribution
 // around the current value.  We respect the bounds (if any).
-//*** need to figure out a way to make the stdev other than 1.0 
-int 
+//*** need to figure out a way to make the stdev other than 1.0
+int
 GARealGaussianMutator(GAGenome& g, float pmut){
   GA1DArrayAlleleGenome<float> &child=
     DYN_CAST(GA1DArrayAlleleGenome<float> &, g);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return(0);
 
   float nMut = pmut * (float)(child.length());
@@ -200,7 +200,7 @@ GARealGaussianMutator(GAGenome& g, float pmut){
 // identical.  If parents are not the same length, the extra elements are not
 // set!  You might want to add some noise to this so that both children are not
 // the same...
-int 
+int
 GARealArithmeticCrossover(const GAGenome& p1, const GAGenome& p2,
 			  GAGenome* c1, GAGenome* c2) {
   const GA1DArrayGenome<float> &mom=
@@ -222,8 +222,8 @@ GARealArithmeticCrossover(const GAGenome& p1, const GAGenome& p2,
     n = 2;
   }
   else if(c1 || c2){
-    GA1DArrayGenome<float> &sis = (c1 ? 
-				   DYN_CAST(GA1DArrayGenome<float> &, *c1) : 
+    GA1DArrayGenome<float> &sis = (c1 ?
+				   DYN_CAST(GA1DArrayGenome<float> &, *c1) :
 				   DYN_CAST(GA1DArrayGenome<float> &, *c2));
 
     int len = GAMax(mom.length(), dad.length());
@@ -240,7 +240,7 @@ GARealArithmeticCrossover(const GAGenome& p1, const GAGenome& p2,
 // Blend crossover generates a new value based on the interval between parents.
 // We generate a uniform distribution based on the distance between parent
 // values, then choose the child value based upon that distribution.
-int 
+int
 GARealBlendCrossover(const GAGenome& p1, const GAGenome& p2,
 		     GAGenome* c1, GAGenome* c2) {
   const GA1DArrayGenome<float> &mom=
@@ -257,9 +257,9 @@ GARealBlendCrossover(const GAGenome& p1, const GAGenome& p2,
     int len = GAMax(mom.length(), dad.length());
     for(int i=0; i<len; i++) {
       float dist = 0;
-      if(mom.gene(i) > dad.gene(i)) 
+      if(mom.gene(i) > dad.gene(i))
 	dist = mom.gene(i) - dad.gene(i);
-      else 
+      else
 	dist = dad.gene(i) - mom.gene(i);
       float lo = (GAMin(mom.gene(i), dad.gene(i))) - 0.5*dist;
       float hi = (GAMax(mom.gene(i), dad.gene(i))) + 0.5*dist;
@@ -276,9 +276,9 @@ GARealBlendCrossover(const GAGenome& p1, const GAGenome& p2,
     int len = GAMax(mom.length(), dad.length());
     for(int i=0; i<len; i++) {
       float dist = 0;
-      if(mom.gene(i) > dad.gene(i)) 
+      if(mom.gene(i) > dad.gene(i))
 	dist = mom.gene(i) - dad.gene(i);
-      else 
+      else
 	dist = dad.gene(i) - mom.gene(i);
       float lo = (GAMin(mom.gene(i), dad.gene(i))) - 0.5*dist;
       float hi = (GAMax(mom.gene(i), dad.gene(i))) + 0.5*dist;
@@ -298,7 +298,7 @@ GARealBlendCrossover(const GAGenome& p1, const GAGenome& p2,
 //
 // These must be included _after_ the specializations because some compilers
 // get all wigged out about the declaration/specialization order.  Note that
-// some compilers require a syntax different than others when forcing the 
+// some compilers require a syntax different than others when forcing the
 // instantiation (i.e. GNU wants the 'template class', borland does not).
 #ifndef GALIB_USE_AUTO_INST
 #include <ga-mpi/GAAllele.C>

--- a/Transportation_MPFA/source/ga-mpi/GATreeGenome.C
+++ b/Transportation_MPFA/source/ga-mpi/GATreeGenome.C
@@ -25,7 +25,7 @@ template <class T> int
 GATreeGenome<T>::classID() const {return GAID::TreeGenome;}
 
 template <class T>
-GATreeGenome<T>::GATreeGenome(GAGenome::Evaluator f, void * u) : 
+GATreeGenome<T>::GATreeGenome(GAGenome::Evaluator f, void * u) :
 GATree<T>(),
 GAGenome(DEFAULT_TREE_INITIALIZER,
 	 DEFAULT_TREE_MUTATOR,
@@ -37,7 +37,7 @@ GAGenome(DEFAULT_TREE_INITIALIZER,
 
 
 template <class T>
-GATreeGenome<T>::GATreeGenome(const GATreeGenome<T> & orig) : 
+GATreeGenome<T>::GATreeGenome(const GATreeGenome<T> & orig) :
 GATree<T>(),
 GAGenome() {
   GATreeGenome<T>::copy(orig);
@@ -70,7 +70,7 @@ GATreeGenome<T>::copy(const GAGenome & orig) {
 
 #ifdef GALIB_USE_STREAMS
 // Traverse the tree (breadth-first) and dump the contents as best we can to
-// the stream.  We don't try to write the contents of the nodes - we simply 
+// the stream.  We don't try to write the contents of the nodes - we simply
 // write a . for each node in the tree.
 //   We allocate space for x,y coord pair for each node in the tree.  Then we
 // do a depth-first traversal of the tree and assign coords to the nodes in the
@@ -102,7 +102,7 @@ _tt(STD_OSTREAM & os, GANode<T> * n)
 }
 
 template <class T> int
-GATreeGenome<T>::write(STD_OSTREAM & os) const 
+GATreeGenome<T>::write(STD_OSTREAM & os) const
 {
   os << "node       parent     child      next       prev       contents\n";
   _tt(os, (GANode<T> *)(this->rt));
@@ -111,7 +111,7 @@ GATreeGenome<T>::write(STD_OSTREAM & os) const
 #endif
 
 
-template <class T> int  
+template <class T> int
 GATreeGenome<T>::equal(const GAGenome & c) const
 {
   if(this == &c) return 1;
@@ -140,7 +140,7 @@ template <class T> int
 GATreeGenome<T>::DestructiveMutator(GAGenome & c, float pmut)
 {
   GATreeGenome<T> &child=DYN_CAST(GATreeGenome<T> &, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return 0;
 
   n = child.size();
@@ -169,14 +169,14 @@ GATreeGenome<T>::DestructiveMutator(GAGenome & c, float pmut)
 // This is a rearranging mutation operator.  It randomly picks two nodes in the
 // tree and swaps them.  Any node has a pmut chance of getting
 // swapped, and the swap could happen to any other node.  And in the case of
-// nMut < 1, the swap may generate a swap partner that is the same node, in 
+// nMut < 1, the swap may generate a swap partner that is the same node, in
 // which case no swap occurs (we don't check).
 //   After the mutation the iterator is left at the root of the tree.
 template <class T> int
 GATreeGenome<T>::SwapNodeMutator(GAGenome & c, float pmut)
 {
   GATreeGenome<T> &child=DYN_CAST(GATreeGenome<T> &, c);
-  register int n, i;
+  int n, i;
   if(pmut <= 0.0) return 0;
 
   n = child.size();
@@ -214,7 +214,7 @@ template <class T> int
 GATreeGenome<T>::SwapSubtreeMutator(GAGenome & c, float pmut)
 {
   GATreeGenome<T> &child=DYN_CAST(GATreeGenome<T> &, c);
-  register int n, i;
+  int n, i;
   int a, b;
   if(pmut <= 0.0) return 0;
 
@@ -247,7 +247,7 @@ GATreeGenome<T>::SwapSubtreeMutator(GAGenome & c, float pmut)
 // We use the recursive tree function to compare the tree structures.  This
 // does not compare the contents of the nodes.
 template <class T> float
-GATreeGenome<T>::TopologyComparator(const GAGenome& a, const GAGenome& b) 
+GATreeGenome<T>::TopologyComparator(const GAGenome& a, const GAGenome& b)
 {
   if(&a == &b) return 0;
   const GATreeGenome<T>& sis=DYN_CAST(const GATreeGenome<T>&, a);
@@ -277,7 +277,7 @@ GATreeGenome<T>::TopologyComparator(const GAGenome& a, const GAGenome& b)
 //     do the check to see if the crossover site is valid.
 template <class T> int
 GATreeGenome<T>::
-OnePointCrossover(const GAGenome& p1, const GAGenome& p2, 
+OnePointCrossover(const GAGenome& p1, const GAGenome& p2,
 		  GAGenome* c1, GAGenome* c2){
   const GATreeGenome<T> &mom=DYN_CAST(const GATreeGenome<T> &, p1);
   const GATreeGenome<T> &dad=DYN_CAST(const GATreeGenome<T> &, p2);


### PR DESCRIPTION
Ensures compatibility with C++17^ by removing the now implicit `register` keyword.
- *.cpp, *.h, *.c: Removed unused `register` reserved word. 
- .gitignore: Added `.vscode`to avoid committing local settings for a VSC workspace.
- CPFA/build.sh: Commented out optional path assignment, script works on MacOS. Requesting test on WSL and native Ubuntu installations. 